### PR TITLE
fix(node): don’t download all notebooks on bootup

### DIFF
--- a/end-to-end/src/vote_mining.rs
+++ b/end-to-end/src/vote_mining.rs
@@ -34,7 +34,7 @@ async fn test_end_to_end_default_vote_mining() {
 				if let Ok(ownership) =
 					grandpa_miner.client.get_ownership(&author, Some(block.hash())).await
 				{
-					if ownership.free > 500_000 && !authors.contains(&author) {
+					if ownership.free >= 500_000 && !authors.contains(&author) {
 						println!("Block Author is ready {:?}", keyring);
 						authors.insert(author);
 					}
@@ -51,7 +51,7 @@ async fn test_end_to_end_default_vote_mining() {
 				}
 			}
 			counter += 1;
-			if counter >= 30 {
+			if counter >= 50 {
 				panic!("Blocks not produced by both authors after 30 blocks -> {:?}", authors);
 			}
 		}

--- a/localchain/src/notary_client.rs
+++ b/localchain/src/notary_client.rs
@@ -216,8 +216,8 @@ impl NotaryClient {
 
     *self.last_metadata.write().await = Some(meta.clone());
     Ok(NotebookMeta {
-      finalized_tick: meta.finalized_tick as i64,
-      finalized_notebook_number: meta.finalized_notebook_number,
+      finalized_tick: meta.last_closed_notebook_tick as i64,
+      finalized_notebook_number: meta.last_closed_notebook_number,
     })
   }
 
@@ -246,7 +246,7 @@ impl NotaryClient {
     let mut has_seen_notebook = {
       let last_metadata = self.last_metadata.read().await;
       if let Some(meta) = &*last_metadata {
-        meta.finalized_notebook_number >= notebook_number
+        meta.last_closed_notebook_number >= notebook_number
       } else {
         false
       }
@@ -277,8 +277,8 @@ impl NotaryClient {
         .write()
         .await
         .replace(argon_primitives::NotebookMeta {
-          finalized_tick: download_info.tick,
-          finalized_notebook_number: download_info.notebook_number,
+          last_closed_notebook_tick: download_info.tick,
+          last_closed_notebook_number: download_info.notebook_number,
         });
       if download_info.notebook_number == notebook_number {
         let client = self.client.read().await;

--- a/localchain/src/test_utils.rs
+++ b/localchain/src/test_utils.rs
@@ -235,8 +235,8 @@ impl MockNotary {
       .headers
       .insert(header.header.notebook_number, header.clone());
     state.metadata = Some(NotebookMeta {
-      finalized_tick: header.header.tick,
-      finalized_notebook_number: header.header.notebook_number,
+      last_closed_notebook_tick: header.header.tick,
+      last_closed_notebook_number: header.header.notebook_number,
     });
     drop(state);
     let _ = self

--- a/node/consensus/src/block_creator.rs
+++ b/node/consensus/src/block_creator.rs
@@ -158,9 +158,8 @@ where
 		let timestamp = sp_timestamp::InherentDataProvider::new(Timestamp::new(timestamp_millis));
 		let seal =
 			BlockSealInherentDataProvider { seal: Some(seal_inherent.clone()), digest: None };
-		let notebooks = NotebooksInherentDataProvider {
-			raw_notebooks: notebook_header_data.signed_headers.into_iter().map(|a| a.0).collect(),
-		};
+		let notebooks =
+			NotebooksInherentDataProvider { raw_notebooks: notebook_header_data.signed_headers };
 
 		let mut inherent_data =
 			(timestamp, seal, notebooks).create_inherent_data().await.inspect_err(|err| {

--- a/node/consensus/src/import_queue.rs
+++ b/node/consensus/src/import_queue.rs
@@ -71,10 +71,17 @@ where
 			.map_err(|e| {
 				Error::MissingRuntimeData(format!("Failed to get voting author power: {:?}", e))
 			})?;
-		let max_fork_power =
-			self.aux_client.record_block(&mut block, block_author, voting_key, tick)?;
+
 		let fork_power = ForkPower::try_from(block.header.digest())
 			.map_err(|e| Error::MissingRuntimeData(format!("Failed to get fork power: {:?}", e)))?;
+
+		let max_fork_power = self.aux_client.record_block(
+			&mut block,
+			block_author,
+			voting_key,
+			tick,
+			fork_power.is_latest_vote,
+		)?;
 
 		let mut is_best_fork = fork_power > max_fork_power;
 		if fork_power == max_fork_power {

--- a/node/consensus/src/mock_notary.rs
+++ b/node/consensus/src/mock_notary.rs
@@ -123,8 +123,8 @@ impl MockNotary {
 			let mut state = self.state.lock().await;
 			state.headers.insert(header.header.notebook_number, header.clone());
 			state.metadata = Some(NotebookMeta {
-				finalized_tick: header.header.tick,
-				finalized_notebook_number: header.header.notebook_number,
+				last_closed_notebook_tick: header.header.tick,
+				last_closed_notebook_number: header.header.notebook_number,
 			});
 		}
 		let _ = self

--- a/notary/src/notary_metrics.rs
+++ b/notary/src/notary_metrics.rs
@@ -52,7 +52,7 @@ impl NotaryMetrics {
 				HistogramVec::new(
 					HistogramOpts::new(
 						"notary_notebook_close_time_after_tick",
-						"Total time [μs] to close notebooks after tick",
+						"Total time [μs] to close notebooks after tick ends (eg, next has begun)",
 					)
 					.buckets(HISTOGRAM_BUCKETS.to_vec()),
 					&[],

--- a/notary/src/server.rs
+++ b/notary/src/server.rs
@@ -257,10 +257,10 @@ impl NotaryServer {
 		tokio::spawn(async move {
 			while let Some((header, _hash)) = subscription.next().await {
 				let mut latest = latest_metadata.lock().await;
-				if header.header.notebook_number > latest.finalized_notebook_number {
+				if header.header.notebook_number > latest.last_closed_notebook_number {
 					*latest = NotebookMeta {
-						finalized_notebook_number: header.header.notebook_number,
-						finalized_tick: header.header.tick,
+						last_closed_notebook_number: header.header.notebook_number,
+						last_closed_notebook_tick: header.header.tick,
 					}
 				}
 			}

--- a/notary/src/stores/notebook_header.rs
+++ b/notary/src/stores/notebook_header.rs
@@ -186,12 +186,15 @@ impl NotebookHeaderStore {
 		.fetch_optional(db)
 		.await?;
 		let Some(record) = record else {
-			return Ok(NotebookMeta { finalized_tick: 0, finalized_notebook_number: 0 });
+			return Ok(NotebookMeta {
+				last_closed_notebook_tick: 0,
+				last_closed_notebook_number: 0,
+			});
 		};
 
 		Ok(NotebookMeta {
-			finalized_tick: record.tick as Tick,
-			finalized_notebook_number: record.notebook_number as NotebookNumber,
+			last_closed_notebook_tick: record.tick as Tick,
+			last_closed_notebook_number: record.notebook_number as NotebookNumber,
 		})
 	}
 

--- a/pallets/ticks/src/lib.rs
+++ b/pallets/ticks/src/lib.rs
@@ -41,9 +41,6 @@ pub mod pallet {
 	pub trait Config: pallet_timestamp::Config + frame_system::Config {
 		/// Type representing the weight of this pallet
 		type WeightInfo: WeightInfo;
-
-		/// Should the system allow multiple blocks to be produced in the same tick
-		type AllowMultipleBlockPerTick: Get<bool>;
 	}
 
 	#[pallet::storage]
@@ -105,9 +102,6 @@ pub mod pallet {
 			}
 
 			RecentBlocksAtTicks::<T>::mutate(parent_tick, |blocks| {
-				if blocks.len() > 0 && !T::AllowMultipleBlockPerTick::get() {
-					panic!("Multiple blocks per tick is not allowed.");
-				}
 				blocks.try_push(<frame_system::Pallet<T>>::parent_hash())
 			})
 				.expect("Failed to push block hash to recent blocks. Too many blocks per tick is a valid panic reason.");

--- a/pallets/ticks/src/mock.rs
+++ b/pallets/ticks/src/mock.rs
@@ -1,7 +1,7 @@
 use crate as pallet_ticks;
 use argon_primitives::tick::Ticker;
 use env_logger::{Builder, Env};
-use frame_support::{derive_impl, parameter_types, traits::ConstU64};
+use frame_support::{derive_impl, traits::ConstU64};
 use sp_runtime::BuildStorage;
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -28,13 +28,8 @@ impl frame_system::Config for Test {
 	type Block = Block;
 }
 
-parameter_types! {
-	pub static AllowMultipleBlockPerTick: bool = true;
-}
-
 impl pallet_ticks::Config for Test {
 	type WeightInfo = ();
-	type AllowMultipleBlockPerTick = AllowMultipleBlockPerTick;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/ticks/src/tests.rs
+++ b/pallets/ticks/src/tests.rs
@@ -85,7 +85,6 @@ fn it_tests_the_current_tick() {
 
 #[test]
 fn it_should_track_blocks_at_tick() {
-	AllowMultipleBlockPerTick::set(true);
 	new_test_ext(500).execute_with(|| {
 		// Go past genesis block so events get deposited
 		System::set_block_number(2);
@@ -144,7 +143,6 @@ fn it_should_track_multiple_blocks_at_tick_if_enabled() {
 		Ticks::on_initialize(3);
 		assert_eq!(Ticks::blocks_at_tick(1).len(), 2);
 
-		AllowMultipleBlockPerTick::set(false);
 		System::initialize(
 			&4,
 			&System::parent_hash(),
@@ -152,16 +150,12 @@ fn it_should_track_multiple_blocks_at_tick_if_enabled() {
 		);
 		Ticks::on_initialize(4);
 		assert_eq!(Ticks::blocks_at_tick(2).len(), 1);
-		let err = catch_unwind(|| {
-			System::initialize(
-				&5,
-				&System::parent_hash(),
-				&Digest {
-					logs: vec![DigestItem::PreRuntime(TICK_DIGEST_ID, TickDigest(2).encode())],
-				},
-			);
-			Ticks::on_initialize(5);
-		});
-		assert!(err.is_err());
+		System::initialize(
+			&5,
+			&System::parent_hash(),
+			&Digest { logs: vec![DigestItem::PreRuntime(TICK_DIGEST_ID, TickDigest(2).encode())] },
+		);
+		Ticks::on_initialize(5);
+		assert_eq!(Ticks::blocks_at_tick(2).len(), 2);
 	});
 }

--- a/primitives/src/fork_power.rs
+++ b/primitives/src/fork_power.rs
@@ -6,6 +6,7 @@ use sp_core::U256;
 
 #[derive(Clone, Encode, Decode, Debug, Eq, PartialEq, MaxEncodedLen, TypeInfo)]
 pub struct ForkPower {
+	/// True if the fork is a vote block, false if it is a compute block.
 	pub is_latest_vote: bool,
 	#[codec(compact)]
 	pub notebooks: u64,

--- a/primitives/src/inherents.rs
+++ b/primitives/src/inherents.rs
@@ -7,6 +7,7 @@ use sp_runtime::RuntimeDebug;
 
 use crate::{
 	bitcoin::{BitcoinBlock, BitcoinHeight, BitcoinRejectedReason, UtxoId, UtxoRef},
+	notary::SignedHeaderBytes,
 	BestBlockVoteSeal, BlockSealDigest, BlockVote, MerkleProof, NotaryId, NotebookNumber,
 	SignedNotebookHeader,
 };
@@ -183,11 +184,11 @@ pub trait NotebookInherentData {
 
 impl NotebookInherentData for InherentData {
 	fn notebooks(&self) -> Result<Option<Vec<SignedNotebookHeader>>, sp_inherents::Error> {
-		let raw = self.get_data::<Vec<Vec<u8>>>(&NOTEBOOKS_INHERENT_IDENTIFIER)?;
+		let raw = self.get_data::<Vec<SignedHeaderBytes>>(&NOTEBOOKS_INHERENT_IDENTIFIER)?;
 		if let Some(raw) = raw {
 			let mut result: Vec<SignedNotebookHeader> = Vec::new();
 			for data in raw {
-				let entry = SignedNotebookHeader::decode(&mut data.as_slice()).map_err(|e| {
+				let entry = SignedNotebookHeader::decode(&mut data.0.as_slice()).map_err(|e| {
 					sp_inherents::Error::DecodingFailed(e, NOTEBOOKS_INHERENT_IDENTIFIER)
 				})?;
 				result.push(entry);
@@ -199,7 +200,7 @@ impl NotebookInherentData for InherentData {
 }
 #[cfg(feature = "std")]
 pub struct NotebooksInherentDataProvider {
-	pub raw_notebooks: Vec<Vec<u8>>,
+	pub raw_notebooks: Vec<SignedHeaderBytes>,
 }
 #[cfg(feature = "std")]
 #[async_trait::async_trait]

--- a/primitives/src/notebook.rs
+++ b/primitives/src/notebook.rs
@@ -327,8 +327,8 @@ impl NotebookHeader {
 pub struct NotebookMeta {
 	/// The last notebook number to be closed/completed (note: this is not the grandpa finality
 	/// meaning)
-	pub finalized_notebook_number: NotebookNumber,
-	pub finalized_tick: Tick,
+	pub last_closed_notebook_number: NotebookNumber,
+	pub last_closed_notebook_tick: Tick,
 }
 
 #[derive(Encode, TypeInfo, MaxEncodedLen)]

--- a/primitives/src/tick.rs
+++ b/primitives/src/tick.rs
@@ -113,7 +113,12 @@ impl Ticker {
 	}
 
 	#[cfg(feature = "std")]
-	pub fn duration_after_tick(&self, tick: Tick) -> Duration {
+	pub fn duration_after_tick_ends(&self, tick: Tick) -> Duration {
+		self.duration_after_tick_starts(tick + 1)
+	}
+
+	#[cfg(feature = "std")]
+	pub fn duration_after_tick_starts(&self, tick: Tick) -> Duration {
 		let current_time = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
 			Ok(n) => n.as_micros(),
 			Err(_) => 0,

--- a/runtime/argon/src/configs/mod.rs
+++ b/runtime/argon/src/configs/mod.rs
@@ -164,7 +164,7 @@ const INCREMENTAL_REWARD_AMOUNT: Balance = 1_000;
 const INCREMENT_TICKS: u32 = 118;
 
 parameter_types! {
-	pub const TargetComputeBlockPercent: FixedU128 = FixedU128::from_rational(51, 100); // aim for less than full compute time so it can wait for notebooks
+	pub const TargetComputeBlockPercent: FixedU128 = FixedU128::from_rational(49, 100); // aim for less than full compute time so it can wait for notebooks
 	pub const TargetBlockVotes: u32 = 50_000;
 	pub const SealSpecVoteHistoryForAverage: u32 = 24 * 60; // 24 hours of history
 	pub const SealSpecComputeHistoryToTrack: u32 = 6 * 60; // 6 hours of history
@@ -263,7 +263,6 @@ impl Get<bool> for MultiBlockPerTickEnabled {
 
 impl pallet_ticks::Config for Runtime {
 	type WeightInfo = ();
-	type AllowMultipleBlockPerTick = MultiBlockPerTickEnabled;
 }
 
 parameter_types! {


### PR DESCRIPTION
When a node was booting up, it was downloading all the notebook headers, even ones already in the finalized state. This PR adds a few conditions where a node should not download headers.
1. When a node boots up, all it does is get the latest header. It will catchup as it needs to
2. Do not initate compute when there’s no assigned compute mining
3. When a new block comes in, if it’s older than the latest finalized block, do not try to create new blocks off of it
4. Only try to create new blocks for ticks within a threshold of now, since they can’t actually be used for votes anyway.
5. Preserve aux history a little longer for notebook summaries