### PR TITLE
Bitcoin price

### DIFF
--- a/pallets/bitcoin_locks/src/mock.rs
+++ b/pallets/bitcoin_locks/src/mock.rs
@@ -67,10 +67,10 @@ pub fn set_argons(account_id: u64, amount: Balance) {
 
 parameter_types! {
 	pub static MaxConcurrentlyReleasingLocks: u32 = 10;
-	pub static BitcoinPriceInUsdCents: Option<FixedU128> = Some(FixedU128::from_u32(62_000_00));
-	pub static ArgonPriceInUsdCents: Option<FixedU128> = Some(FixedU128::from_u32(100));
+	pub static BitcoinPriceInUsd: Option<FixedU128> = Some(FixedU128::from_rational(62_000_00, 100));
+	pub static ArgonPriceInUsd: Option<FixedU128> = Some(FixedU128::from_rational(100, 100));
 	pub static ArgonCPI: Option<argon_primitives::ArgonCPI> = Some(FixedI128::from_float(0.1));
-	pub static ArgonTargetPriceInUsdCents: Option<FixedU128> = Some(FixedU128::from_u32(100));
+	pub static ArgonTargetPriceInUsd: Option<FixedU128> = Some(FixedU128::from_rational(100, 100));
 	pub static LockReleaseCosignDeadlineBlocks: BitcoinHeight = 5;
 	pub static LockReclamationBlocks: BitcoinHeight = 30;
 	pub static LockDurationBlocks: BitcoinHeight = 144 * 365;
@@ -138,11 +138,11 @@ impl UtxoLockEvents<u64, Balance> for EventHandler {
 
 pub struct StaticPriceProvider;
 impl PriceProvider<Balance> for StaticPriceProvider {
-	fn get_latest_btc_price_in_us_cents() -> Option<FixedU128> {
-		BitcoinPriceInUsdCents::get()
+	fn get_latest_btc_price_in_usd() -> Option<FixedU128> {
+		BitcoinPriceInUsd::get()
 	}
-	fn get_latest_argon_price_in_us_cents() -> Option<FixedU128> {
-		ArgonPriceInUsdCents::get()
+	fn get_latest_argon_price_in_usd() -> Option<FixedU128> {
+		ArgonPriceInUsd::get()
 	}
 	fn get_argon_cpi() -> Option<argon_primitives::ArgonCPI> {
 		ArgonCPI::get()
@@ -151,7 +151,7 @@ impl PriceProvider<Balance> for StaticPriceProvider {
 		todo!()
 	}
 	fn get_redemption_r_value() -> Option<FixedU128> {
-		ArgonPriceInUsdCents::get()?.checked_div(&ArgonTargetPriceInUsdCents::get().unwrap())
+		ArgonPriceInUsd::get()?.checked_div(&ArgonTargetPriceInUsd::get().unwrap())
 	}
 }
 

--- a/pallets/block_rewards/src/mock.rs
+++ b/pallets/block_rewards/src/mock.rs
@@ -198,10 +198,10 @@ impl PriceProvider<Balance> for StaticPriceProvider {
 	fn get_argon_cpi() -> Option<argon_primitives::ArgonCPI> {
 		Some(ArgonCPI::get())
 	}
-	fn get_latest_argon_price_in_us_cents() -> Option<FixedU128> {
+	fn get_latest_argon_price_in_usd() -> Option<FixedU128> {
 		ArgonPricePerUsd::get()
 	}
-	fn get_latest_btc_price_in_us_cents() -> Option<FixedU128> {
+	fn get_latest_btc_price_in_usd() -> Option<FixedU128> {
 		BitcoinPricePerUsd::get()
 	}
 	fn get_argon_pool_liquidity() -> Option<Balance> {

--- a/pallets/mint/src/mock.rs
+++ b/pallets/mint/src/mock.rs
@@ -57,10 +57,10 @@ impl PriceProvider<Balance> for StaticPriceProvider {
 	fn get_argon_cpi() -> Option<argon_primitives::ArgonCPI> {
 		ArgonCPI::get()
 	}
-	fn get_latest_argon_price_in_us_cents() -> Option<FixedU128> {
+	fn get_latest_argon_price_in_usd() -> Option<FixedU128> {
 		ArgonPricePerUsd::get()
 	}
-	fn get_latest_btc_price_in_us_cents() -> Option<FixedU128> {
+	fn get_latest_btc_price_in_usd() -> Option<FixedU128> {
 		BitcoinPricePerUsd::get()
 	}
 	fn get_argon_pool_liquidity() -> Option<Balance> {

--- a/pallets/price_index/src/lib.rs
+++ b/pallets/price_index/src/lib.rs
@@ -58,7 +58,7 @@ impl PriceIndex {
 	}
 
 	pub fn redemption_r_value(&self) -> FixedU128 {
-		self.argonot_usd_price
+		self.argon_usd_price
 			.checked_div(&self.argon_usd_target_price)
 			.unwrap_or(FixedU128::one())
 	}
@@ -291,11 +291,11 @@ pub mod pallet {
 		fn get_argon_cpi() -> Option<ArgonCPI> {
 			Self::get_current().map(|a| a.argon_cpi())
 		}
-		fn get_latest_argon_price_in_us_cents() -> Option<FixedU128> {
+		fn get_latest_argon_price_in_usd() -> Option<FixedU128> {
 			Self::get_current().map(|a| a.argon_usd_price)
 		}
 
-		fn get_latest_btc_price_in_us_cents() -> Option<FixedU128> {
+		fn get_latest_btc_price_in_usd() -> Option<FixedU128> {
 			Self::get_current().map(|a| a.btc_usd_price)
 		}
 

--- a/primitives/src/bitcoin.rs
+++ b/primitives/src/bitcoin.rs
@@ -320,6 +320,12 @@ mod bitcoin_compat {
 			child_number.is_hardened()
 		}
 
+		/// Derives a child public key from the current xpub at the given index.
+		/// NOTE: this uses unhardened derivation because it's in the public blockchain and hardened
+		/// derivation requires a private key. This does mean that if a single private key for a
+		/// vault is compromised, all the other xprivs derived from it can be compromised as well.
+		/// TODO: when we switch to taproot, we can use hardened derivation for the vault xpub
+		/// equivalent.
 		pub fn derive_pubkey(&self, index: u32) -> Result<BitcoinXPub, XpubErrors> {
 			let child_number =
 				ChildNumber::new(index, false).map_err(|_| XpubErrors::InvalidXpubkeyChild)?;

--- a/primitives/src/providers.rs
+++ b/primitives/src/providers.rs
@@ -44,8 +44,8 @@ pub trait PriceProvider<Balance: Codec + Copy + AtLeast32BitUnsigned + Into<u128
 		let satoshis_per_bitcoin = FixedU128::saturating_from_integer(SATOSHIS_PER_BITCOIN);
 		let microgons_per_argon = FixedU128::saturating_from_integer(MICROGONS_PER_ARGON);
 
-		let btc_usd_price = Self::get_latest_btc_price_in_us_cents()?;
-		let argon_usd_price = Self::get_latest_argon_price_in_us_cents()?;
+		let btc_usd_price = Self::get_latest_btc_price_in_usd()?;
+		let argon_usd_price = Self::get_latest_argon_price_in_usd()?;
 
 		let satoshi_cents =
 			satoshis.saturating_mul(btc_usd_price).checked_div(&satoshis_per_bitcoin)?;
@@ -57,10 +57,10 @@ pub trait PriceProvider<Balance: Codec + Copy + AtLeast32BitUnsigned + Into<u128
 		Some(microgons.saturating_mul_int(Balance::one()))
 	}
 
-	/// Prices of a single bitcoin in US cents
-	fn get_latest_btc_price_in_us_cents() -> Option<FixedU128>;
-	/// Prices of a single argon in US cents
-	fn get_latest_argon_price_in_us_cents() -> Option<FixedU128>;
+	/// Prices of a single bitcoin in USD
+	fn get_latest_btc_price_in_usd() -> Option<FixedU128>;
+	/// Prices of a single argon in USD
+	fn get_latest_argon_price_in_usd() -> Option<FixedU128>;
 
 	/// Get argon liquidity in the pool
 	fn get_argon_pool_liquidity() -> Option<Balance>;


### PR DESCRIPTION
Fixes:
- the bitcoin lock price calculation resulted in some truncation that was revealed with smaller numbers
- the price provider was referring to prices as being in cents, but they are not in cents so they're renamed
- the burn rate when a bitcoin was spent outside the system was the redemption rate, but this created a case where it became economically advantageous to move bitcoins outside the system.