### PR TITLE
Add https support for bitcoin apis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 default_stages: [ pre-commit, pre-push ]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,7 @@ dependencies = [
  "k256",
  "log",
  "miniscript",
+ "minreq",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand",
@@ -1372,6 +1373,7 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-http",
  "anyhow",
+ "argon-bitcoin",
  "argon-client",
  "argon-primitives",
  "argon-testing",
@@ -9513,6 +9515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lioness"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17290,6 +17298,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22377,9 +22398,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",
@@ -24761,13 +24782,12 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "linux-raw-sys 0.4.15",
- "rustix 0.38.43",
+ "rustix 1.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,6 +353,7 @@ impl-trait-for-tuples = "0.2.2"
 rsntp = { version = "4.0" }
 
 bitcoincore-rpc = { version = "0.19" }
+minreq = { version = "2.7.0", features = ["https", "json-using-serde"] }
 bitcoin = { version = "0.32.0", default-features = false }
 bip39 = { version = "2.0.0" }
 miniscript = { version = "12.0.0", default-features = false }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,6 +29,8 @@ hwi = { workspace = true, optional = true }
 
 argon-primitives = { workspace = true, default-features = false, features = ["bitcoin"] }
 log = { workspace = true }
+minreq = { workspace = true, optional = true, features = ["https", "json-using-serde"] }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 frame-support = { workspace = true }
@@ -39,7 +41,7 @@ env_logger = { workspace = true }
 rand = { workspace = true }
 base64 = { workspace = true }
 bitcoin = { workspace = true, features = ["base64"] }
-serde_json = { workspace = true }
+
 
 [features]
 default = [ "std" ]
@@ -53,7 +55,9 @@ std = [
 	"k256/std",
 	"log/std",
 	"miniscript/std",
+	"minreq",
 	"parking_lot/default",
+	"serde_json/std",
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",

--- a/bitcoin/src/client.rs
+++ b/bitcoin/src/client.rs
@@ -1,0 +1,129 @@
+use bitcoin::hashes::serde;
+use bitcoincore_rpc::{
+	jsonrpc,
+	jsonrpc::{base64, minreq, minreq_http::HttpError, Request, Response},
+	Auth, Error, RpcApi,
+};
+use log::{
+	debug, log_enabled, trace,
+	Level::{Debug, Trace, Warn},
+};
+use serde::Deserialize;
+use serde_json::Value;
+use std::{fmt, io::Read, sync::atomic, time::Duration};
+
+/// This class is a modified version of the minreq client built into bitcoincore-rpc-rs, but with
+/// the rust tls feature activated
+pub struct Client {
+	pub timeout: Duration,
+	url: String,
+	basic_auth: Option<String>,
+	nonce: atomic::AtomicUsize,
+}
+
+impl fmt::Debug for Client {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "bitcoincore_rpc::Client({:?})", self.url)
+	}
+}
+
+impl Client {
+	/// Creates a client to a bitcoind JSON-RPC server.
+	pub fn new(url: &str, auth: Auth) -> anyhow::Result<Self> {
+		let mut basic = None;
+		match auth {
+			Auth::None => {},
+			Auth::UserPass(u, p) => {
+				let auth = format!("{}:{}", u, p);
+				basic = Some(auth.into_bytes());
+			},
+			Auth::CookieFile(file) => {
+				let mut cookie = std::fs::File::open(file)?;
+				let mut buf = vec![];
+				cookie.read_to_end(&mut buf)?;
+				basic = Some(buf);
+			},
+		}
+		let basic_auth = basic.map(|buf| format!("Basic {}", base64::encode(buf)));
+
+		let timeout = Duration::from_secs(15);
+
+		let client = Client {
+			basic_auth,
+			url: url.to_string(),
+			nonce: atomic::AtomicUsize::new(0),
+			timeout,
+		};
+		Ok(client)
+	}
+
+	fn send_request(&self, req: Request) -> Result<Response, jsonrpc::minreq_http::Error> {
+		let mut client = minreq::Request::new(minreq::Method::Post, &self.url)
+			.with_timeout(self.timeout.as_secs());
+
+		if let Some(auth) = &self.basic_auth {
+			client = client.with_header("Authorization", auth);
+		}
+		let resp = client.with_json(&req)?.send()?;
+		match resp.json() {
+			Ok(json) => Ok(json),
+			Err(minreq_err) =>
+				if resp.status_code != 200 {
+					Err(jsonrpc::minreq_http::Error::Http(HttpError {
+						status_code: resp.status_code,
+						body: resp.as_str().unwrap_or("").to_string(),
+					}))
+				} else {
+					Err(jsonrpc::minreq_http::Error::Minreq(minreq_err))
+				},
+		}
+	}
+}
+
+impl RpcApi for Client {
+	fn call<T: for<'a> Deserialize<'a>>(
+		&self,
+		cmd: &str,
+		args: &[Value],
+	) -> bitcoincore_rpc::Result<T> {
+		let raw = serde_json::value::to_raw_value(args)?;
+		let nonce = self.nonce.fetch_add(1, atomic::Ordering::Relaxed);
+		let req = Request {
+			method: cmd,
+			params: Some(&raw),
+			id: serde_json::Value::from(nonce),
+			jsonrpc: Some("2.0"),
+		};
+		if log_enabled!(Debug) {
+			debug!(target: "bitcoincore_rpc", "JSON-RPC request: {} {}", cmd, serde_json::Value::from(args));
+		}
+
+		let resp = self
+			.send_request(req)
+			.map_err(|e| Error::JsonRpc(jsonrpc::Error::Transport(Box::new(e)).into()));
+		log_response(cmd, &resp);
+		Ok(resp?.result()?)
+	}
+}
+
+fn log_response(cmd: &str, resp: &bitcoincore_rpc::Result<jsonrpc::Response>) {
+	if log_enabled!(Warn) || log_enabled!(Debug) || log_enabled!(Trace) {
+		match resp {
+			Err(ref e) =>
+				if log_enabled!(Debug) {
+					debug!(target: "bitcoincore_rpc", "JSON-RPC failed parsing reply of {}: {:?}", cmd, e);
+				},
+			Ok(ref resp) =>
+				if let Some(ref e) = resp.error {
+					if log_enabled!(Debug) {
+						debug!(target: "bitcoincore_rpc", "JSON-RPC error for {}: {:?}", cmd, e);
+					}
+				} else if log_enabled!(Trace) {
+					let def =
+						serde_json::value::to_raw_value(&serde_json::value::Value::Null).unwrap();
+					let result = resp.result.as_ref().unwrap_or(&def);
+					trace!(target: "bitcoincore_rpc", "JSON-RPC response for {}: {}", cmd, result);
+				},
+		}
+	}
+}

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -11,6 +11,8 @@ pub use utxo_spend_filter::{BlockFilter, UtxoSpendFilter};
 mod cosign_releaser;
 mod cosign_script;
 
