### PR TITLE
fix(import_queue): make re-imports safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14197,6 +14197,7 @@ dependencies = [
  "sc-executor",
  "sc-keystore",
  "sc-network",
+ "sc-network-sync",
  "sc-network-types",
  "sc-offchain",
  "sc-rpc",

--- a/bitcoin/nodejs/src/lib.rs
+++ b/bitcoin/nodejs/src/lib.rs
@@ -69,6 +69,7 @@ pub fn create_cosign_pubkey(
 }
 
 #[wasm_bindgen(js_name = "calculateFee")]
+#[allow(clippy::too_many_arguments)]
 pub fn calculate_fee(
 	vault_pubkey_hex: &str,
 	vault_claim_pubkey_hex: &str,
@@ -142,6 +143,7 @@ pub fn sign_psbt(
 }
 
 #[wasm_bindgen(js_name = "getCosignPsbt")]
+#[allow(clippy::too_many_arguments)]
 pub fn get_cosigned_psbt(
 	txid: &str,
 	vout: u32,

--- a/bitcoin/src/psbt_utils.rs
+++ b/bitcoin/src/psbt_utils.rs
@@ -125,7 +125,7 @@ pub fn sign(psbt: &mut Psbt, privkey: PrivateKey) -> Result<(Signature, PublicKe
 		let (msg, ecdsa_type) = psbt.sighash_ecdsa(i, &mut cache).map_err(Error::SignError)?;
 		let sig = secp.sign_ecdsa(&msg, &privkey.inner);
 		let signature = Signature { signature: sig, sighash_type: ecdsa_type };
-		signatures.push((pubkey.clone(), signature));
+		signatures.push((pubkey, signature));
 	}
 	let mut result = None;
 	for (pubkey, signature) in signatures {
@@ -168,7 +168,7 @@ pub fn sign_derived(
 		else {
 			return Err(Error::DerivedKeySignError);
 		};
-		signatures.push((signature.clone(), pubkey.clone()));
+		signatures.push((*signature, pubkey));
 	}
 
 	Ok(signatures.remove(0))

--- a/end-to-end/src/bitcoin.rs
+++ b/end-to-end/src/bitcoin.rs
@@ -30,6 +30,7 @@ use bitcoind::{
 	bitcoincore_rpc::{Auth, RpcApi, bitcoincore_rpc_json::AddressType, jsonrpc::serde_json},
 };
 use polkadot_sdk::*;
+use serial_test::serial;
 use sp_arithmetic::FixedU128;
 use sp_core::{Pair, crypto::AccountId32, sr25519};
 use sp_keyring::Sr25519Keyring::{Alice, Bob, Eve};
@@ -38,6 +39,7 @@ use tokio::{fs, time::sleep};
 use url::Url;
 
 #[tokio::test(flavor = "multi_thread")]
+#[serial]
 async fn test_bitcoin_minting_e2e() {
 	let test_node = start_argon_test_node().await;
 	// need a test notary to get ownership rewards, so we can actually mint.
@@ -241,7 +243,8 @@ async fn test_bitcoin_minting_e2e() {
 	drop(test_node);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
 async fn test_bitcoin_xpriv_lock_e2e() {
 	let test_node = start_argon_test_node().await;
 	let bitcoind = test_node.bitcoind.as_ref().expect("bitcoind");
@@ -352,6 +355,9 @@ async fn test_bitcoin_xpriv_lock_e2e() {
 		}
 		println!("Waiting for utxo lock to be verified in block {:?}", next.unwrap().hash());
 	}
+
+	println!("Submitting new bitcoin price");
+	submit_price(&ticker, &client, &price_index_operator).await;
 
 	// 5. Ask for the bitcoin to be releaseed
 	println!("\nOwner requests release");

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -38,6 +38,7 @@ polkadot-sdk.features = [
     'sp-arithmetic',
     "sc-transaction-pool",
     "sc-transaction-pool-api",
+    "sc-network-sync",
     "sc-utils",
     "sc-executor",
     "sp-io",

--- a/node/consensus/src/error.rs
+++ b/node/consensus/src/error.rs
@@ -77,8 +77,8 @@ pub enum Error {
 	#[error("Notary sync missing notebook dependencies: {0}")]
 	MissingNotebooksError(String),
 
-	#[error("A duplicate block was created by this author {0} for the given voting key")]
-	DuplicateAuthoredBlock(AccountId),
+	#[error("A duplicate block was created by this author {0} for the given {1} key")]
+	DuplicateAuthoredBlock(AccountId, String),
 
 	#[error("The block state is not available")]
 	StateUnavailableError,

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -266,10 +266,15 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 							continue;
 						}
 						// If this block can still be finalized, see if we can beat it. This could be the best block
-						// or could be a new branch
+						// or could be a new branch. NOTE: we only want to do this if we have notebooks, otherwise we might kick the
+						// chain back to compute. We will try to solve again once the notebook arrives anyway and look for beatable blocks
 						let voting_schedule = VotingSchedule::when_creating_block(tick);
 						if let Ok(info) = aux_client.get_tick_voting_power(voting_schedule.notebook_tick()) {
-							check_for_better_blocks = info
+							if let Some((_, _, notebooks)) = info {
+								if notebooks > 0 {
+									check_for_better_blocks = info;
+								}
+							}
 						}
 					}
 				},

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -8,7 +8,8 @@ use crate::{
 use argon_bitcoin_utxo_tracker::UtxoTracker;
 use argon_node_consensus::{
 	BlockBuilderParams, NotaryClient, NotebookDownloader, aux_client::ArgonAux,
-	create_import_queue, run_block_builder_task, run_notary_sync,
+	create_import_queue, import_queue::ensure_best_block_state_task, run_block_builder_task,
+	run_notary_sync,
 };
 use argon_primitives::{AccountId, TickApis, tick::Ticker};
 use polkadot_sdk::*;
@@ -133,13 +134,13 @@ where
 
 	let aux_client = ArgonAux::<Block, _>::new(client.clone());
 	let ticker = {
-		let best_hash = client.info().best_hash;
-		let ticker: Ticker = client.runtime_api().ticker(best_hash).map_err(|e| {
+		let finalized_hash = client.info().finalized_hash;
+		let ticker: Ticker = client.runtime_api().ticker(finalized_hash).map_err(|e| {
 			ServiceError::Other(format!("Failed to establish runtime ticker: {:?}", e))
 		})?;
 		let latest_tick = client
 			.runtime_api()
-			.current_tick(best_hash)
+			.current_tick(finalized_hash)
 			.map_err(|e| ServiceError::Other(format!("Failed to get runtime tick: {:?}", e)))?;
 		aux_client
 			.migrate(latest_tick)
@@ -256,6 +257,16 @@ where
 			block_relay: None,
 			metrics,
 		})?;
+
+	let best_block_state_service =
+		ensure_best_block_state_task(client.clone(), sync_service.clone()).map_err(|e| {
+			ServiceError::Other(format!("Failed to start best block service {:?}", e))
+		})?;
+	task_manager.spawn_essential_handle().spawn_blocking(
+		"best-block-state",
+		None,
+		best_block_state_service,
+	);
 
 	let role = config.role;
 	let name = config.network.node_name.clone();

--- a/pallets/bitcoin_locks/src/tests.rs
+++ b/pallets/bitcoin_locks/src/tests.rs
@@ -193,7 +193,7 @@ fn calculates_redemption_prices() {
 			let price: f64 = price
 				.replace(",", "")
 				.parse()
-				.expect(format!("should parse price {}", price).as_str());
+				.unwrap_or_else(|_| panic!("should parse price {}", price));
 
 			FixedU128::from_float(price)
 		}

--- a/pallets/bitcoin_utxos/src/lib.rs
+++ b/pallets/bitcoin_utxos/src/lib.rs
@@ -158,7 +158,7 @@ pub mod pallet {
 			if let Some(operator) = &self.tip_oracle_operator {
 				<OracleOperatorAccount<T>>::put(operator);
 			}
-			<BitcoinNetwork<T>>::put(self.network.clone());
+			<BitcoinNetwork<T>>::put(self.network);
 		}
 	}
 	#[pallet::hooks]

--- a/scripts/join_public_testnet.sh
+++ b/scripts/join_public_testnet.sh
@@ -8,6 +8,6 @@ set -x  # Print commands and their arguments as they are executed
 "$BASEDIR/target/release/argon-node" --chain testnet \
  --sync=fast \
  --alice --compute-miners 1 --unsafe-force-node-key-generation \
- --bitcoin-rpc-url=https://bitcoin:bitcoin@bitcoin-node.testnet.argonprotocol.org \
+ --bitcoin-rpc-url=https://bitcoin:bitcoin@electrs.testnet.argonprotocol.org \
  -linfo,pallet=trace,argon=trace,txpool=trace \
  --notebook-archive-hosts=https://testnet-notebook-archive.argonprotocol.org \


### PR DESCRIPTION
Context
-------
A Substrate import-queue can see **the same block hash several times**: ‣ header first, later with state
‣ repeatedly gossip from many peers
‣ a retry after “parent state missing”
‣ replay with a GRANDPA justification/finality
‣ a peer continuing to insist they have a best block

Previous code had edge cases where nodes could get stuck trying to import a best block, but it would never get marked best block, so they would loop in the same spot.

What was broken & how we fixed it
---------------------------------
- if state is not available for the parent block, we now queue up the state and wait for the parent to import, then replay it
- if a block is imported again, and it doesn’t add state, or add finalization, we exit before re-importing
- we retrieve fork power from the block headers instead of aux, so we’re always in sync with the chain (instead of whichever top fork power we’ve seen). this was creating a potential “reorg” situation where rolling back to a new best block - eg, because of a finalized block not on a path, would cause the node to be unable to revert to a new “max power” and get stuck
- we had no deterministc tie breaker that the network would agree on for equal powered blocks
- any duplicated compute blocks (same fork power strength) by the same author are rejected - meaning, once a block is submitted, the chain will force you to move forward on that block instead of retrying it - which can lead to that block “overflow” at a height that we ran into
- we had a clause where a block with state would not be re-imported properly if already imported and it wasn’t on the finalization chain
- We set block.import_existing = true on the non-best twin so a peer can resend it without blowing the per-height child quota.