### PR TITLE
Remove difficulty percentile + Fix Oracle

### DIFF
--- a/oracle/src/argon_price.rs
+++ b/oracle/src/argon_price.rs
@@ -63,12 +63,11 @@ impl ArgonPriceLookup {
 
 	pub async fn get_latest_price(
 		&mut self,
-		default_token_price: FixedU128,
 		tick: Tick,
 		max_argon_change_per_tick_away_from_target: FixedU128,
 		usd_token_price: FixedU128,
 	) -> Result<FixedU128> {
-		let mut price = self.uniswap_oracle.get_current_price(default_token_price).await?;
+		let mut price = self.uniswap_oracle.get_current_price().await?;
 		// ARGON/USDC * USDC/USD = ARGON/USD
 		price = price * usd_token_price;
 
@@ -275,12 +274,7 @@ mod test {
 
 		assert_eq!(
 			argon_price_lookup
-				.get_latest_price(
-					FixedU128::from_float(1.0),
-					ticker.current() + 1,
-					FixedU128::from_float(0.01),
-					usdc_usd_price,
-				)
+				.get_latest_price(ticker.current() + 1, FixedU128::from_float(0.01), usdc_usd_price,)
 				.await
 				.unwrap(),
 			FixedU128::from_float(0.9801)

--- a/oracle/src/price_index.rs
+++ b/oracle/src/price_index.rs
@@ -112,7 +112,6 @@ pub async fn price_index_loop(
 		} else {
 			argon_price_lookup
 				.get_latest_price(
-					target_price,
 					tick,
 					max_argon_change_per_tick_away_from_target,
 					usd_price_lookup.usdc,
@@ -123,8 +122,12 @@ pub async fn price_index_loop(
 		let argon_usd_price = match price_result {
 			Ok(x) => x,
 			Err(e) => {
-				tracing::warn!("Couldn't update argon prices {:?}", e);
-				continue;
+				tracing::warn!(
+					"Couldn't update argon prices. Using target {} {:?}",
+					target_price,
+					e
+				);
+				target_price
 			},
 		};
 

--- a/oracle/src/uniswap_oracle.rs
+++ b/oracle/src/uniswap_oracle.rs
@@ -67,18 +67,17 @@ impl UniswapOracle {
 		})
 	}
 
-	pub async fn get_current_price(&self, default_price: FixedU128) -> Result<FixedU128> {
+	pub async fn get_current_price(&self) -> Result<FixedU128> {
 		#[cfg(test)]
 		{
 			if let Some(price) = MOCK_PRICES.lock().pop() {
 				return Ok(price);
 			}
 		}
-		let Some(price) = self.get_aggregated_twap(60 * 60).await? else {
-			warn!("Failed to get price, using default of {}", default_price.to_float());
-			// set to default if nothing returned
-			return Ok(default_price);
-		};
+		let price = self
+			.get_aggregated_twap(60 * 60)
+			.await?
+			.ok_or(anyhow!("Failed to get price, using default"))?;
 		let scaled_numerator = price.adjusted_for_decimals().to_decimal() * FixedU128::accuracy();
 		let float = scaled_numerator.to_u128().ok_or(anyhow!("Failed to convert to u128"))?;
 		Ok(FixedU128::from_inner(float))
@@ -198,7 +197,7 @@ mod test {
 		)
 		.await
 		.expect("Failed to create oracle");
-		let price = oracle.get_current_price(FixedU128::from_float(1.0)).await.unwrap();
+		let price = oracle.get_current_price().await.unwrap();
 		println!("Price: {:?}", price);
 		// should be around 1.0
 		assert!((price.to_float() - 1.0).abs() < 0.1);

--- a/oracle/src/us_cpi.rs
+++ b/oracle/src/us_cpi.rs
@@ -519,4 +519,35 @@ mod tests {
 		assert_eq!(retriever.ticks_since_last_cpi(tick + 60), 60);
 		assert_eq!(retriever.ticks_since_last_cpi(tick + 60 * 24), 24 * 60);
 	}
+
+	#[test]
+	fn test_cpi_cache() {
+		let cpi: UsCpiRetriever  = serde_json::from_str(r#"{
+			"schedule":[{"ref_month":"2024-10-01T00:00:00Z","release_date":"2024-11-13T00:00:00Z"},{"ref_month":"2024-11-01T00:00:00Z","release_date":"2024-12-11T00:00:00Z"},{"ref_month":"2024-12-01T00:00:00Z","release_date":"2025-01-15T00:00:00Z"},{"ref_month":"2025-01-01T00:00:00Z","release_date":"2025-02-12T00:00:00Z"},{"ref_month":"2025-02-01T00:00:00Z","release_date":"2025-03-12T00:00:00Z"},{"ref_month":"2025-03-01T00:00:00Z","release_date":"2025-04-10T00:00:00Z"},{"ref_month":"2025-04-01T00:00:00Z","release_date":"2025-05-13T00:00:00Z"},{"ref_month":"2025-05-01T00:00:00Z","release_date":"2025-06-11T00:00:00Z"},{"ref_month":"2025-06-01T00:00:00Z","release_date":"2025-07-15T00:00:00Z"},{"ref_month":"2025-07-01T00:00:00Z","release_date":"2025-08-12T00:00:00Z"},{"ref_month":"2025-08-01T00:00:00Z","release_date":"2025-09-11T00:00:00Z"},{"ref_month":"2025-09-01T00:00:00Z","release_date":"2025-10-15T00:00:00Z"},{"ref_month":"2025-10-01T00:00:00Z","release_date":"2025-11-13T00:00:00Z"},{"ref_month":"2025-11-01T00:00:00Z","release_date":"2025-12-10T00:00:00Z"}],
+			"current_cpi_release_tick":28948320,
+			"current_cpi_duration_ticks":40320,
+			"current_cpi_end_value":"315605000000000032768",
+			"current_cpi_ref_month":"2024-12-01T00:00:00Z",
+			"previous_us_cpi":"315492999999999967232",
+			"cpi_change_per_tick":"2777777777779",
+			"last_schedule_check":"2025-01-16T01:33:05.613573128Z",
+			"last_cpi_check":"2025-01-16T01:33:05.613573667Z"}"#
+		).unwrap();
+		let x = cpi.calculate_smoothed_us_cpi_ratio(28948321);
+		assert_eq!(x, FixedI128::from_inner(315492999999999967232 + 2777777777779));
+
+		let cpi: UsCpiRetriever  = serde_json::from_str(r#"{
+			"schedule":[{"ref_month":"2024-10-01T00:00:00Z","release_date":"2024-11-13T00:00:00Z"},{"ref_month":"2024-11-01T00:00:00Z","release_date":"2024-12-11T00:00:00Z"},{"ref_month":"2024-12-01T00:00:00Z","release_date":"2025-01-15T00:00:00Z"},{"ref_month":"2025-01-01T00:00:00Z","release_date":"2025-02-12T00:00:00Z"},{"ref_month":"2025-02-01T00:00:00Z","release_date":"2025-03-12T00:00:00Z"},{"ref_month":"2025-03-01T00:00:00Z","release_date":"2025-04-10T00:00:00Z"},{"ref_month":"2025-04-01T00:00:00Z","release_date":"2025-05-13T00:00:00Z"},{"ref_month":"2025-05-01T00:00:00Z","release_date":"2025-06-11T00:00:00Z"},{"ref_month":"2025-06-01T00:00:00Z","release_date":"2025-07-15T00:00:00Z"},{"ref_month":"2025-07-01T00:00:00Z","release_date":"2025-08-12T00:00:00Z"},{"ref_month":"2025-08-01T00:00:00Z","release_date":"2025-09-11T00:00:00Z"},{"ref_month":"2025-09-01T00:00:00Z","release_date":"2025-10-15T00:00:00Z"},{"ref_month":"2025-10-01T00:00:00Z","release_date":"2025-11-13T00:00:00Z"},{"ref_month":"2025-11-01T00:00:00Z","release_date":"2025-12-10T00:00:00Z"}],
+			"current_cpi_release_tick":28948320,
+			"current_cpi_duration_ticks":40320,
+			"current_cpi_end_value":"315492999999999967232",
+			"current_cpi_ref_month":"2024-12-01T00:00:00Z",
+			"previous_us_cpi":"315492999999999967232",
+			"cpi_change_per_tick":"0",
+			"last_schedule_check":"2025-01-16T01:33:05.613573128Z",
+			"last_cpi_check":"2025-01-16T01:33:05.613573667Z"}"#
+		).unwrap();
+		let x = cpi.calculate_smoothed_us_cpi_ratio(28949321);
+		assert_eq!(x, FixedI128::from_inner(315492999999999967232));
+	}
 }

--- a/pallets/block_seal_spec/src/lib.rs
+++ b/pallets/block_seal_spec/src/lib.rs
@@ -348,11 +348,8 @@ pub mod pallet {
 			// only adjust difficulty every `ChangePeriod` blocks
 			if block_as_u32 % T::ComputeDifficultyChangePeriod::get() == 0u32 {
 				let mut timestamps = <PastComputeBlockTimes<T>>::get().to_vec();
-				// trim off the max 90th percentile
+				// trim off the max 90th percentile and bottom 10th
 				timestamps.sort();
-				let len = timestamps.len();
-				let to_trim = len * 8 / 10;
-				timestamps.truncate(to_trim);
 
 				let tick_millis = T::TickProvider::ticker().tick_duration_millis;
 				let target_time =

--- a/pallets/block_seal_spec/src/mock.rs
+++ b/pallets/block_seal_spec/src/mock.rs
@@ -52,6 +52,8 @@ parameter_types! {
 	pub static TargetComputeBlockPercent: Percent = Percent::from_percent(50);
 	pub const MaxNotaries: u32 = 100;
 	pub static LockedNotaries: Vec<(NotaryId, Tick)> = vec![];
+	pub static TickDuration: u64 = 200;
+	pub static HistoricalComputeBlocksForAverage: u32 = 10;
 
 	pub static CurrentTick: Tick = 0;
 }
@@ -101,7 +103,7 @@ impl TickProvider<Block> for StaticTickProvider {
 		CurrentTick::get()
 	}
 	fn ticker() -> Ticker {
-		Ticker::new(200, 2)
+		Ticker::new(TickDuration::get(), 2)
 	}
 	fn blocks_at_tick(_: Tick) -> Vec<H256> {
 		vec![]
@@ -120,7 +122,7 @@ impl pallet_block_seal_spec::Config for Test {
 	type NotebookProvider = StaticNotebookProvider;
 	type SealInherent = CurrentSeal;
 	type HistoricalVoteBlocksForAverage = ConstU32<10>;
-	type HistoricalComputeBlocksForAverage = ConstU32<10>;
+	type HistoricalComputeBlocksForAverage = HistoricalComputeBlocksForAverage;
 	type TargetComputeBlockPercent = TargetComputeBlockPercent;
 	type TickProvider = StaticTickProvider;
 	type MaxActiveNotaries = MaxNotaries;


### PR DESCRIPTION
This PR removes the percentile clamp from the difficulty algorithm. This was imposing too much of a limitation on the adjustment when compute got too hard, and it is already using the bitcoin clamp of max 4x down or up per adjustment. This change is to remove the percentile since we also increased max blocks by 60 per tick.

This PR also fixes an issue where the oracle will default to the wrong amount if a uniswap token is unavailable.