### PR TITLE
Add Prometheus Metrics

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -102,4 +102,5 @@ jobs:
           CARGO_INCREMENTAL: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUST_LOG: info
+          CI: true
           SQLX_OFFLINE: ${{ startsWith(matrix.os, 'macos') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edeef7d7b199195a2d7d7a8155d2d04aee736e60c5c7bdd7097d115369a8817d"
+checksum = "77de71da1ca673855aacea507a7aed363beb8934cf61b62364fc4b479d2e8cda"
 dependencies = [
  "age-core",
  "base64 0.21.7",
@@ -4268,7 +4268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7324,7 +7324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -10787,7 +10787,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.1",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -15815,7 +15815,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix 0.38.41",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17515,7 +17515,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,7 @@ dependencies = [
  "sc-service",
  "sp-api",
  "sp-runtime",
+ "substrate-prometheus-endpoint",
  "thiserror 2.0.4",
  "tokio",
 ]

--- a/README.md
+++ b/README.md
@@ -52,8 +52,14 @@ algorithm (more details to come in the whitepaper).
 The Argon mainchain is built using the [Substrate](https://substrate.dev) framework. Substrate is a modular blockchain
 framework that allows developers to build custom blockchains that operate independently, but can connect into a shared
 ecosystem called "Parachains". Substrate is built in Rust and has a WebAssembly runtime that allows for upgrades to the
-blockchain without forks. Argon runs as a "solochain", which means our consensus is not shared with other chains. It
-will gain integration through a "Transferchain" that allows for the transfer of Argons between chains.
+blockchain without forks. Argon runs as a "solochain", which means our consensus is not shared with other chains.
+
+Cross-chain transfers are enabled via [Hyperbridge](https://hyperbridge.network), which is a zero-trust, decentralized
+bridge. Fees are payable in Argons when going Argon -> Ethereum/Base/Binance Chain/etc, and the native token of a source
+chain when transferring into Argon.
+
+A Uniswap liquidity pool with USDC is used to create a price-point for the Argon. The main Uniswap contract initially in
+use is on Ethereum.
 
 The Localchain is a Rust library that can be run in a standalone cli, within Node.js via bindings created
 using [napi-rs](https://napi.rs) or as a library in iOS/Android using [uniffi](https://github.com/mozilla/uniffi-rs). It

--- a/node/bitcoin_utxo_tracker/Cargo.toml
+++ b/node/bitcoin_utxo_tracker/Cargo.toml
@@ -28,6 +28,7 @@ sc-service = { workspace = true }
 sp-api = { workspace = true, features = ["std"] }
 sp-runtime = { workspace = true, features = ["std"] }
 sc-client-api = { workspace = true }
+prometheus-endpoint = { workspace = true }
 
 [dev-dependencies]
 bitcoind = { workspace = true }

--- a/node/bitcoin_utxo_tracker/src/metrics.rs
+++ b/node/bitcoin_utxo_tracker/src/metrics.rs
@@ -1,0 +1,84 @@
+use argon_primitives::inherents::BitcoinUtxoSync;
+use prometheus_endpoint::{
+	prometheus, register, CounterVec, Gauge, HistogramOpts, HistogramVec, Opts, PrometheusError,
+	Registry, U64,
+};
+use std::time::Instant;
+
+/// Metrics for the bitcoin utxos
+#[derive(Debug, Clone)]
+pub struct BitcoinMetrics {
+	/// Time to verify bitcoin utxos
+	bitcoin_utxos_verify_time: HistogramVec,
+	/// Number of bitcoin utxos being tracked
+	bitcoin_utxos_tracked_total: Gauge<U64>,
+	/// Amount of utxos being tracked
+	bitcoin_utxos_satoshis_total: Gauge<U64>,
+	/// Bitcoins spent
+	bitcoin_utxos_spent_total: CounterVec<U64>,
+	/// Bitcoins verified
+	bitcoin_utxos_verified_total: CounterVec<U64>,
+}
+
+impl BitcoinMetrics {
+	/// Create an instance of metrics
+	pub fn new(metrics_registry: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			bitcoin_utxos_verify_time: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"argon_bitcoin_utxos_verify_time",
+						"Total time [μs] to verify all bitcoin utxos",
+					)
+					.buckets(prometheus::exponential_buckets(10.0, 5.0, 12)?),
+					&[],
+				)?,
+				metrics_registry,
+			)?,
+			bitcoin_utxos_tracked_total: register(
+				Gauge::new(
+					"argon_bitcoin_utxos_tracked_total",
+					"Number of bitcoin utxos being tracked",
+				)?,
+				metrics_registry,
+			)?,
+			bitcoin_utxos_satoshis_total: register(
+				Gauge::new("argon_bitcoin_utxos_satoshis_total", "Amount of utxos being tracked")?,
+				metrics_registry,
+			)?,
+			bitcoin_utxos_spent_total: register(
+				CounterVec::new(
+					Opts::new("argon_bitcoin_utxos_spent_total", "Bitcoins spent"),
+					&[],
+				)?,
+				metrics_registry,
+			)?,
+			bitcoin_utxos_verified_total: register(
+				CounterVec::new(
+					Opts::new("argon_bitcoin_utxos_verified_total", "Bitcoins verified"),
+					&[],
+				)?,
+				metrics_registry,
+			)?,
+		})
+	}
+
+	pub fn track(
+		&self,
+		sync_state: &BitcoinUtxoSync,
+		count: u64,
+		satoshis: u64,
+		start_time: Instant,
+	) {
+		self.bitcoin_utxos_verified_total
+			.with_label_values(&[])
+			.inc_by(sync_state.verified.len() as u64);
+		self.bitcoin_utxos_spent_total
+			.with_label_values(&[])
+			.inc_by(sync_state.spent.len() as u64);
+		let elapsed = start_time.elapsed().as_micros() as f64;
+		self.bitcoin_utxos_verify_time.with_label_values(&[]).observe(elapsed);
+		self.bitcoin_utxos_tracked_total.set(count);
+		self.bitcoin_utxos_satoshis_total.set(satoshis);
+	}
+}

--- a/node/consensus/src/compute_worker.rs
+++ b/node/consensus/src/compute_worker.rs
@@ -419,7 +419,7 @@ where
 			{
 				tracing::info!(
 					?notebooks_at_latest_tick,
-					tick = notebook_tick - 1,
+					notebook_tick,
 					"Found new notebooks at tick. Will try to solve tick with compute"
 				);
 				solve_notebook_tick = notebook_tick;

--- a/node/consensus/src/import_queue.rs
+++ b/node/consensus/src/import_queue.rs
@@ -177,7 +177,9 @@ where
 				.digest_notebooks(parent_hash, digest)
 				.map_err(|e| format!("Error calling digest notebooks api {e:?}"))?
 				.map_err(|e| format!("Failed to get digest notebooks: {:?}", e))?;
-			self.notary_client.verify_notebook_audits(digest_notebooks).await?;
+			self.notary_client
+				.verify_notebook_audits(&parent_hash, digest_notebooks)
+				.await?;
 		}
 
 		// NOTE: we verify compute nonce in import queue because we use the pre-hash, which

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -303,7 +303,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 					compute_handle.start_solving(proposal);
 					if let Some(metrics) = consensus_metrics_finder.as_ref() {
 						let time_after_tick = ticker.duration_after_tick(tick);
-						metrics.start_fallback_mining(tick, time_after_tick);
+						metrics.start_fallback_mining(time_after_tick);
 					}
 				}
 			}

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -36,8 +36,10 @@ pub(crate) mod block_creator;
 pub(crate) mod compute_worker;
 pub mod error;
 pub mod import_queue;
