### PR TITLE
Aux Migration Fix

### DIFF
--- a/bitcoin/nodejs/ts/CosignScript.ts
+++ b/bitcoin/nodejs/ts/CosignScript.ts
@@ -216,6 +216,8 @@ export function getBitcoinNetworkFromApi(
     return BitcoinNetwork.Testnet;
   } else if (network.isRegtest) {
     return BitcoinNetwork.Regtest;
+  } else if (network.isSignet) {
+    return BitcoinNetwork.Signet;
   }
   throw new Error('Unsupported network: ' + network);
 }

--- a/client/nodejs/src/utils.ts
+++ b/client/nodejs/src/utils.ts
@@ -2,16 +2,18 @@ import BigNumber, * as BN from 'bignumber.js';
 import type { ArgonClient, GenericEvent } from './index';
 import type { DispatchError } from '@polkadot/types/interfaces';
 import { EventRecord } from '@polkadot/types/interfaces/system';
-import { hexToU8a } from '@polkadot/util';
 
 const { ROUND_FLOOR } = BN;
 
 export const MICROGONS_PER_ARGON = 1_000_000;
 
-export function formatArgons(x: bigint | number): string {
-  if (x === undefined || x === null) return 'na';
-  const isNegative = x < 0;
-  let format = BigNumber(x.toString()).abs().div(MICROGONS_PER_ARGON).toFormat(2, ROUND_FLOOR);
+export function formatArgons(microgons: bigint | number): string {
+  if (microgons === undefined || microgons === null) return 'na';
+  const isNegative = microgons < 0;
+  let format = BigNumber(microgons.toString())
+    .abs()
+    .div(MICROGONS_PER_ARGON)
+    .toFormat(2, ROUND_FLOOR);
   if (format.endsWith('.00')) {
     format = format.slice(0, -3);
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - --datadir=/bitcoin
       - --blockfilterindex
       - --txindex
-      - --wallet=1
+      - --wallet=mining
     ports:
       - "0:18444"
     healthcheck:
@@ -110,14 +110,14 @@ services:
           echo "rpcport=18444" >> /bitcoin/bitcoin.conf
           echo "txindex=1" >> /bitcoin/bitcoin.conf
           echo "blockfilterindex=1" >> /bitcoin/bitcoin.conf
-          echo "wallet=default" >> /bitcoin/bitcoin.conf
+          echo "wallet=mining" >> /bitcoin/bitcoin.conf
         fi
         echo "Bitcoin conf created at /bitcoin/bitcoin.conf"
         echo $(bitcoin-cli -regtest -datadir=/bitcoin -conf=/bitcoin/bitcoin.conf getwalletinfo)
         if ! bitcoin-cli -regtest -datadir=/bitcoin -conf=/bitcoin/bitcoin.conf getwalletinfo >/dev/null 2>&1; then
           echo "Creating Bitcoin wallet..."
-          bitcoin-cli -regtest -datadir=/bitcoin -conf=/bitcoin/bitcoin.conf createwallet default 2>/dev/null \
-          || bitcoin-cli -regtest -datadir=/bitcoin -conf=/bitcoin/bitcoin.conf loadwallet default
+          bitcoin-cli -regtest -datadir=/bitcoin -conf=/bitcoin/bitcoin.conf createwallet mining 2>/dev/null \
+          || bitcoin-cli -regtest -datadir=/bitcoin -conf=/bitcoin/bitcoin.conf loadwallet mining
         fi
         echo "Bitcoin wallet initialized"
       '
@@ -133,6 +133,7 @@ services:
         -regtest
         -datadir=/bitcoin
         -conf=/bitcoin/bitcoin.conf
+        -rpcwallet=mining
     depends_on:
       bitcoin-wallet-init:
         condition: service_completed_successfully
@@ -145,6 +146,7 @@ services:
         -regtest
         -datadir=/bitcoin
         -conf=/bitcoin/bitcoin.conf
+        -rpcwallet=mining
     depends_on:
       bitcoin-init:
         condition: service_completed_successfully
@@ -478,8 +480,8 @@ services:
       - /tmp/oracle/data/:/tmp/oracle/data/
     environment:
       - TRUSTED_RPC_URL=ws://archive-node:9944
-      - ARGON_TOKEN_ADDRESS=${ARGON_TOKEN_ADDRESS:-6b175474e89094c44da98b954eedeac495271d0f}
-      - ARGONOT_TOKEN_ADDRESS=${ARGONOT_TOKEN_ADDRESS:-6b175474e89094c44da98b954eedeac495271d0f}
+      - ARGON_TOKEN_ADDRESS=${ARGON_TOKEN_ADDRESS:-3e622317f8C93f7328350cF0B56d9eD4C620C5d6}
+      - ARGONOT_TOKEN_ADDRESS=${ARGONOT_TOKEN_ADDRESS:-3e622317f8C93f7328350cF0B56d9eD4C620C5d6}
       - BLS_API_KEY=${BLS_API_KEY}
       - INFURA_PROJECT_ID=${INFURA_PROJECT_ID}
       - ORACLE_CPI_CACHE_PATH=/tmp/oracle/data/US_CPI_State.json

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -341,7 +341,11 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 			}
 
 			if *notary_client.pause_queue_processing.read().await {
-				info!(?best_hash, ?best_number, "🏁Node state is synched. Activating notary sync.");
+				info!(
+					?best_hash,
+					?best_number,
+					"🏁 Node state is synched. Activating notary sync."
+				);
 				*notary_client.pause_queue_processing.write().await = false;
 			}
 

--- a/node/randomx/src/lib.rs
+++ b/node/randomx/src/lib.rs
@@ -66,7 +66,6 @@ pub mod full_vm {
 				*entry = Some((*key_hash, vm));
 			} else {
 				let new_vm = data.new_vm()?;
-				info!(target:"argon-randomx", "Created new Randomx VM for key: {:?}", hex::encode(key_hash));
 				*entry = Some((*key_hash, new_vm));
 			};
 
@@ -94,7 +93,9 @@ pub mod full_vm {
 		let data: Arc<VMData> = if let Some(data) = shared_caches.get_mut(key_hash) {
 			data.clone()
 		} else if shared_caches.len() < shared_caches.capacity() || !global_config().large_pages {
-			Arc::new(VMData::new(&key_hash[..], &global_config(), true)?)
+			let vm_data = VMData::new(&key_hash[..], &global_config(), true)?;
+			info!(target:"argon-randomx", "Created new Randomx VMData for key: {:?}", hex::encode(key_hash));
+			Arc::new(vm_data)
 		} else {
 			// last case is using large pages
 			// replace the entry with a single entry


### PR DESCRIPTION
An aux migration bug caused part of notebooks to be cleaned up, and the other part to be left in place. This confused the notebook auditing system, which then was unable to add notebooks to the queue. The fix I've put in includes a less faulty approach to tracking historical tick data (eg less tracked by ticks and more in single entities that can be extracted and saved).

Other fixes:
- Client: Enable signet in CosignScript
- Node: Message tweaks
- Docker: use named bitcoin wallet in rpc calls