### PR TITLE
fix(node): don’t set best block in verifier

### DIFF
--- a/node/consensus/src/aux_client.rs
+++ b/node/consensus/src/aux_client.rs
@@ -77,8 +77,9 @@ pub enum AuxKey {
 impl AuxKey {
 	pub fn default_state<C: AuxStore>(&self, client: Arc<C>) -> AuxState<C> {
 		match self {
-			AuxKey::NotaryStateAtTick(_) | AuxKey::AuthorsAtTick(_) =>
-				panic!("Deprecated key, use `NotaryState` or `Authors` instead"),
+			AuxKey::NotaryStateAtTick(_) | AuxKey::AuthorsAtTick(_) => {
+				panic!("Deprecated key, use `NotaryState` or `Authors` instead")
+			},
 			AuxKey::NotaryNotebooks(_) =>
 				AuxState::NotaryNotebooks(AuxData::new(client, self.clone()).into()),
 			AuxKey::VotesAtTick(_) =>
@@ -223,7 +224,7 @@ impl<B: BlockT, C: AuxStore + 'static> ArgonAux<B, C> {
 		let authors = block_authors.get();
 		if let Some(authors_at_height) = authors.get(&tick) {
 			if let Some(authors_for_key) = authors_at_height.get(&block_key) {
-				return authors_for_key.contains(account_id)
+				return authors_for_key.contains(account_id);
 			}
 		}
 		false

--- a/node/consensus/src/block_creator.rs
+++ b/node/consensus/src/block_creator.rs
@@ -91,11 +91,11 @@ where
 			Ok(Some(x)) => x,
 			Ok(None) => {
 				tracing::warn!("Parent header not found {:?}", parent_hash);
-				return None
+				return None;
 			},
 			Err(err) => {
 				tracing::error!(?err, ?parent_hash, "Error while fetching parent header");
-				return None
+				return None;
 			},
 		};
 

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -625,7 +625,7 @@ where
 			let mut queue_range: Range<NotebookNumber> = 0..0;
 			while let Some(queue) = queues.get_mut(&notary_id) {
 				if queue.is_empty() {
-					return None
+					return None;
 				}
 				queue_range = Range { start: queue[0].0, end: queue[queue.len() - 1].0 };
 
@@ -1526,7 +1526,7 @@ mod test {
 			let block_chain = self.block_chain.lock();
 			if let Some(pos) = block_chain.iter().position(|h| h == hash) {
 				if pos > 0 {
-					return Ok(block_chain[pos - 1])
+					return Ok(block_chain[pos - 1]);
 				}
 			}
 			Ok(H256::from_slice(&[3; 32]))

--- a/notary/src/block_watch.rs
+++ b/notary/src/block_watch.rs
@@ -104,7 +104,7 @@ async fn process_block(
 	info!("Processing block {} ({})", block.hash(), block.number());
 	if BlocksStore::has_block(&mut *db, block.hash()).await? {
 		info!("Duplicated block {} ({})", block.hash(), block.number());
-		return Ok(())
+		return Ok(());
 	}
 
 	let notebooks_header = block.header().digest.logs.iter().find_map(|log| match log {

--- a/notary/src/notebook_closer.rs
+++ b/notary/src/notebook_closer.rs
@@ -58,7 +58,9 @@ impl FinalizedNotebookHeaderListener {
 		let header = match notification.payload().parse() {
 			Ok(notebook_number) =>
 				NotebookHeaderStore::load_with_signature(&self.pool, notebook_number).await?,
-			Err(e) => return Err(anyhow::anyhow!("Error parsing notified notebook number {:?}", e)),
+			Err(e) => {
+				return Err(anyhow::anyhow!("Error parsing notified notebook number {:?}", e));
+			},
 		};
 		let hash = header.header.hash();
 

--- a/notary/src/stores/blocks.rs
+++ b/notary/src/stores/blocks.rs
@@ -168,7 +168,7 @@ impl BlocksStore {
 				const UNIQUE_VIOLATION: &str = "23505"; // PostgreSQL error code for unique_violation
 
 				if pg_err.code() == UNIQUE_VIOLATION {
-					return Ok(())
+					return Ok(());
 				}
 
 				Err(Error::Database(db_err.to_string()))

--- a/notary/src/stores/notebook_audit_failure.rs
+++ b/notary/src/stores/notebook_audit_failure.rs
@@ -32,7 +32,9 @@ impl AuditFailureListener {
 		let notification = &self.listener.recv().await?;
 		let notebook_number = match notification.payload().parse() {
 			Ok(notebook_number) => notebook_number,
-			Err(e) => return Err(anyhow::anyhow!("Error parsing notified notebook number {:?}", e)),
+			Err(e) => {
+				return Err(anyhow::anyhow!("Error parsing notified notebook number {:?}", e));
+			},
 		};
 
 		self.failed_audits_notification.notify(|| Ok(notebook_number)).map_err(

--- a/pallets/bitcoin_locks/src/mock.rs
+++ b/pallets/bitcoin_locks/src/mock.rs
@@ -165,7 +165,7 @@ impl BitcoinVaultProvider for StaticVaultProvider {
 
 	fn is_owner(vault_id: VaultId, account_id: &Self::AccountId) -> bool {
 		if vault_id == 1 {
-			return DefaultVault::get().operator_account_id == *account_id
+			return DefaultVault::get().operator_account_id == *account_id;
 		}
 		false
 	}

--- a/pallets/block_rewards/src/lib.rs
+++ b/pallets/block_rewards/src/lib.rs
@@ -350,7 +350,7 @@ pub mod pallet {
 				return RewardAmounts {
 					ownership: final_starting_amount.saturating_div(halvings + 1).into(),
 					argons: final_starting_amount.into(),
-				}
+				};
 			}
 
 			let start_block_argons = T::StartingArgonsPerBlock::get().into();

--- a/pallets/liquidity_pools/src/tests.rs
+++ b/pallets/liquidity_pools/src/tests.rs
@@ -455,7 +455,9 @@ fn it_can_distribute_bid_pool_capital() {
 				vault_id: 1,
 				vault_operator_account_id: 10,
 				earnings: 400_000_000 + 1, // 50% of the 800 + 1 extra penny
-				earnings_for_vault: (400_000_000.0 * 0.5) as u128 + (100.0/500.0 * 400_000_000.0 * 0.5) as u128 + 1, // 50% of the 400 + 50% * 100 of 500 contributed argons * 400) + 1 extra penny
+				earnings_for_vault: (400_000_000.0 * 0.5) as u128
+					+ (100.0 / 500.0 * 400_000_000.0 * 0.5) as u128
+					+ 1, // 50% of the 400 + 50% * 100 of 500 contributed argons * 400) + 1 extra penny
 				capital_contributed_by_vault: 100_000_000,
 				frame_id: 3,
 				capital_contributed: 500_000_000,

--- a/pallets/notebook/src/lib.rs
+++ b/pallets/notebook/src/lib.rs
@@ -455,12 +455,12 @@ pub mod pallet {
 			if let Some((notebook_number, at_tick, failed_audit_reason)) =
 				<NotariesLockedForFailedAudit<T>>::get(notary_id)
 			{
-				return NotaryState::Locked { notebook_number, at_tick, failed_audit_reason }
+				return NotaryState::Locked { notebook_number, at_tick, failed_audit_reason };
 			}
 			if let Some(reprocess_notebook_number) =
 				LockedNotaryReadyForReprocess::<T>::get(notary_id)
 			{
-				return NotaryState::Reactivated { reprocess_notebook_number }
+				return NotaryState::Reactivated { reprocess_notebook_number };
 			}
 
 			NotaryState::Active

--- a/primitives/src/vault.rs
+++ b/primitives/src/vault.rs
@@ -400,7 +400,7 @@ impl<
 		self.argons_scheduled_for_release.retain(|height, released_amount| {
 			if *height <= block_height {
 				amount.saturating_accrue(*released_amount);
-				return false
+				return false;
 			}
 			true
 		});

--- a/testing/src/argon_node.rs
+++ b/testing/src/argon_node.rs
@@ -84,7 +84,7 @@ impl ArgonNodeStartArgs {
 		let node_log = "info";
 
 		let rust_log = format!(
-			"{},node={},pallet=info,argon=trace,sc_rpc_server=info,argon_notary_apis=info",//,grandpa=trace,runtime::grandpa=trace",
+			"{},node={},pallet=info,argon=trace,sc_rpc_server=info,argon_notary_apis=info", //,grandpa=trace,runtime::grandpa=trace",
 			overall_log, node_log,
 		);
 


### PR DESCRIPTION
The verifier layer of the import_queue was setting the best block, which could then cause issues during import like prematurely importing a best block before state is available.

chore: rustup fmt updates