### PR TITLE
Bug fixes

### DIFF
--- a/node/consensus/src/error.rs
+++ b/node/consensus/src/error.rs
@@ -64,6 +64,8 @@ pub enum Error {
 
 	#[error("Notary error: {0}")]
 	NotaryError(String),
+	#[error("The notebook can't be audited yet {0}")]
+	NotebookAuditBeforeTick(String),
 	#[error("Notary archive error: {0}")]
 	NotaryArchiveError(String),
 	#[error("A block could not be verified because a notary could not be synchronized with. {0}")]

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -148,6 +148,7 @@ where
 		client.clone(),
 		aux_client.clone(),
 		notary_client.clone(),
+		Some(Box::new(grandpa_block_import.clone())),
 		grandpa_block_import,
 		&task_manager.spawn_essential_handle(),
 		config.prometheus_registry(),
@@ -240,6 +241,7 @@ where
 
 	let role = config.role;
 	let name = config.network.node_name.clone();
+	let disable_grandpa = config.disable_grandpa;
 	let prometheus_registry = config.prometheus_registry().cloned();
 
 	#[cfg(not(debug_assertions))]
@@ -327,7 +329,7 @@ where
 		);
 	}
 	// grandpa voter task
-	{
+	if !disable_grandpa {
 		// TODO: we need to create a keystore for each grandpa voter we want to run. Probably a
 		// service 	 that can dynamically allocate an deallocate voters with restricted/filtered
 		// keystore access start the full GRANDPA voter

--- a/pallets/mining_slot/src/lib.rs
+++ b/pallets/mining_slot/src/lib.rs
@@ -993,7 +993,7 @@ pub trait OnNewSlot<AccountId> {
 	fn on_new_slot(
 		removed_authorities: Vec<(&AccountId, Self::Key)>,
 		added_authorities: Vec<(&AccountId, Self::Key)>,
-		force: bool,
+		with_delay: bool,
 	);
 }
 
@@ -1001,7 +1001,7 @@ pub trait SlotEvents<AccountId> {
 	fn on_new_slot<Ks: OpaqueKeys>(
 		removed_authorities: Vec<(AccountId, Ks)>,
 		added_authorities: Vec<(AccountId, Ks)>,
-		force: bool,
+		with_delay: bool,
 	);
 }
 
@@ -1011,7 +1011,7 @@ impl<AId> SlotEvents<AId> for Tuple {
 	fn on_new_slot<Ks: OpaqueKeys>(
 		removed_authorities: Vec<(AId, Ks)>,
 		added_authorities: Vec<(AId, Ks)>,
-		force: bool,
+		with_delay: bool,
 	) {
 		for_tuples!(
 		#(
@@ -1023,7 +1023,7 @@ impl<AId> SlotEvents<AId> for Tuple {
 				added_authorities.iter().filter_map(|k| {
 					k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID).map(|k1| (&k.0, k1))
 				}).collect::<Vec<_>>();
-			Tuple::on_new_slot(removed_keys, added_keys, force);
+			Tuple::on_new_slot(removed_keys, added_keys, with_delay);
 		)*
 		)
 	}

--- a/pallets/notebook/src/lib.rs
+++ b/pallets/notebook/src/lib.rs
@@ -179,6 +179,8 @@ pub mod pallet {
 		InvalidReprocessNotebook,
 		/// Invalid notary operator
 		InvalidNotaryOperator,
+		/// Invalid notebook submission tick
+		InvalidNotebookSubmissionTick,
 	}
 
 	#[pallet::hooks]
@@ -229,6 +231,7 @@ pub mod pallet {
 				Error::<T>::InvalidNotebookDigest
 			);
 
+			let current_tick = T::TickProvider::current_tick();
 			let mut notebooks = notebooks;
 			notebooks.sort_by(|a, b| a.header.notebook_number.cmp(&b.header.notebook_number));
 
@@ -243,6 +246,7 @@ pub mod pallet {
 					"Processing notebook",
 				);
 
+				ensure!(header.tick < current_tick, Error::<T>::InvalidNotebookSubmissionTick);
 				ensure!(
 					!Self::is_notary_locked_at_tick(notary_id, header.tick),
 					Error::<T>::NotebookSubmittedForLockedNotary

--- a/pallets/notebook/src/tests.rs
+++ b/pallets/notebook/src/tests.rs
@@ -73,7 +73,7 @@ fn it_locks_notaries_on_audit_failure() {
 		let digest = notebook_digest(vec![(1, 1, 1, false), (2, 1, 1, true)]);
 		Digests::mutate(|d| d.notebooks = digest.clone());
 		Notebook::on_initialize(1);
-		CurrentTick::set(1);
+		CurrentTick::set(2);
 		assert_err!(
 			Notebook::submit(RuntimeOrigin::none(), vec![]),
 			Error::<Test>::InvalidNotebookDigest

--- a/runtime/argon/src/configs/mod.rs
+++ b/runtime/argon/src/configs/mod.rs
@@ -335,14 +335,12 @@ pub struct GrandpaSlotRotation;
 impl OnNewSlot<AccountId> for GrandpaSlotRotation {
 	type Key = GrandpaId;
 	fn on_new_slot(
-		removed_authorities: Vec<(&AccountId, Self::Key)>,
-		added_authorities: Vec<(&AccountId, Self::Key)>,
-		force: bool,
+		_removed_authorities: Vec<(&AccountId, Self::Key)>,
+		_added_authorities: Vec<(&AccountId, Self::Key)>,
+		delay: bool,
 	) {
 		let next_authorities: AuthorityList = Grandpa::grandpa_authorities();
-		if removed_authorities.is_empty() && added_authorities.is_empty() && !force {
-			return;
-		}
+
 		// TODO: we need to be able to run multiple grandpas on a single miner before activating
 		// 	changing the authorities. We want to activate a trailing 3 hours of miners who closed
 		//  blocks to activate a more decentralized grandpa process
@@ -355,11 +353,9 @@ impl OnNewSlot<AccountId> for GrandpaSlotRotation {
 		// 	next_authorities.push((authority_id, 1));
 		// }
 
-		// Only schedule a single rotation. This is mostly just to ensure that development (which
-		// won't have migrations) will get a grandpa change. Grandpa changes are needed to enable
-		// proofs of finality
+		let in_blocks = if delay { 1 } else { 0 };
 		log::info!("Scheduling grandpa change");
-		if let Err(err) = Grandpa::schedule_change(next_authorities, 1, None) {
+		if let Err(err) = Grandpa::schedule_change(next_authorities, in_blocks, None) {
 			log::error!("Failed to schedule grandpa change: {:?}", err);
 		}
 	}


### PR DESCRIPTION
This PR fixes two major issues:
1. Grandpa justifications would fail occasionally. This was because of a misconfiguration in the import queue.
2. When synching a node, the notary client was having issues occasionally with two things:
 - a race condition where it tried to audit a notebook that had already been audited
 - failing audit because the audit is attempted against a block that is older than the notebook. The solution for this is to re-queue a failed audit that occurs when the notebook tick is newer than the latest runtime tick. NOTE: this does mean a failing audit notebook will go in AFTER the tick it is designated for.