+pub(crate) mod metrics;
 pub(crate) mod notary_client;
 pub(crate) mod notebook_sealer;
+
 pub use notary_client::{run_notary_sync, NotaryClient, NotebookDownloader};
 
 use crate::{compute_worker::ComputeState, notebook_sealer::create_vote_seal};
@@ -131,6 +133,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 		compute_threads,
 	} = params;
 
+	let consensus_metrics = notary_client.metrics.clone();
 	let block_creator = BlockCreator {
 		block_import,
 		client: client.clone(),
@@ -140,6 +143,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 		aux_client: aux_client.clone(),
 		justification_sync_link,
 		utxo_tracker,
+		metrics: consensus_metrics.clone(),
 		_phantom: Default::default(),
 	};
 
@@ -151,7 +155,12 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 	let compute_handle = ComputeHandle::new(compute_block_tx);
 
 	if compute_threads > 0 {
-		run_compute_solver_threads(task_manager, compute_handle.clone(), compute_threads)
+		run_compute_solver_threads(
+			task_manager,
+			compute_handle.clone(),
+			compute_threads,
+			consensus_metrics.clone(),
+		)
 	}
 
 	let notebook_sealer = NotebookSealer::new(
@@ -201,13 +210,13 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 								continue;
 							},
 						};
-						creator.submit_block(proposal, digest).await;
+						creator.submit_block(proposal, digest, &ticker).await;
 					}
 				},
 				// compute blocks are created with a hash on top of the pre-built block
 				compute_block = compute_block_rx.next() => {
 					if let Some((block, digest)) = compute_block {
-						creator.submit_block(block.proposal, digest).await;
+						creator.submit_block(block.proposal, digest, &ticker).await;
 					}
 				},
 
@@ -215,6 +224,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 		}
 	};
 
+	let consensus_metrics_finder = consensus_metrics.clone();
 	let block_finder_task = async move {
 		let mut import_stream = client.every_import_notification_stream();
 		let idle_delay = if ticker.tick_duration_millis <= 10_000 { 100 } else { 1000 };
@@ -266,7 +276,9 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 				continue;
 			};
 
-			let Some(best_hash) = compute_state.on_new_notebook_tick(next_notebooks_at_tick) else {
+			let Some(best_hash) = compute_state
+				.on_new_notebook_tick(next_notebooks_at_tick, &consensus_metrics_finder)
+			else {
 				continue;
 			};
 
@@ -289,6 +301,10 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 				{
 					trace!(?best_hash, ?tick, "Fallback mining activated");
 					compute_handle.start_solving(proposal);
+					if let Some(metrics) = consensus_metrics_finder.as_ref() {
+						let time_after_tick = ticker.duration_after_tick(tick);
+						metrics.start_fallback_mining(tick, time_after_tick);
+					}
 				}
 			}
 		}