+#[cfg(feature = "std")]
+pub mod client;
 mod errors;
 #[cfg(feature = "std")]
 mod utxo_spend_filter;

--- a/bitcoin/src/utxo_spend_filter.rs
+++ b/bitcoin/src/utxo_spend_filter.rs
@@ -2,13 +2,8 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
+use crate::client::Client;
 use anyhow::bail;
-use bitcoin::{bip158, hashes::Hash};
-use bitcoincore_rpc::{Auth, Client, RpcApi};
-use codec::{Decode, Encode};
-use parking_lot::Mutex;
-use sp_runtime::RuntimeDebug;
-
 use argon_primitives::{
 	bitcoin::{
 		BitcoinBlock, BitcoinHeight, BitcoinNetwork, BitcoinRejectedReason, BitcoinSyncStatus,
@@ -16,6 +11,11 @@ use argon_primitives::{
 	},
 	inherents::BitcoinUtxoSync,
 };
+use bitcoin::{bip158, hashes::Hash};
+use bitcoincore_rpc::{Auth, RpcApi};
+use codec::{Decode, Encode};
+use parking_lot::Mutex;
+use sp_runtime::RuntimeDebug;
 
 #[derive(Clone, Decode, Encode, PartialEq, Eq, RuntimeDebug)]
 pub struct BlockFilter {

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -308,7 +308,7 @@ impl MiningConfig {
 			));
 		};
 
