### PR TITLE
fix(node): improve fast sync speed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -516,6 +516,10 @@ services:
       - price-oracle
       - all
 
+networks:
+  default:
+    name: argon-net
+
 volumes:
   minio-data:
   pgdata:


### PR DESCRIPTION
The duplicate block check was slowing down fast sync, so I changed it to only run if we're not importing `NETWORK_INITIAL_SYNC`, which should only occur for finalized blocks in any case.