### PR TITLE
fix(node): properly retieve aux data

### DIFF
--- a/node/consensus/src/aux_client.rs
+++ b/node/consensus/src/aux_client.rs
@@ -173,6 +173,7 @@ impl<B: BlockT, C: AuxStore + 'static> ArgonAux<B, C> {
 			.insert_aux(vec![], &to_delete.iter().map(|a| a.as_slice()).collect::<Vec<_>>())?;
 
 		version.mutate(|a| *a = VERSION)?;
+		info!("Migration of aux data complete {}", version.get());
 
 		Ok(())
 	}

--- a/node/consensus/src/aux_data.rs
+++ b/node/consensus/src/aux_data.rs
@@ -23,9 +23,8 @@ where
 		AuxData { client, key, data: Arc::new(RwLock::new(start_data)) }
 	}
 
-	pub fn get_static(key: &[u8], client: &Arc<C>) -> T {
-		let key = key.encode();
-		if let Ok(Some(bytes)) = client.get_aux(&key) {
+	fn get_static(encoded_key: &[u8], client: &Arc<C>) -> T {
+		if let Ok(Some(bytes)) = client.get_aux(&encoded_key) {
 			T::decode(&mut &bytes[..]).ok().unwrap_or_default()
 		} else {
 			Default::default()


### PR DESCRIPTION
A double-encoding of keys was preventings the node from retrieving existing aux keys on startup.