### PR TITLE
Fix Prebond + Bitcoin Release cost

### DIFF
--- a/client/nodejs/src/BitcoinLocks.ts
+++ b/client/nodejs/src/BitcoinLocks.ts
@@ -460,7 +460,7 @@ export class BitcoinLocks {
       priceIndex,
       releaseRequest: { bitcoinNetworkFee, toScriptPubkey },
       argonKeyring,
-      tip,
+      tip = 0n,
       txProgressCallback,
     } = args;
 
@@ -483,7 +483,7 @@ export class BitcoinLocks {
 
     if (!canAfford.canAfford) {
       throw new Error(
-        `Insufficient funds to release lock. Available: ${formatArgons(canAfford.availableBalance)}, Required: ${formatArgons(redemptionPrice)}`,
+        `Insufficient funds to release lock. Available: ${formatArgons(canAfford.availableBalance)}, Required: ${formatArgons(redemptionPrice + canAfford.txFee + tip)}`,
       );
     }
     const txResult = await submitter.submit({


### PR DESCRIPTION
Fixes:
- The prebond was adding an extra frame to the calculation of the net sum of existing funds already added, which caused it to not add one frame
- The bitcoin locks client nodejs calculation of the release cost was not including the fee on error