### PR TITLE
Update localchain.md

### DIFF
--- a/docs/localchain.md
+++ b/docs/localchain.md
@@ -106,7 +106,7 @@ have access to move funds between them. The following example transfers 10 Argon
 corresponding Localchain account.
 
 ```bash
-argon-localchain transactions from-mainchain 10.0 --name="alice" --mainchain-url="wss://rpc.testnet.argonprotocol.org"
+argon-localchain transactions from-mainchain 10.0 --name="alice" --mainchain-url="wss://rpc.testnet.argonprotocol.org"  --key-password="password"
 ```
 
 This will initiate a transaction on the Mainchain. You need to wait for the transaction to be confirmed before you have


### PR DESCRIPTION
I found that without the --key-password flag the
`argon-localchain transactions from-mainchain 10.0 --name="test" --mainchain-url="wss://rpc.testnet.argonprotocol.org"`

wouldn't execute
```
2024-12-23T18:17:48.985175Z  INFO main argon_localchain: localchain/src/lib.rs:169: Loading localchain at "/home/polkadot/.local/share/argon/localchain/test.db"
Error: Could not unlock the embedded key

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: argon_localchain::cli::run::{{closure}}.3101
   2: argon_localchain::main
   3: std::sys::backtrace::__rust_begin_short_backtrace
   4: main
   5: <unknown>
   6: __libc_start_main
   7: _start
```