-		let bitcoin_url = Url::parse(bitcoin_rpc_url).map_err(|e| {
+		let mut bitcoin_url = Url::parse(bitcoin_rpc_url).map_err(|e| {
 			Error::Input(format!("Unable to parse bitcoin rpc url ({}) {:?}", bitcoin_rpc_url, e))
 		})?;
 		let (user, password) = (bitcoin_url.username(), bitcoin_url.password());
@@ -318,6 +318,8 @@ impl MiningConfig {
 		} else {
 			None
 		};
+		bitcoin_url.set_username("").ok();
+		bitcoin_url.set_password(None).ok();
 		Ok((bitcoin_url, bitcoin_auth))
 	}
 }

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -28,6 +28,7 @@ clap = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
 directories = { workspace = true }
+argon-bitcoin = { workspace = true, features = ["default"] }
 argon-client = { workspace = true }
 argon-primitives = { workspace = true, features = ["default", "bitcoin"] }
 url = { workspace = true }

--- a/oracle/src/bitcoin_tip.rs
+++ b/oracle/src/bitcoin_tip.rs
@@ -1,14 +1,14 @@
 use anyhow::bail;
-use bitcoincore_rpc::{Auth, Client, RpcApi};
-use std::time::Duration;
-use tokio::time::sleep;
-
+use argon_bitcoin::client::Client;
 use argon_client::{
 	api::{runtime_types::argon_primitives::bitcoin as bitcoin_primitives_subxt, storage, tx},
 	signer::Signer,
 	ArgonConfig, ReconnectingClient,
 };
 use argon_primitives::bitcoin::{BitcoinNetwork, H256Le};
+use bitcoincore_rpc::{Auth, RpcApi};
+use std::time::Duration;
+use tokio::time::sleep;
 
 const CONFIRMATIONS: u64 = 6;
 

--- a/oracle/src/main.rs
+++ b/oracle/src/main.rs
@@ -206,17 +206,19 @@ async fn main() -> anyhow::Result<()> {
 			}
 		},
 		Subcommand::Bitcoin { bitcoin_rpc_url } => {
-			let bitcoin_url = Url::parse(&bitcoin_rpc_url).map_err(|e| {
+			let mut bitcoin_url = Url::parse(&bitcoin_rpc_url).map_err(|e| {
 				anyhow!("Unable to parse bitcoin rpc url ({}) {:?}", bitcoin_rpc_url, e)
 			})?;
 			let (user, password) = (bitcoin_url.username(), bitcoin_url.password());
-
 			let bitcoin_auth = if !user.is_empty() {
 				Some((user.to_string(), password.unwrap_or_default().to_string()))
 			} else {
 				None
 			};
-			bitcoin_loop(bitcoin_rpc_url, bitcoin_auth, trusted_rpc_url, signer).await?
+			bitcoin_url.set_username("").ok();
+			bitcoin_url.set_password(None).ok();
+
+			bitcoin_loop(bitcoin_url.to_string(), bitcoin_auth, trusted_rpc_url, signer).await?
 		},
 		_ => bail!("Handled above, qed, not possible"),
 	};

--- a/testing/src/argon_node.rs
+++ b/testing/src/argon_node.rs
@@ -303,7 +303,7 @@ impl ArgonTestNode {
 	}
 
 	pub fn get_bitcoin_url(&self) -> (String, Auth) {
-		let rpc_url = self.start_args.bitcoin_rpc_url().unwrap();
+		let mut rpc_url = self.start_args.bitcoin_rpc_url().unwrap();
 
 		let auth = if !rpc_url.username().is_empty() {
 			Auth::UserPass(
@@ -313,6 +313,8 @@ impl ArgonTestNode {
 		} else {
 			Auth::None
 		};
+		rpc_url.set_password(None).unwrap();
+		rpc_url.set_username("").unwrap();
 		(rpc_url.to_string(), auth)
 	}
 }


### PR DESCRIPTION
The default bitcoin library didn't support https endpoints, which is difficult when trying to use hosted bitcoin servers. This adds https support by activating it in `minreq` and replicating the "call" feature from the built-in library.