--- a/node/consensus/src/metrics.rs
+++ b/node/consensus/src/metrics.rs
@@ -1,0 +1,210 @@
+use crate::block_creator::ProposalMeta;
+use argon_primitives::{
+	tick::{Tick, Ticker},
+	NotaryId,
+};
+use prometheus_endpoint::{
+	prometheus, register, CounterVec, GaugeVec, HistogramOpts, HistogramVec, Opts, PrometheusError,
+	Registry, U64,
+};
+use std::time::{Duration, Instant};
+
+/// Metrics for the node consensus engine
+#[derive(Debug, Clone)]
+pub struct ConsensusMetrics {
+	/// Histogram over compute hashes need
+	compute_hashes_total: HistogramVec,
+	/// Blocks created with compute
+	compute_blocks_created_total: CounterVec<U64>,
+	/// Number of times we had to reset the compute state
+	compute_resets_from_notebooks: CounterVec<U64>,
+	/// Blocks created with votes
+	vote_blocks_created_total: CounterVec<U64>,
+	/// Block time created after tick
+	block_time_after_tick: HistogramVec,
+	/// Time when fallback compute was activated
+	fallback_compute_activated_time: HistogramVec,
+	/// Notebook queue depth
+	notebook_queue_depth: GaugeVec<U64>,
+	/// Notebook time after tick notification was received
+	notebook_notification_after_tick_time: HistogramVec,
+	/// Notebook processed time after tick
+	notebook_audited_after_tick_time: HistogramVec,
+	/// Notebook total processing time
+	notebook_processing_time: HistogramVec,
+}
+
+impl ConsensusMetrics {
+	/// Create an instance of metrics
+	pub fn new(metrics_registry: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			compute_hashes_total: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"argon_compute_hashes_total",
+						"Total number of compute hashes applied to a block",
+					)
+					.buckets(prometheus::exponential_buckets(10.0, 10.0, 12)?),
+					&[],
+				)?,
+				metrics_registry,
+			)?,
+			compute_blocks_created_total: register(
+				CounterVec::new(
+					Opts::new("argon_compute_blocks_created_total", "Blocks created with compute"),
+					&["notebooks"],
+				)?,
+				metrics_registry,
+			)?,
+			compute_resets_from_notebooks: register(
+				CounterVec::new(
+					Opts::new(
+						"argon_compute_resets_from_notebooks",
+						"Number of times we reset the compute state due to new notebooks",
+					),
+					&[],
+				)?,
+				metrics_registry,
+			)?,
+			fallback_compute_activated_time: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"argon_fallback_compute_activated_time",
+						"Time [μs] after target tick when fallback compute was activated",
+					),
+					&["tick"],
+				)?,
+				metrics_registry,
+			)?,
+			vote_blocks_created_total: register(
+				CounterVec::new(
+					Opts::new("argon_vote_blocks_crated_total", "Blocks created with votes"),
+					&["notebooks"],
+				)?,
+				metrics_registry,
+			)?,
+			block_time_after_tick: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"argon_blocks_time_after_tick",
+						"Total time [μs] after a tick that a block is created",
+					)
+					.buckets(prometheus::exponential_buckets(10.0, 10.0, 12)?),
+					&[],
+				)?,
+				metrics_registry,
+			)?,
+			notebook_queue_depth: register(
+				GaugeVec::new(
+					Opts::new("argon_notebook_queue_depth", "Notebook queue depth"),
+					&["notary_id"],
+				)?,
+				metrics_registry,
+			)?,
+			notebook_notification_after_tick_time: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"argon_notebook_notification_after_tick_time",
+						"Total time [μs] after a tick that a notebook notification was received",
+					)
+					.buckets(prometheus::exponential_buckets(10.0, 10.0, 12)?),
+					&["notary_id", "tick"],
+				)?,
+				metrics_registry,
+			)?,
+			notebook_audited_after_tick_time: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"argon_notebook_audited_after_tick_time",
+						"Total time [μs] after a tick that a notebook was audited",
+					)
+					.buckets(prometheus::exponential_buckets(10.0, 10.0, 12)?),
+					&["notary_id", "tick"],
+				)?,
+				metrics_registry,
+			)?,
+			notebook_processing_time: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"argon_notebook_processing_time",
+						"Total time [μs] to process a notebook",
+					)
+					.buckets(prometheus::exponential_buckets(10.0, 10.0, 12)?),
+					&["notary_id", "tick"],
+				)?,
+				metrics_registry,
+			)?,
+		})
+	}
+
+	pub(crate) fn record_compute_hashes(&self, hashes: u64) {
+		self.compute_hashes_total.with_label_values(&[]).observe(hashes as f64);
+	}
+
+	pub(crate) fn on_block_created(&self, ticker: &Ticker, proposal_meta: &ProposalMeta) {
+		let expected_tick_time = ticker.duration_after_tick(proposal_meta.tick);
+		let time_after_tick = expected_tick_time.as_micros() as u64;
+		let notebooks = proposal_meta.notebooks;
+		self.block_time_after_tick
+			.with_label_values(&[])
+			.observe(time_after_tick as f64);
+		if proposal_meta.is_compute {
+			self.compute_blocks_created_total
+				.with_label_values(&[&notebooks.to_string()])
+				.inc();
+		} else {
+			self.vote_blocks_created_total
+				.with_label_values(&[&notebooks.to_string()])
+				.inc();
+		}
+	}
+
+	pub(crate) fn did_reset_compute_for_notebooks(&self) {
+		self.compute_resets_from_notebooks.with_label_values(&[]).inc();
+	}
+
+	pub(crate) fn start_fallback_mining(&self, tick: Tick, time_after_tick: Duration) {
+		self.fallback_compute_activated_time
+			.with_label_values(&[&tick.to_string()])
+			.observe(time_after_tick.as_micros() as f64);
+	}
+
+	pub(crate) fn notebook_processed(
+		&self,
+		notary_id: NotaryId,
+		tick: Tick,
+		enqueue_time: Instant,
+		ticker: &Ticker,
+	) {
+		let time = enqueue_time.elapsed().as_micros() as f64;
+		let expected_tick_time = ticker.micros_for_tick(tick);
+		let time_after_tick = enqueue_time.elapsed().as_micros().saturating_sub(expected_tick_time);
+
+		self.notebook_audited_after_tick_time
+			.with_label_values(&[&notary_id.to_string(), &tick.to_string()])
+			.observe(time_after_tick as f64);
+		self.notebook_processing_time
+			.with_label_values(&[&notary_id.to_string(), &tick.to_string()])
+			.observe(time);
+	}
+
+	pub(crate) fn notebook_notification_received(
+		&self,
+		notary_id: NotaryId,
+		tick: Tick,
+		ticker: &Ticker,
+	) {
+		let duration_after_tick = ticker.duration_after_tick(tick);
+
+		let time_after_tick = duration_after_tick.as_micros() as f64;
+		self.notebook_notification_after_tick_time
+			.with_label_values(&[&notary_id.to_string(), &tick.to_string()])
+			.observe(time_after_tick);
+	}
+
+	pub(crate) fn record_queue_depth(&self, notary_id: NotaryId, depth: u64) {
+		self.notebook_queue_depth
+			.with_label_values(&[&notary_id.to_string()])
+			.set(depth);
+	}
+}

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -1542,7 +1542,17 @@ mod test {
 				.iter()
 				.map(|(n, a, _)| { (*n, a.is_some()) })
 				.collect::<Vec<_>>(),
-			vec![(9, false)]
+			vec![
+				(1, false),
+				(2, false),
+				(3, false),
+				(4, false),
+				(5, false),
+				(6, false),
+				(7, false),
+				(8, false),
+				(9, false)
+			]
 		);
 		for _ in 0..10 {
 			test_notary.create_notebook_header(vec![]).await;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -114,10 +114,12 @@ where
 	let (bitcoin_url, bitcoin_auth) = mining_config
 		.bitcoin_rpc_url_with_auth()
 		.map_err(|e| ServiceError::Other(format!("Failed to parse bitcoin rpc url {:?}", e)))?;
-	let utxo_tracker = UtxoTracker::new(bitcoin_url.origin().unicode_serialization(), bitcoin_auth)
-		.map_err(|e| {
-			ServiceError::Other(format!("Failed to initialize bitcoin monitoring {:?}", e))
-		})?;
+	let utxo_tracker = UtxoTracker::new(
+		bitcoin_url.origin().unicode_serialization(),
+		bitcoin_auth,
+		config.prometheus_registry(),
+	)
+	.map_err(|e| ServiceError::Other(format!("Failed to initialize bitcoin monitoring {:?}", e)))?;
 
 	let utxo_tracker = Arc::new(utxo_tracker);
 
@@ -137,6 +139,8 @@ where
 		aux_client.clone(),
 		idle_delay,
 		notebook_downloader,
+		config.prometheus_registry(),
+		ticker,
 	);
 
 	let (import_queue, argon_block_import) = create_import_queue(

--- a/notary/src/lib.rs
+++ b/notary/src/lib.rs
@@ -13,7 +13,8 @@ pub mod block_watch;
 
 pub mod notebook_closer;
 
-pub(crate) mod metrics;
 pub(crate) mod middleware;
+pub(crate) mod notary_metrics;
+pub(crate) mod rpc_metrics;
 pub mod s3_archive;
 pub mod server;

--- a/notary/src/main.rs
+++ b/notary/src/main.rs
@@ -232,7 +232,7 @@ async fn main() -> anyhow::Result<()> {
 					ticker,
 					server.completed_notebook_sender.clone(),
 					s3_buckets.clone(),
-					prom_registry.clone(),
+					server.notary_metrics.clone(),
 				)?;
 
 				let mut subscription = server.audit_failure_stream.subscribe(10);

--- a/notary/src/middleware.rs
+++ b/notary/src/middleware.rs
@@ -1,4 +1,4 @@
-use crate::{metrics::*, server::RpcConfig};
+use crate::{rpc_metrics::*, server::RpcConfig};
 use futures::future::{BoxFuture, FutureExt};
 use governor::{
 	clock::{Clock, DefaultClock, QuantaClock},

--- a/notary/src/notary_metrics.rs
+++ b/notary/src/notary_metrics.rs
@@ -1,0 +1,172 @@
+//! Metrics about the notary itself
+
+use crate::rpc_metrics::HISTOGRAM_BUCKETS;
+use argon_primitives::{tick::Tick, Balance};
+use prometheus_endpoint::{
+	register, CounterVec, HistogramOpts, HistogramVec, Opts, PrometheusError, Registry, U64,
+};
+use sp_runtime::traits::UniqueSaturatedInto;
+use std::time::Instant;
+
+/// Metrics for the notary processing
+#[derive(Debug, Clone)]
+pub struct NotaryMetrics {
+	/// Histogram over notebook close time.
+	notebook_close_time: HistogramVec,
+	/// Histogram over notebook time after tick that it finishes
+	notebook_close_time_after_tick: HistogramVec,
+	/// Size of notebooks
+	notebook_bytes: HistogramVec,
+	/// Size of notebook headers
+	notebook_header_bytes: HistogramVec,
+	/// Number of notarizations processed.
+	notarizations_total: CounterVec<U64>,
+	/// Number of notebooks created
+	notebooks_total: CounterVec<U64>,
+	/// Balance changes
+	balance_changes_total: CounterVec<U64>,
+	/// Block votes
+	block_votes_total: CounterVec<U64>,
+	/// Domains
+	domains_total: CounterVec<U64>,
+	/// Tax
+	tax_total: CounterVec<U64>,
+}
+
+impl NotaryMetrics {
+	/// Create an instance of metrics
+	pub fn new(metrics_registry: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			notebook_close_time: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"notary_notebook_close_time",
+						"Total time [μs] to close notebooks",
+					)
+					.buckets(HISTOGRAM_BUCKETS.to_vec()),
+					&["tick"],
+				)?,
+				metrics_registry,
+			)?,
+			notebook_close_time_after_tick: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"notary_notebook_close_time_after_tick",
+						"Total time [μs] to close notebooks after tick",
+					)
+					.buckets(HISTOGRAM_BUCKETS.to_vec()),
+					&["tick"],
+				)?,
+				metrics_registry,
+			)?,
+			notebook_bytes: register(
+				HistogramVec::new(
+					HistogramOpts::new("notary_notebook_bytes", "Size of notebooks").buckets(
+						prometheus::exponential_buckets(100.0, 10.0, 10)
+							.expect("parameters are always valid values; qed"),
+					),
+					&["tick"],
+				)?,
+				metrics_registry,
+			)?,
+			notebook_header_bytes: register(
+				HistogramVec::new(
+					HistogramOpts::new("notary_notebook_header_bytes", "Size of notebook headers")
+						.buckets(
+							prometheus::exponential_buckets(100.0, 10.0, 10)
+								.expect("parameters are always valid values; qed"),
+						),
+					&["tick"],
+				)?,
+				metrics_registry,
+			)?,
+			notarizations_total: register(
+				CounterVec::new(
+					Opts::new("notary_notarizations_total", "Number of notarizations processed"),
+					&["tick", "is_error"],
+				)?,
+				metrics_registry,
+			)?,
+			notebooks_total: register(
+				CounterVec::new(
+					Opts::new("notary_notebooks_total", "Number of notebooks created"),
+					&["tick"],
+				)?,
+				metrics_registry,
+			)?,
+			balance_changes_total: register(
+				CounterVec::new(
+					Opts::new("notary_balance_changes_total", "Number of balance changes"),
+					&["tick"],
+				)?,
+				metrics_registry,
+			)?,
+			block_votes_total: register(
+				CounterVec::new(
+					Opts::new("notary_block_votes_total", "Number of block votes"),
+					&["tick"],
+				)?,
+				metrics_registry,
+			)?,
+			domains_total: register(
+				CounterVec::new(Opts::new("notary_domains_total", "Number of domains"), &["tick"])?,
+				metrics_registry,
+			)?,
+			tax_total: register(
+				CounterVec::new(Opts::new("notary_tax_total", "Total tax"), &["tick"])?,
+				metrics_registry,
+			)?,
+		})
+	}
+
+	pub(crate) fn on_notebook_close(
+		&self,
+		now: Instant,
+		start_time: Instant,
+		tick: Tick,
+		time_after_tick_micros: u128,
+		notebook_bytes: usize,
+		header_bytes: usize,
+	) {
+		let tick = tick.to_string();
+		self.notebooks_total.with_label_values(&[&tick]).inc();
+		self.notebook_close_time
+			.with_label_values(&[&tick])
+			.observe(now.duration_since(start_time).as_micros() as f64);
+		self.notebook_close_time_after_tick
+			.with_label_values(&[&tick])
+			.observe(time_after_tick_micros as f64);
+		self.notebook_bytes.with_label_values(&[&tick]).observe(notebook_bytes as f64);
+		self.notebook_header_bytes
+			.with_label_values(&[&tick])
+			.observe(header_bytes as f64);
+	}
+
+	pub(crate) fn on_notarization(
+		&self,
+		tick: Tick,
+		balance_changes: usize,
+		block_votes: usize,
+		domains: usize,
+		tax: Balance,
+	) {
+		self.notarizations_total.with_label_values(&[&tick.to_string(), "false"]).inc();
+
+		self.balance_changes_total
+			.with_label_values(&[&tick.to_string()])
+			.inc_by(balance_changes as u64);
+		self.block_votes_total
+			.with_label_values(&[&tick.to_string()])
+			.inc_by(block_votes as u64);
+		self.domains_total
+			.with_label_values(&[&tick.to_string()])
+			.inc_by(domains as u64);
+		self.tax_total
+			.with_label_values(&[&tick.to_string()])
+			.inc_by(tax.unique_saturated_into());
+	}
+
+	pub(crate) fn on_notarization_error(&self, tick: Tick) {
+		self.notarizations_total.with_label_values(&[&tick.to_string(), "true"]).inc();
+	}
+}

