### PR TITLE
Change token symbols; Fix grandpa finality proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ node_modules
 /client/nodejs/**/*.*js
 /client/nodejs/**/*.d.ts
 /oracle/.env
-/scripts/hyperbridge/paseo-messaging-relayer.toml
+/scripts/hyperbridge/**/*-messaging-relayer.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4145,6 +4145,7 @@ dependencies = [
  "miniscript",
  "rand",
  "regex",
+ "serde",
  "serial_test",
  "sp-arithmetic",
  "sp-core",

--- a/docs/run-a-miner.md
+++ b/docs/run-a-miner.md
@@ -292,14 +292,17 @@ is determined from the block "seal" used to close a block. You can see if biddin
 ## Block Rewards
 
 Block rewards are given for each closed block as both Argons and Ownership Tokens. Rewards are scaled by the number of
-notebooks included in a block vs the active notaries. If no current notebooks are included, the block reward is only 1
-microgon (eg, you are mostly just earning fees).
+notebooks included in a block vs the active notaries. If no "current" notebooks are included, the block reward is only 1
+microgon (eg, you are mostly just earning fees). Current means the notebook tick is one prior to the block tick.
 
 Block rewards start at 0.5 Argons and 0.5 Ownership Tokens per block, and increase by 1 milligon (1/10th of an Argon)
 every 118 blocks. This will continue until the block reward reaches 5 Argons and 5 Ownership Tokens per block. After
 this point, the Ownership Tokens will become deflationary, with the block reward halving every 2.1 million blocks.
 Argons are currently slated to stay level, but we anticipate a future model where Argons are related to the total
 circulation to ensure sustainable economic security.
+
+NOTE: a miner earns 75% of the block rewards, and the vote creator earns 25% of the block rewards. If no vote creator is
+involved, the 25% are not issued.
 
 ### Reward Maturation
 

--- a/end-to-end/Cargo.toml
+++ b/end-to-end/Cargo.toml
@@ -32,3 +32,7 @@ sp-core = { workspace = true }
 subxt = { workspace = true }
 serial_test = { workspace = true }
 regex = { workspace = true }
+serde = { workspace = true }
+
+[dependencies]
+serde = { version = "1.0.215", features = ["derive"] }

--- a/end-to-end/src/lib.rs
+++ b/end-to-end/src/lib.rs
@@ -5,6 +5,8 @@ mod localchain_transfer;
 #[cfg(test)]
 mod notary;
 #[cfg(test)]
+mod sync;
+#[cfg(test)]
 mod vote_mining;
 
 #[cfg(test)]

--- a/end-to-end/src/sync.rs
+++ b/end-to-end/src/sync.rs
@@ -1,0 +1,55 @@
+use argon_testing::{test_miner_count, ArgonTestNode};
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use std::env;
+use subxt::rpc_params;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct EncodedFinalityProof(pub sp_core::Bytes);
+
+/// Tests that finality can be proven
+#[tokio::test]
+#[serial]
+async fn test_can_prove_finality() {
+	env::set_var("RUST_LOG", "info");
+	let grandpa_miner = ArgonTestNode::start_with_args("alice", 0).await.unwrap();
+	let miner_threads = test_miner_count();
+	let miner_1 = grandpa_miner.fork_node("bob", miner_threads).await.unwrap();
+
+	let mut blocks_sub = grandpa_miner.client.live.blocks().subscribe_finalized().await.unwrap();
+
+	loop {
+		if let Some(Ok(block)) = blocks_sub.next().await {
+			let block_number = block.header().number;
+			if block_number <= 0 {
+				continue;
+			}
+			let events = block.events().await.unwrap().iter().flatten().collect::<Vec<_>>();
+			println!(
+				"Events: {:?}",
+				events
+					.iter()
+					.map(|a| format!("{}.{}", a.pallet_name(), a.variant_name()))
+					.collect::<Vec<_>>()
+			);
+			// api won't work until grandpa rotates
+			if !events.iter().find(|a| a.pallet_name() == "Grandpa").is_some() {
+				continue;
+			}
+			let proof = grandpa_miner
+				.client
+				.rpc
+				.request::<Option<EncodedFinalityProof>>(
+					"grandpa_proveFinality",
+					rpc_params![block_number],
+				)
+				.await
+				.unwrap();
+			assert_eq!(proof.is_some(), true);
+			break;
+		}
+	}
+
+	drop(miner_1);
+	drop(grandpa_miner);
+}

--- a/notary/src/s3_archive.rs
+++ b/notary/src/s3_archive.rs
@@ -79,6 +79,7 @@ impl S3Archive {
 			credentials_provider.clone(),
 			region,
 		);
+		let mut remove_bucket_on_drop = false;
 		if let Err(e) = client
 			.head_bucket(HeadBucketRequest {
 				bucket: bucket_name.clone(),
@@ -86,6 +87,7 @@ impl S3Archive {
 			})
 			.await
 		{
+			remove_bucket_on_drop = true;
 			if matches!(&e, rusoto_core::RusotoError::Service(HeadBucketError::NoSuchBucket(_))) ||
 				matches!(&e, rusoto_core::RusotoError::Unknown(BufferedHttpResponse { headers, .. }) if headers.get("x-minio-error-code").cloned().unwrap_or_default() == "NoSuchBucket")
 			{
@@ -134,7 +136,7 @@ impl S3Archive {
 			notary_id,
 			client,
 			credentials_provider,
-			remove_bucket_on_drop: true,
+			remove_bucket_on_drop,
 		};
 
 		Ok((

--- a/oracle/src/argon_price.rs
+++ b/oracle/src/argon_price.rs
@@ -1,7 +1,10 @@
 use crate::uniswap_oracle::{UniswapOracle, USDC_ADDRESS, USDC_ADDRESS_SEPOLIA};
 use anyhow::Result;
 use argon_client::api::runtime_types::pallet_price_index::PriceIndex;
-use argon_primitives::tick::{Tick, Ticker};
+use argon_primitives::{
+	tick::{Tick, Ticker},
+	ARGON_TOKEN_SYMBOL,
+};
 use sp_runtime::{traits::One, FixedI128, FixedPointNumber, FixedU128, Saturating};
 use std::env;
 use uniswap_sdk_core::{prelude::*, token};
@@ -51,7 +54,8 @@ impl ArgonPriceLookup {
 		let project_id = env::var("INFURA_PROJECT_ID").expect("INFURA_PROJECT_ID must be set");
 
 		let usdc_token = get_usdc_token(network);
-		let lookup_token = token!(network as u64, argon_token_address, 18, "ARGON", "Argon");
+		let lookup_token =
+			token!(network as u64, argon_token_address, 18, ARGON_TOKEN_SYMBOL, "Argon");
 		Self::new(ticker, last_price, project_id, usdc_token, lookup_token).await
 	}
 

--- a/oracle/src/uniswap_oracle.rs
+++ b/oracle/src/uniswap_oracle.rs
@@ -177,6 +177,7 @@ impl UniswapOracle {
 mod test {
 	use super::*;
 	use std::env;
+	use tracing::warn;
 	use uniswap_sdk_core::token;
 
 	#[tokio::test]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -89,8 +89,8 @@ pub type BlockHash = BlakeTwo256;
 
 pub const TOKEN_DECIMALS: u8 = 6;
 
-pub const ARGON_TOKEN_SYMBOL: &str = "ARGON";
-pub const OWNERSHIP_TOKEN_SYMBOL: &str = "ARGONOT";
+pub const ARGON_TOKEN_SYMBOL: &str = "ARGN";
+pub const OWNERSHIP_TOKEN_SYMBOL: &str = "ARGNOT";
 
 pub mod prelude {
 	pub use super::{

--- a/runtime/argon/build.rs
+++ b/runtime/argon/build.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("ARGON", 6)
+		.enable_metadata_hash("ARGN", 6)
 		.build()
 }
 

--- a/runtime/argon/src/configs/mod.rs
+++ b/runtime/argon/src/configs/mod.rs
@@ -333,29 +333,25 @@ pub struct GrandpaSlotRotation;
 impl OnNewSlot<AccountId> for GrandpaSlotRotation {
 	type Key = GrandpaId;
 	fn on_new_slot(
-		removed_authorities: Vec<(&AccountId, Self::Key)>,
-		added_authorities: Vec<(&AccountId, Self::Key)>,
+		_removed_authorities: Vec<(&AccountId, Self::Key)>,
+		_added_authorities: Vec<(&AccountId, Self::Key)>,
 	) {
-		if removed_authorities.is_empty() && added_authorities.is_empty() {
-			return;
-		}
-		let mut next_authorities: AuthorityList = Grandpa::grandpa_authorities();
-		for (_, authority_id) in removed_authorities {
-			if let Some(index) = next_authorities.iter().position(|x| x.0 == authority_id) {
-				next_authorities.remove(index);
-			}
-		}
-		for (_, authority_id) in added_authorities {
-			next_authorities.push((authority_id, 1));
-		}
-
+		let next_authorities: AuthorityList = Grandpa::grandpa_authorities();
 		// TODO: we need to be able to run multiple grandpas on a single miner before activating
 		// 	changing the authorities. We want to activate a trailing 3 hours of miners who closed
-		// blocks 	to activate a more decentralized grandpa process
-		//
-		// if let Err(err) = Grandpa::schedule_change(next_authorities, Zero::zero(), None) {
-		// 	log::error!("Failed to schedule grandpa change: {:?}", err);
+		//  blocks to activate a more decentralized grandpa process
+		// for (_, authority_id) in removed_authorities {
+		// 	if let Some(index) = next_authorities.iter().position(|x| x.0 == authority_id) {
+		// 		next_authorities.remove(index);
+		// 	}
 		// }
+		// for (_, authority_id) in added_authorities {
+		// 	next_authorities.push((authority_id, 1));
+		// }
+
+		if let Err(err) = Grandpa::schedule_change(next_authorities, 1, None) {
+			log::error!("Failed to schedule grandpa change: {:?}", err);
+		}
 	}
 }
 

--- a/runtime/argon/src/lib.rs
+++ b/runtime/argon/src/lib.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 mod benchmark;
 
 pub mod configs;
+mod migrations;
 pub mod weights;
 
 pub use crate::configs::NotaryRecordT;
@@ -51,6 +52,7 @@ use sp_version::RuntimeVersion;
 
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+use crate::migrations::AddGrandpaRotation;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 #[cfg(feature = "std")]
@@ -79,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 102,
+	spec_version: 103,
 	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -194,8 +196,7 @@ pub type SignedExtra = (
 /// All migrations of the runtime, aside from the ones declared in the pallets.
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
-#[allow(unused_parens)]
-type Migrations = ();
+type Migrations = (AddGrandpaRotation<Runtime>,);
 
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/runtime/argon/src/migrations/mod.rs
+++ b/runtime/argon/src/migrations/mod.rs
@@ -1,0 +1,15 @@
+use crate::{configs::Get, Grandpa};
+use core::marker::PhantomData;
+use log::warn;
+use pallet_grandpa::Config;
+
+/// The grandpa authorities need a rotation for proofs to work
+pub struct AddGrandpaRotation<T>(PhantomData<T>);
+impl<T: Config> frame_support::traits::OnRuntimeUpgrade for AddGrandpaRotation<T> {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		warn!("Adding grandpa rotation");
+		Grandpa::schedule_change(Grandpa::grandpa_authorities(), 1, None)
+			.expect("Needs to be accepted");
+		T::DbWeight::get().reads_writes(1, 2)
+	}
+}

--- a/runtime/canary/build.rs
+++ b/runtime/canary/build.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("ARGON", 6)
+		.enable_metadata_hash("ARGN", 6)
 		.build()
 }
 

--- a/scripts/local_testnet_docker.sh
+++ b/scripts/local_testnet_docker.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# This script is meant to be run on Unix/Linux based systems
+set -e
+
+BASEDIR=$(dirname "$0")/..
+# create array of validators
+validators=(alice bob dave)
+
+# Check if minio is active on port 9000
+if ! nc -z localhost 9000; then
+  echo "Minio is not running on port 9000. Please start minio and try again (`./docker_minio.sh`)."
+  exit 1
+fi
+
+RUNID=test01182025
+DBPATH=postgres://postgres:password@localhost:5432/notary-$RUNID
+# Create a minio bucket name
+BUCKET_NAME="notary-$RUNID"
+NOTEBOOK_ARCHIVE="http://127.0.0.1:9000/$BUCKET_NAME"
+
+set -x  # Print commands and their arguments as they are executed
+createdb notary-$RUNID || true;
+mkdir -p /tmp/argon/$RUNID;
+mkdir -p /tmp/argon/bitcoin;
+export VERSION=1.0.1
+TRAP_CMD=""
+
+$("$BASEDIR/target/debug/argon-testing-bitcoin") -regtest -fallbackfee=0.0001 -listen=0 -datadir=/tmp/argon/bitcoin -blockfilterindex -txindex -rpcport=18444 -rpcuser=bitcoin -rpcpassword=bitcoin &
+
+# Function to check if the Bitcoin node is ready
+is_node_ready() {
+  curl -s --user bitcoin:bitcoin --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getblockchaininfo", "params": [] }' -H 'content-type: text/plain;' http://127.0.0.1:18444/ | grep -q "result"
+}
+
+# Wait for the node to start
+echo -e "Waiting for Bitcoin node to start...\n"
+until is_node_ready; do
+  sleep 1
+done
+
+
+### start ngrok
+##ngrok  --config "${BASEDIR}/scripts/ngrok.yml,$HOME/Library/Application Support/ngrok/ngrok.yml" start --all > /dev/null &
+##
+### Function to check if ngrok is ready
+##is_ngrok_ready() {
+##  curl -s http://127.0.0.1:4040/api/tunnels | grep -q "tunnels"
+##}
+##
+### Wait for ngrok to start
+##echo -e "Waiting for ngrok to start...\n\n"
+##until is_ngrok_ready; do
+##  sleep 1
+##done
+
+argon_LOCAL_TESTNET_NOTARY_URL=$(curl -s http://localhost:4040/api/tunnels/notary | jq -r '.public_url' | sed 's/https:\/\///' | sed 's/http:\/\///');
+
+export argon_LOCAL_TESTNET_NOTARY_URL="wss://$argon_LOCAL_TESTNET_NOTARY_URL"
+
+# start a temporary node with alice and bob funded
+for i in {0..2} ; do
+  mkdir -p /tmp/argon/$RUNID/${validators[$i]};
+  docker run -d --network=host --name "argon-node-${validators[$i]}" --restart=unless-stopped ghcr.io/argonprotocol/argon-miner:v$VERSION \
+    --${validators[$i]} --detailed-log-output --chain local --name=${validators[$i]} \
+    --base-path /tmp/argon/$RUNID/${validators[$i]} \
+    --notebook-archive-hosts=$NOTEBOOK_ARCHIVE \
+    --rpc-port=994$((i+4)) --port 3033$((i+4)) --compute-miners 1 \
+    --pruning=archive -lRUST_LOG=info,argon=info,ismp=trace \
+    --unsafe-force-node-key-generation --unsafe-rpc-external --rpc-methods=unsafe \
+    --rpc-cors=all  --bitcoin-rpc-url=http://bitcoin:bitcoin@localhost:18444 &
+  # remove docker on exit
+  TRAP_CMD="docker rm -f argon-node-${validators[$i]} && $TRAP_CMD"
+done
+
+# Function to check if the Substrate node is ready
+is_node_ready() {
+  curl -s http://127.0.0.1:9944/health | grep -q "\"isSyncing\":false"
+}
+
+# Wait for the node to start
+echo -e "Waiting for Substrate node to start...\n\n"
+until is_node_ready; do
+  sleep 1
+done
+
+docker run -it --rm ghcr.io/argonprotocol/argon-notary:v$VERSION insert-key --keystore-path /tmp/notary_keystore --suri //Ferdie//notary;
+docker run -it --rm --network=host ghcr.io/argonprotocol/argon-notary:v$VERSION migrate --db-url ${DBPATH};
+
+# use dev to create the archive bucket for us
+docker run -d --network=host -e RUST_LOG=info --name=argon-notary ghcr.io/argonprotocol/argon-notary:v$VERSION run \
+  --operator-address=5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL --db-url ${DBPATH} -t ws://127.0.0.1:9944 \
+  --keystore-path /tmp/notary_keystore \
+  --dev \
+  --archive-bucket "$BUCKET_NAME" \
+  -b "0.0.0.0:9925" &
+
+# remove docker on exit
+trap "$TRAP_CMD & docker rm -f argon-notary && 'kill $(jobs -p)'" EXIT SIGHUP SIGINT SIGTERM
+
+#echo -e "Starting a bitcoin oracle...\n\n"
+#"$BASEDIR/target/debug/argon-oracle" insert-key --crypto-type=sr25519 --keystore-path /tmp/bitcoin_keystore --suri //Dave
+#RUST_LOG=info "$BASEDIR/target/debug/argon-oracle" --keystore-path /tmp/bitcoin_keystore \
+#  --signer-crypto=sr25519 --signer-address=5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy \
+#  -t ws://127.0.0.1:9944 bitcoin --bitcoin-rpc-url=http://bitcoin:bitcoin@localhost:18444 &
+#
+#echo -e "Starting a pricing oracle...\n\n"
+#"$BASEDIR/target/debug/argon-oracle" insert-key --crypto-type=sr25519 --keystore-path /tmp/price_keystore  --suri //Eve
+#RUST_LOG=info "$BASEDIR/target/debug/argon-oracle" --keystore-path /tmp/price_keystore \
+#  --signer-crypto=sr25519 --signer-address=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
+#  -t ws://127.0.0.1:9944 price-index --simulate-prices &
+#
+wait


### PR DESCRIPTION
Grandpa finality proofs don't work until you do a rotation of grandpa authorities (bug in underlying library). This PR adds a migration to do rotate the authorities, as well as fixing an issue with the shared voter state in the node.

Several testing scripts were updated to simulate upgrading the network and watching the authorities apply.

Secondarily, this PR changes the token symbol in metadata hash and the chain spec. Neither of these changes seems to cause a genesis mismatch per testing. Will want to confirm on testnet as well.