--- a/notary/src/notebook_closer.rs
+++ b/notary/src/notebook_closer.rs
@@ -207,7 +207,6 @@ impl NotebookCloser {
 			self.notary_metrics.on_notebook_close(
 				Instant::now(),
 				start_time,
-				tick,
 				time_after_tick,
 				notebook_bytes,
 				header_bytes,

--- a/notary/src/notebook_closer.rs
+++ b/notary/src/notebook_closer.rs
@@ -1,4 +1,5 @@
 use crate::{
+	notary_metrics::NotaryMetrics,
 	s3_archive::S3Archive,
 	server::NotebookHeaderInfo,
 	stores::{
@@ -13,11 +14,11 @@ use crate::{
 use argon_notary_apis::error::Error;
 use argon_primitives::{tick::Ticker, AccountId, NotaryId, SignedNotebookHeader};
 use futures::FutureExt;
-use prometheus::Registry;
 use sc_utils::notification::NotificationSender;
 use sp_core::{ed25519, H256};
 use sp_keystore::KeystorePtr;
 use sqlx::{postgres::PgListener, PgPool};
+use std::{sync::Arc, time::Instant};
 use tokio::task::JoinHandle;
 
 pub const NOTARY_KEYID: sp_core::crypto::KeyTypeId = sp_core::crypto::KeyTypeId(*b"nota");
@@ -30,7 +31,7 @@ pub struct NotebookCloser {
 	pub operator_account_id: AccountId,
 	pub ticker: Ticker,
 	pub s3_buckets: S3Archive,
-	pub prometheus_registry: Registry,
+	pub notary_metrics: Arc<NotaryMetrics>,
 }
 
 pub struct FinalizedNotebookHeaderListener {
@@ -90,7 +91,7 @@ pub fn spawn_notebook_closer(
 	ticker: Ticker,
 	completed_notebook_sender: NotificationSender<NotebookHeaderInfo>,
 	s3_buckets: S3Archive,
-	prometheus_registry: Registry,
+	notary_metrics: Arc<NotaryMetrics>,
 ) -> anyhow::Result<NotebookCloserHandles> {
 	let pool1 = pool.clone();
 	let handle_1 = tokio::spawn(async move {
@@ -101,7 +102,7 @@ pub fn spawn_notebook_closer(
 			operator_account_id,
 			ticker,
 			s3_buckets,
-			prometheus_registry,
+			notary_metrics,
 		};
 		notebook_closer.create_task().await?;
 		Ok(())
@@ -172,6 +173,7 @@ impl NotebookCloser {
 
 	pub(super) fn try_close_notebook(&mut self) -> BoxFutureResult<()> {
 		async move {
+			let start_time = Instant::now();
 			let mut tx = self.pool.begin().await?;
 			let step = NotebookFinalizationStep::ReadyForClose;
 			let (notebook_number, tick) =
@@ -191,12 +193,25 @@ impl NotebookCloser {
 				&self.keystore,
 			)
 			.await?;
+			let header_bytes = signed_header.len();
+			let notebook_bytes = notebook.len();
 
 			self.s3_buckets.put_header(notebook_number, signed_header).await?;
 			self.s3_buckets.put_notebook(notebook_number, notebook).await?;
 
 			NotebookStatusStore::next_step(&mut *tx, notebook_number, step).await?;
 			tx.commit().await?;
+
+			let expected_tick_time = self.ticker.duration_after_tick(tick);
+			let time_after_tick = expected_tick_time.as_micros();
+			self.notary_metrics.on_notebook_close(
+				Instant::now(),
+				start_time,
+				tick,
+				time_after_tick,
+				notebook_bytes,
+				header_bytes,
+			);
 
 			Ok(())
 		}
@@ -231,6 +246,7 @@ mod tests {
 	use anyhow::{anyhow, bail};
 	use frame_support::assert_ok;
 	use futures::{task::noop_waker_ref, StreamExt};
+	use prometheus::Registry;
 	use sp_core::{bounded_vec, crypto::AccountId32, ed25519::Public, sr25519::Signature, Pair};
 	use sp_keyring::{
 		sr25519::Keyring,
@@ -310,10 +326,11 @@ mod tests {
 		let ticker: Ticker = client.get().await?.lookup_ticker().await?;
 
 		let prometheus_registry = Registry::new();
+		let notary_metrics = Arc::new(NotaryMetrics::new(&prometheus_registry)?);
 		let server = NotaryServer::create_http_server(
 			"127.0.0.1:0",
 			Default::default(),
-			prometheus_registry.clone(),
+			prometheus_registry,
 		)
 		.await?;
 		let addr = server.local_addr()?;
@@ -332,7 +349,7 @@ mod tests {
 			archive_settings,
 			ticker,
 			pool.clone(),
-			prometheus_registry.clone(),
+			notary_metrics.clone(),
 		)
 		.await?;
 
@@ -344,7 +361,7 @@ mod tests {
 			ticker,
 			notary_server.completed_notebook_sender.clone(),
 			s3_buckets,
-			prometheus_registry,
+			notary_metrics.clone(),
 		)?;
 
 		propose_bob_as_notary(&ctx.client.live, notary_key, addr).await?;
@@ -362,6 +379,7 @@ mod tests {
 
 		let domain_hash = Domain::new("HelloWorld", DomainTopLevel::Entertainment).hash();
 		let result = submit_balance_change_to_notary_and_create_domain(
+			&notary_server.notary_metrics,
 			&pool,
 			&ticker,
 			ferdie_transfer,
@@ -402,13 +420,15 @@ mod tests {
 		);
 
 		// Record the balance change
-		let result = submit_balance_change_to_notary(&pool, &ticker, bob_transfer).await?;
+		let result =
+			submit_balance_change_to_notary(&notary_metrics, &pool, &ticker, bob_transfer).await?;
 		let origin = AccountOrigin {
 			account_uid: result.new_account_origins[0].account_uid,
 			notebook_number: result.notebook_number,
 		};
 
 		let (hold_note, hold_result) = create_channel_hold(
+			&notary_metrics,
 			&pool,
 			bob_balance as u128,
 			5_000_000,
@@ -485,6 +505,7 @@ mod tests {
 				continue;
 			};
 			match settle_channel_hold_and_vote(
+				&notary_metrics,
 				&pool,
 				&ticker,
 				vote_tick,
@@ -676,6 +697,7 @@ mod tests {
 	}
 
 	async fn submit_balance_change_to_notary(
+		notary_metrics: &Arc<NotaryMetrics>,
 		pool: &PgPool,
 		ticker: &Ticker,
 		transfer: (TransferToLocalchainId, u32, Keyring),
@@ -694,6 +716,7 @@ mod tests {
 			1,
 			&Ferdie.to_account_id(),
 			ticker,
+			notary_metrics,
 			vec![BalanceChange {
 				account_id: keypair.public().into(),
 				account_type: Deposit,
@@ -719,6 +742,7 @@ mod tests {
 		Ok(result)
 	}
 	async fn submit_balance_change_to_notary_and_create_domain(
+		notary_metrics: &Arc<NotaryMetrics>,
 		pool: &PgPool,
 		ticker: &Ticker,
 		transfer: (TransferToLocalchainId, u32, Keyring),
@@ -739,6 +763,7 @@ mod tests {
 			1,
 			&Ferdie.to_account_id(),
 			ticker,
+			notary_metrics,
 			vec![
 				BalanceChange {
 					account_id: keypair.public().into(),
@@ -807,6 +832,7 @@ mod tests {
 
 	#[allow(clippy::too_many_arguments)]
 	async fn create_channel_hold(
+		notary_metrics: &Arc<NotaryMetrics>,
 		pool: &PgPool,
 		balance: u128,
 		amount: u128,
@@ -848,6 +874,7 @@ mod tests {
 			1,
 			&Ferdie.to_account_id(),
 			ticker,
+			notary_metrics,
 			changes,
 			vec![],
 			vec![],
@@ -857,6 +884,7 @@ mod tests {
 	}
 
 	async fn settle_channel_hold_and_vote(
+		notary_metrics: &Arc<NotaryMetrics>,
 		pool: &PgPool,
 		ticker: &Ticker,
 		vote_tick: Tick,
@@ -914,6 +942,7 @@ mod tests {
 			1,
 			&Ferdie.to_account_id(),
 			ticker,
+			notary_metrics,
 			changes,
 			vec![BlockVote {
 				account_id: Alice.to_account_id(),

--- a/notary/src/rpc_metrics.rs
+++ b/notary/src/rpc_metrics.rs
@@ -27,7 +27,7 @@ use prometheus_endpoint::{
 };
 
 /// Histogram time buckets in microseconds.
-const HISTOGRAM_BUCKETS: [f64; 11] = [
+pub(crate) const HISTOGRAM_BUCKETS: [f64; 11] = [
 	5.0,
 	25.0,
 	100.0,
@@ -67,7 +67,7 @@ impl RpcMetrics {
 				calls_time: register(
 					HistogramVec::new(
 						HistogramOpts::new(
-							"rpc_calls_time",
+							"notary_rpc_calls_time",
 							"Total time [μs] of processed RPC calls",
 						)
 						.buckets(HISTOGRAM_BUCKETS.to_vec()),
@@ -78,7 +78,7 @@ impl RpcMetrics {
 				calls_started: register(
 					CounterVec::new(
 						Opts::new(
-							"rpc_calls_started",
+							"notary_rpc_calls_started",
 							"Number of received RPC calls (unique un-batched requests)",
 						),
 						&["protocol", "method"],
@@ -88,7 +88,7 @@ impl RpcMetrics {
 				calls_finished: register(
 					CounterVec::new(
 						Opts::new(
-							"rpc_calls_finished",
+							"notary_rpc_calls_finished",
 							"Number of processed RPC calls (unique un-batched requests)",
 						),
 						&["protocol", "method", "is_error", "is_rate_limited"],
@@ -97,7 +97,7 @@ impl RpcMetrics {
 				)?,
 				ws_sessions_opened: register(
 					Counter::new(
-						"rpc_sessions_opened",
+						"notary_rpc_sessions_opened",
 						"Number of persistent RPC sessions opened",
 					)?,
 					metrics_registry,
@@ -105,7 +105,7 @@ impl RpcMetrics {
 				.into(),
 				ws_sessions_closed: register(
 					Counter::new(
-						"rpc_sessions_closed",
+						"notary_rpc_sessions_closed",
 						"Number of persistent RPC sessions closed",
 					)?,
 					metrics_registry,
@@ -114,7 +114,7 @@ impl RpcMetrics {
 				ws_sessions_time: register(
 					HistogramVec::new(
 						HistogramOpts::new(
-							"rpc_sessions_time",
+							"notary_rpc_sessions_time",
 							"Total time [s] for each websocket session",
 						)
 						.buckets(HISTOGRAM_BUCKETS.to_vec()),

--- a/notary/src/server.rs
+++ b/notary/src/server.rs
@@ -1,5 +1,6 @@
 use crate::{
 	middleware::{register_prometheus_metrics, MiddlewareLayer},
+	notary_metrics::NotaryMetrics,
 	stores::{
 		balance_tip::BalanceTipStore,
 		notarizations::NotarizationsStore,
@@ -68,8 +69,7 @@ pub struct NotaryServer {
 
 	latest_metadata: Arc<Mutex<NotebookMeta>>,
 	archive_settings: ArchiveSettings,
-	#[allow(dead_code)]
-	prometheus_registry: Registry,
+	pub notary_metrics: Arc<NotaryMetrics>,
 }
 
 impl Drop for NotaryServer {
@@ -176,7 +176,7 @@ impl NotaryServer {
 		archive_settings: ArchiveSettings,
 		ticker: Ticker,
 		pool: PgPool,
-		prometheus_registry: Registry,
+		notary_metrics: Arc<NotaryMetrics>,
 	) -> anyhow::Result<Self> {
 		let (completed_notebook_sender, completed_notebook_stream) =
 			NotebookHeaderStream::channel();
@@ -204,7 +204,7 @@ impl NotaryServer {
 			audit_handle: Arc::new(audit_handle),
 			latest_metadata,
 			archive_settings,
-			prometheus_registry,
+			notary_metrics,
 		};
 
 		let mut module = RpcModule::new(());
@@ -236,6 +236,7 @@ impl NotaryServer {
 		registry: Registry,
 	) -> anyhow::Result<Self> {
 		let server = Self::create_http_server(addrs, rpc_config, registry.clone()).await?;
+		let notary_metrics = Arc::new(NotaryMetrics::new(&registry)?);
 		Self::start_with(
 			server,
 			notary_id,
@@ -243,7 +244,7 @@ impl NotaryServer {
 			archive_settings,
 			ticker,
 			pool,
-			registry,
+			notary_metrics,
 		)
 		.await
 	}
@@ -428,16 +429,21 @@ impl LocalchainRpcServer for NotaryServer {
 		domains: NotarizationDomains,
 	) -> Result<BalanceChangeResult, ErrorObjectOwned> {
 		self.ensure_active().await?;
+		let tick = self.ticker.current();
 		Ok(NotarizationsStore::apply(
 			&self.pool,
 			self.notary_id,
 			&self.operator_account_id,
 			&self.ticker,
+			&self.notary_metrics,
 			balance_changeset.into_inner(),
 			block_votes.into_inner(),
 			domains.into_inner(),
 		)
-		.await?)
+		.await
+		.inspect_err(|_| {
+			self.notary_metrics.on_notarization_error(tick);
+		})?)
 	}
 
 	async fn get_tip(
@@ -604,7 +610,7 @@ mod tests {
 			operator_account_id: operator.clone(),
 			ticker,
 			s3_buckets,
-			prometheus_registry: Registry::new(),
+			notary_metrics: notary.notary_metrics.clone(),
 		};
 		let mut header_listener = FinalizedNotebookHeaderListener::connect(
 			pool.clone(),
@@ -699,7 +705,7 @@ mod tests {
 			operator_account_id: operator.clone(),
 			ticker,
 			s3_buckets,
-			prometheus_registry: Registry::new(),
+			notary_metrics: notary.notary_metrics.clone(),
 		};
 
 		notebook_closer

--- a/notary/src/server.rs
+++ b/notary/src/server.rs
@@ -429,7 +429,6 @@ impl LocalchainRpcServer for NotaryServer {
 		domains: NotarizationDomains,
 	) -> Result<BalanceChangeResult, ErrorObjectOwned> {
 		self.ensure_active().await?;
-		let tick = self.ticker.current();
 		Ok(NotarizationsStore::apply(
 			&self.pool,
 			self.notary_id,
@@ -442,7 +441,7 @@ impl LocalchainRpcServer for NotaryServer {
 		)
 		.await
 		.inspect_err(|_| {
-			self.notary_metrics.on_notarization_error(tick);
+			self.notary_metrics.on_notarization_error();
 		})?)
 	}
 

--- a/notary/src/stores/notarizations.rs
+++ b/notary/src/stores/notarizations.rs
@@ -166,6 +166,7 @@ impl NotarizationsStore {
 	///    blocks since that change.
 	/// 6. If a notary is compromised, the user can use the proof of last balance change to migrate
 	///    their balance to a new notary. NOTE: you must have proof from the completed notebook.
+	#[allow(clippy::too_many_arguments)]
 	pub async fn apply(
 		pool: &PgPool,
 		notary_id: NotaryId,

--- a/notary/src/stores/notarizations.rs
+++ b/notary/src/stores/notarizations.rs
@@ -421,7 +421,7 @@ impl NotarizationsStore {
 
 		tx.commit().await?;
 
-		notary_metrics.on_notarization(tick, balance_change_len, block_votes_len, domains_len, tax);
+		notary_metrics.on_notarization(balance_change_len, block_votes_len, domains_len, tax);
 
 		Ok(BalanceChangeResult {
 			notebook_number: current_notebook_number,

--- a/primitives/src/digests.rs
+++ b/primitives/src/digests.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ensure, fork_power::ForkPower, tick::TickDigest, BlockSealAuthoritySignature, BlockVotingPower,
-	NotebookAuditResult, VotingKey,
+	ensure, fork_power::ForkPower, notary::SignedHeaderBytes, tick::TickDigest,
+	BlockSealAuthoritySignature, BlockVotingPower, NotebookAuditResult, VotingKey,
 };
 use alloc::{vec, vec::Vec};
 use codec::{Codec, Decode, Encode, MaxEncodedLen};
@@ -287,7 +287,7 @@ pub struct NotebookDigest<VerifyError: Codec> {
 	DefaultNoBound,
 )]
 pub struct NotebookHeaderData<VerifyError: Codec> {
-	pub signed_headers: Vec<Vec<u8>>,
+	pub signed_headers: Vec<SignedHeaderBytes>,
 	pub notebook_digest: NotebookDigest<VerifyError>,
 	pub vote_digest: BlockVoteDigest,
 }

--- a/primitives/src/notary.rs
+++ b/primitives/src/notary.rs
@@ -157,6 +157,31 @@ pub enum NotaryState<NotebookVerifyError: Codec + Clone + PartialEq + Debug> {
 	},
 }
 
+#[derive(
+	Clone, Default, PartialEq, Eq, TypeInfo, Debug, Decode, Encode, Serialize, Deserialize,
+)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct NotebookBytes(pub Vec<u8>);
+
+impl From<Vec<u8>> for NotebookBytes {
+	fn from(bytes: Vec<u8>) -> Self {
+		Self(bytes)
+	}
+}
+
+#[derive(
+	Clone, Default, PartialEq, Eq, TypeInfo, Debug, Decode, Encode, Serialize, Deserialize,
+)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct SignedHeaderBytes(pub Vec<u8>);
+impl From<Vec<u8>> for SignedHeaderBytes {
+	fn from(bytes: Vec<u8>) -> Self {
+		Self(bytes)
+	}
+}
+
 #[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Default)]
 pub struct NotaryNotebookTickState {
 	#[codec(compact)]
@@ -164,7 +189,7 @@ pub struct NotaryNotebookTickState {
 	#[codec(compact)]
 	pub notaries: u16,
 	pub notebook_key_details_by_notary: BTreeMap<NotaryId, NotaryNotebookVoteDigestDetails>,
-	pub raw_headers_by_notary: BTreeMap<NotaryId, Vec<u8>>,
+	pub raw_headers_by_notary: BTreeMap<NotaryId, SignedHeaderBytes>,
 }
 
 #[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]


### PR DESCRIPTION
This PR does two major things:
1. Full nodes were not dialing a notary on bootup before importing a best block. This meant it could get stuck, having not loaded any of the state related to notebooks
2. Adds metrics for the health of importing notebooks and processing bitcoin utxos

### Metrics
## Notebook
```
          /// Histogram over notebook close time.
          notebook_close_time: HistogramVec,
          /// Histogram over notebook time after tick that it finishes
          notebook_close_time_after_tick: HistogramVec,
          /// Size of notebooks
          notebook_bytes: HistogramVec,
          /// Size of notebook headers
          notebook_header_bytes: HistogramVec,
          /// Number of notarizations processed.
          notarizations_total: CounterVec<U64>,
          /// Number of notebooks created
          notebooks_total: CounterVec<U64>,
          /// Balance changes
          balance_changes_total: CounterVec<U64>,
          /// Block votes
          block_votes_total: CounterVec<U64>,
          /// Domains
          domains_total: CounterVec<U64>,
          /// Tax
          tax_total: CounterVec<U64>,
```

## Bitcoin Utxos
```
	/// Time to verify bitcoin utxos
	bitcoin_utxos_verify_time: HistogramVec,
	/// Number of bitcoin utxos being tracked
	bitcoin_utxos_tracked_total: Gauge<U64>,
	/// Amount of utxos being tracked
	bitcoin_utxos_satoshis_total: Gauge<U64>,
	/// Bitcoins spent
	bitcoin_utxos_spent_total: CounterVec<U64>,
	/// Bitcoins verified
	bitcoin_utxos_verified_total: CounterVec<U64>,
```
## Node
```
/// Histogram over compute hashes need
	compute_hashes_total: HistogramVec,
	/// Blocks created with compute
	compute_blocks_created_total: CounterVec<U64>,
	/// Number of times we had to reset the compute state
	compute_resets_from_notebooks: CounterVec<U64>,
	/// Blocks created with votes
	vote_blocks_created_total: CounterVec<U64>,
	/// Block time created after tick
	block_time_after_tick: HistogramVec,
	/// Time when fallback compute was activated
	fallback_compute_activated_time: HistogramVec,
	/// Notebook queue depth
	notebook_queue_depth: GaugeVec<U64>,
	/// Notebook time after tick notification was received
	notebook_notification_after_tick_time: HistogramVec,
	/// Notebook processed time after tick
	notebook_audited_after_tick_time: HistogramVec,
	/// Notebook total processing time
	notebook_processing_time: HistogramVec,
```
