### PR TITLE
fix(mining_slot): fix ties in miner nonce scores

### DIFF
--- a/docs/run-a-miner.md
+++ b/docs/run-a-miner.md
@@ -161,7 +161,7 @@ author_rotateKeys"}' http://localhost:9944/
 
 Mining requires you to have two tokens: Argons and Argonots (Ownership Tokens). There are initially
 100 mining slots available in Argon, each lasting 10 days. So every day, you are bidding for 1 of 10
-available slots. This will grow to 10,000 slots as the network grows. Bidding will continue until a
+available slots. This will grow to 1,440 slots as the network grows. Bidding will continue until a
 random block less than or equal to 200 ticks before the next slot begins (slots start every 1440
 ticks).
 
@@ -171,8 +171,8 @@ else on the list by bidding more Argons than they have. You will be refunded if 
 slot.
 
 Mining seats will dynamically adjust for each frame based on the average bid price vs the target.
-The number can range from 10-1000 seats per frame. You can look up the target price for a frame
-using constants `miningSlot.targetPricePerSeat`.
+The number can range from 10-144 seats per frame. You can look up the target price for a frame using
+constants `miningSlot.targetPricePerSeat`.
 
 Your bids will go into a bid "pool" for your slot and into the Slot Treasury Pool. This pool helps
 grant liquidity to Bitcoin holders when minting is delayed. Vaults are able to crowd-source funds to
@@ -213,7 +213,7 @@ slot. You're bidding for a 10- day period starting at the next block that is div
 There are initially 10 mining positions available every "slot", and 100 total miners at genesis.
 Each slot will last 10 days, so at any given time, there are 10 overlapping cohorts of miners. Each
 day, 1/10th will rotate out and 1/10th will rotate in. Over time, the number of miners will increase
-to 10,000.
+to 1,440.
 
 You are bidding for a slot, and can be outbid at any time by someone who bids more Argons than you.
 You can monitor if you currently have a winning slot by looking at the

--- a/pallets/block_seal/src/lib.rs
+++ b/pallets/block_seal/src/lib.rs
@@ -410,14 +410,12 @@ pub mod pallet {
 
 			// in v2, any miner can submit a seal, the runtime will only verify that the seal proof
 			// is correct
-			let previous_block =
-				<frame_system::Pallet<T>>::block_number().saturating_sub(1u32.into());
-
 			let expected_nonce_score = T::AuthorityProvider::get_authority_score(
 				seal_proof,
 				&authority_id,
 				block_author,
-				previous_block,
+				// the current tick hasn't changed yet
+				T::TickProvider::current_tick(),
 			)
 			.ok_or(Error::<T>::NoClosestMinerFoundForVote)?;
 

--- a/pallets/block_seal/src/mock.rs
+++ b/pallets/block_seal/src/mock.rs
@@ -101,7 +101,7 @@ impl AuthorityProvider<BlockSealAuthorityId, Block, AccountId> for StaticAuthori
 		_seal_proof: U256,
 		authority_id: &BlockSealAuthorityId,
 		account: &AccountId,
-		_block_number: BlockNumberFor<Test>,
+		_at_tick: Tick,
 	) -> Option<U256> {
 		if let Some((authority, distance)) = BestMinerNonce::get() {
 			if authority.authority_id == *authority_id || authority.account_id == *account {

--- a/pallets/block_seal_spec/src/mock.rs
+++ b/pallets/block_seal_spec/src/mock.rs
@@ -73,7 +73,7 @@ impl AuthorityProvider<BlockSealAuthorityId, Block, u64> for StaticAuthorityProv
 		_seal_proof: U256,
 		_authority_id: &BlockSealAuthorityId,
 		_account: &u64,
-		_for_block_number: BlockNumberFor<Test>,
+		_at_tick: Tick,
 	) -> Option<U256> {
 		todo!()
 	}

--- a/pallets/mining_slot/src/lib.rs
+++ b/pallets/mining_slot/src/lib.rs
@@ -60,7 +60,7 @@ pub mod pallet {
 		SlotEvents, TickProvider, block_seal::MiningRegistration, vault::MiningBidPoolProvider,
 	};
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(8);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(9);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -161,7 +161,7 @@ pub mod pallet {
 		type BidIncrements: Get<Self::Balance>;
 
 		// Find the author of a block
-		type SealerInfo: BlockSealerProvider<Self::AccountId>;
+		type SealerInfo: BlockSealerProvider<Self::AccountId, Self::MiningAuthorityId>;
 	}
 
 	/// A reason for the pallet placing a hold on funds.
@@ -603,10 +603,18 @@ impl<T: Config> AuthorityProvider<T::MiningAuthorityId, T::Block, T::AccountId> 
 		let mut best = None;
 		let mut scores = vec![];
 
-		let block_number = frame_system::Pallet::<T>::block_number();
+		let tick = T::TickProvider::current_tick();
+		let frame_start_tick = Self::tick_for_frame(Self::current_frame_id());
+		let ticks_since_frame_start = tick.saturating_sub(frame_start_tick);
+		let active_miners = ActiveMinersCount::<T>::get();
+		if active_miners == 0 {
+			return None;
+		}
+		let expected_per_miner = ticks_since_frame_start.saturating_div(active_miners as u64);
 		for (frame_id, cohort) in nonces {
 			for (i, miner_scoring) in cohort.into_iter().enumerate() {
-				let score = ClosestMiner::new(seal_proof, miner_scoring).get_score(block_number);
+				let score = ClosestMiner::new(seal_proof, miner_scoring)
+					.get_score(expected_per_miner as u16);
 				scores.push(score);
 				if score < best_score {
 					let authority = Self::get_mining_authority_by_index((frame_id, i as u32))?;
@@ -634,7 +642,7 @@ impl<T: Config> AuthorityProvider<T::MiningAuthorityId, T::Block, T::AccountId> 
 		seal_proof: U256,
 		authority_id: &T::MiningAuthorityId,
 		account_id: &T::AccountId,
-		for_block_number: BlockNumberFor<T>,
+		at_tick: Tick,
 	) -> Option<U256> {
 		let miner_index = AccountIndexLookup::<T>::get(account_id)?;
 		let authority = Self::get_mining_authority_by_index(miner_index)?;
@@ -644,8 +652,12 @@ impl<T: Config> AuthorityProvider<T::MiningAuthorityId, T::Block, T::AccountId> 
 		let nonces = MinerNonceScoringByCohort::<T>::get();
 		let scoring_for_frame = nonces.get(&miner_index.0)?;
 		let miner_scoring = scoring_for_frame.get(miner_index.1 as usize)?;
-		let score =
-			ClosestMiner::new(seal_proof, miner_scoring.clone()).get_score(for_block_number);
+		let frame_start_tick = Self::tick_for_frame(Self::current_frame_id());
+		let ticks_since_frame_start = at_tick.saturating_sub(frame_start_tick);
+		let expected_per_miner =
+			ticks_since_frame_start.saturating_div(ActiveMinersCount::<T>::get() as u64);
+		let score = ClosestMiner::new(seal_proof, miner_scoring.clone())
+			.get_score(expected_per_miner.unique_saturated_into());
 		Some(score)
 	}
 }
@@ -693,13 +705,13 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub(crate) fn record_block_author(author: T::AccountId) {
-		let Some(miner_index) = <AccountIndexLookup<T>>::get(author) else {
+		let Some(miner_index) = <AccountIndexLookup<T>>::get(&author) else {
 			return;
 		};
 		MinerNonceScoringByCohort::<T>::mutate(|a| {
 			if let Some(cohort_nonces) = a.get_mut(&miner_index.0) {
 				if let Some(miner_scoring) = cohort_nonces.get_mut(miner_index.1 as usize) {
-					miner_scoring.blocks_won = miner_scoring.blocks_won.saturating_add(1);
+					miner_scoring.blocks_won_in_frame.saturating_accrue(1);
 					miner_scoring.last_win_block = Some(frame_system::Pallet::<T>::block_number());
 				}
 			}
@@ -718,6 +730,7 @@ impl<T: Config> Pallet<T> {
 
 		IsNextSlotBiddingOpen::<T>::put(true);
 
+		Self::reset_miner_nonce_scoring();
 		let mut active_miners = ActiveMinersCount::<T>::get();
 		let mut added_miners = vec![];
 		let mut removed_miners = vec![];
@@ -755,7 +768,12 @@ impl<T: Config> Pallet<T> {
 			let nonce =
 				MinerNonce::<T> { account_id: entry.account_id.clone(), block_hash: parent_hash }
 					.generate();
-			let scoring = MinerNonceScoring { nonce, blocks_won: 0, last_win_block: None };
+			let scoring = MinerNonceScoring {
+				nonce,
+				blocks_won_in_frame: 0,
+				last_win_block: None,
+				frame_start_blocks_won_surplus: 0,
+			};
 
 			miner_scoring.push(scoring);
 		}
@@ -796,6 +814,30 @@ impl<T: Config> Pallet<T> {
 
 		T::SlotEvents::rotate_grandpas(frame_id, removed_miners, added_miners);
 		T::SlotEvents::on_frame_start(frame_id);
+	}
+
+	pub(crate) fn reset_miner_nonce_scoring() {
+		let starting_miners = ActiveMinersCount::<T>::get();
+		if starting_miners == 0 {
+			return;
+		}
+		MinerNonceScoringByCohort::<T>::mutate(|a| {
+			let mut total_block_mined = 0;
+			for (_frame_id, miners) in a.iter() {
+				for miner in miners.iter() {
+					total_block_mined += miner.blocks_won_in_frame;
+				}
+			}
+			let expected_blocks =
+				FixedU128::from_rational(total_block_mined as u128, starting_miners as u128);
+			for (_frame_id, miners) in a.iter_mut() {
+				for miner in miners.iter_mut() {
+					miner.frame_start_blocks_won_surplus += miner.blocks_won_in_frame as i16 -
+						expected_blocks.round().saturating_mul_int(1i16);
+					miner.blocks_won_in_frame = 0;
+				}
+			}
+		});
 	}
 
 	/// Adjust the argonots per seat amount based on a rolling 10-frame average of bids.
@@ -1155,7 +1197,10 @@ impl<T: Config> Pallet<T> {
 pub struct MinerNonceScoring<T: Config> {
 	pub nonce: U256,
 	pub last_win_block: Option<BlockNumberFor<T>>,
-	pub blocks_won: u32,
+	/// Number of blocks won in the current frame
+	pub blocks_won_in_frame: u16,
+	/// Number of blocks off target set at start of each frame
+	pub frame_start_blocks_won_surplus: i16,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebugNoBound)]
@@ -1184,7 +1229,7 @@ impl<T: Config> ClosestMiner<T> {
 		Self { seal_proof, miner_nonce: scoring.nonce, scoring }
 	}
 
-	fn get_score(&self, block_number: BlockNumberFor<T>) -> U256 {
+	fn get_score(&self, expected_wins_at_tick: u16) -> U256 {
 		// 1. Create a full U256 from the concatenation of the seal_proof and the miner_nonce
 		let hash_bytes = self.using_encoded(blake2_256);
 
@@ -1192,33 +1237,22 @@ impl<T: Config> ClosestMiner<T> {
 		for (i, b) in hash_bytes.iter().enumerate() {
 			r2[i & 1] ^= *b;
 		}
-		let rand = u16::from_le_bytes(r2);
+		let random_base_score = u16::from_le_bytes(r2);
 
-		// Signals (small, bounded, integer)
-		let since_last_blocks: u16 = self
-			.scoring
-			.last_win_block
-			.map(|b| {
-				UniqueSaturatedInto::<u16>::unique_saturated_into(block_number.saturating_sub(b))
-			})
-			.unwrap_or(u16::MAX);
+		let wins_against_expected = (self.scoring.blocks_won_in_frame as i16) -
+			expected_wins_at_tick as i16 +
+			self.scoring.frame_start_blocks_won_surplus;
 
-		let active = ActiveMinersCount::<T>::get() as u32;
-		let freshness_penalty = active.saturating_sub(since_last_blocks.min(active as u16) as u32);
-		let wins = self.scoring.blocks_won;
+		// Apply a bounded, *additive* correction based on deviation. Do not scale by
+		// `random_base_score` or we risk R + R*multiplier == 0 (or negative wrap),
+		// which collapses the distribution. We keep the jitter (`random_base_score`)
+		// independent and nudge it by a fixed gain per win delta.
+		let multiplier = (wins_against_expected.abs() << 8) as i64;
+		let score_adjustment = (wins_against_expected as i64) * multiplier;
 
-		let penalty = wins.saturating_add(freshness_penalty);
-
-		// Combine penalty (high bits) and random jitter (low bits).
-		// Lower scores win; randomness provides small tie-breaking variation.
-		let key32 = (penalty << 7) | (rand as u32);
-
-		// Re-embed into U256 (high bits) purely for compatibility
-		let mut res = U256::from(key32) << (256 - 32);
-		if res == U256::MAX {
-			res = res.saturating_sub(U256::one());
-		}
-		res
+		let final_score = (random_base_score as i64) + score_adjustment;
+		let final_clamped = final_score.clamp(0, u32::MAX as i64);
+		U256::from(final_clamped)
 	}
 }
 

--- a/pallets/mining_slot/src/lib.rs
+++ b/pallets/mining_slot/src/lib.rs
@@ -1210,8 +1210,8 @@ impl<T: Config> ClosestMiner<T> {
 
 		// multiply penalty by 2^7 to leave space for rand in low 7 bits
 		// this allows us to have a random tie-breaker for same-priority miners
-		// (since priority is unbounded, we just take the low 26 bits)
-		let key32 = (penalty << 7) | (rand as u32);
+		// key32 layout: [penalty: upper 25 bits][rand: lower 7 bits]
+		let key32 = (penalty << 7) | (rand as u32 & 0x7F);
 
 		// Re-embed into U256 (high bits) purely for compatibility
 		let mut res = U256::from(key32) << (256 - 32);

--- a/pallets/mining_slot/src/lib.rs
+++ b/pallets/mining_slot/src/lib.rs
@@ -1247,7 +1247,7 @@ impl<T: Config> ClosestMiner<T> {
 		// `random_base_score` or we risk R + R*multiplier == 0 (or negative wrap),
 		// which collapses the distribution. We keep the jitter (`random_base_score`)
 		// independent and nudge it by a fixed gain per win delta.
-		let multiplier = (wins_against_expected.abs() << 8) as i64;
+		let multiplier = (wins_against_expected.abs() as i64) << 8;
 		let score_adjustment = (wins_against_expected as i64) * multiplier;
 
 		let final_score = (random_base_score as i64) + score_adjustment;

--- a/pallets/mining_slot/src/migrations/mod.rs
+++ b/pallets/mining_slot/src/migrations/mod.rs
@@ -1,103 +1,61 @@
-use crate::{
-	AccountIndexLookup, ActiveMinersCount, Config, MinerNonceScoring, MinerNonceScoringByCohort,
-	MinersByCohort, Pallet,
-};
-
+use crate::{Config, MinerNonceScoring, MinerNonceScoringByCohort, Pallet};
 use frame_support::{storage_alias, traits::UncheckedOnRuntimeUpgrade};
 use pallet_prelude::*;
+pub mod v8;
 
 pub struct InnerMigrate<T: crate::Config>(core::marker::PhantomData<T>);
 
-#[storage_alias]
-pub type MinerXorKeysByCohort<T: Config> = StorageValue<
-	Pallet<T>,
-	BoundedBTreeMap<
-		FrameId,
-		BoundedVec<U256, <T as Config>::MaxCohortSize>,
-		<T as Config>::FramesPerMiningTerm,
-	>,
-	ValueQuery,
->;
+mod old_storage {
+	use super::*;
+
+	#[storage_alias]
+	pub type MinerNonceScoringByCohort<T: Config> = StorageValue<
+		Pallet<T>,
+		BoundedBTreeMap<
+			FrameId,
+			BoundedVec<MinerNonceScoring<T>, <T as Config>::MaxCohortSize>,
+			<T as Config>::FramesPerMiningTerm,
+		>,
+		ValueQuery,
+	>;
+
+	#[derive(
+		Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebugNoBound, MaxEncodedLen,
+	)]
+	#[scale_info(skip_type_params(T))]
+	pub struct MinerNonceScoring<T: Config> {
+		pub nonce: U256,
+		pub last_win_block: Option<BlockNumberFor<T>>,
+		pub blocks_won: u32,
+	}
+}
 
 impl<T: Config + pallet_treasury::Config> UncheckedOnRuntimeUpgrade for InnerMigrate<T> {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
-		let xor_keys = MinerXorKeysByCohort::<T>::get();
-		Ok(xor_keys.encode())
+		let nonces = old_storage::MinerNonceScoringByCohort::<T>::get();
+		Ok(nonces.encode())
 	}
 
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		log::info!("Migrating mining slots");
-		let mut modify_count = 0;
-		let xor_keys = MinerXorKeysByCohort::<T>::take();
-		let mut oldest_frame: Option<FrameId> = None;
+		let modify_count = 1;
+		let old_value = old_storage::MinerNonceScoringByCohort::<T>::take();
 		MinerNonceScoringByCohort::<T>::mutate(|a| {
-			for (frame_id, xor_key) in &xor_keys {
-				if oldest_frame.is_none() {
-					oldest_frame = Some(*frame_id);
-				} else {
-					oldest_frame = Some((*frame_id).min(oldest_frame.unwrap()));
-				}
+			for (frame_id, old_scoring_vec) in &old_value {
 				let mut scoring_vec =
 					BoundedVec::<MinerNonceScoring<T>, T::MaxCohortSize>::default();
-				for nonce in xor_key.into_iter() {
+				for old_scoring in old_scoring_vec.into_iter() {
 					let _ = scoring_vec.try_push(MinerNonceScoring {
-						nonce: *nonce,
-						last_win_block: None,
-						blocks_won: 0,
+						nonce: old_scoring.nonce,
+						last_win_block: old_scoring.last_win_block,
+						blocks_won_in_frame: 0,
+						frame_start_blocks_won_surplus: 0,
 					});
 				}
 				let _ = a.try_insert(*frame_id, scoring_vec);
 			}
 		});
-		let oldest_frame = oldest_frame.expect("At least one cohort should exist");
-		log::info!("Oldest frame to keep: {:?}. {:#?}", oldest_frame, xor_keys);
-		modify_count += 1;
-		let cohort_frames = MinersByCohort::<T>::iter_keys().collect::<Vec<_>>();
-		let mut active_miners = 0;
-		for frame_id in cohort_frames {
-			if frame_id < oldest_frame {
-				log::info!("Cleaning up cohort frame {:?}", frame_id);
-				modify_count += 1;
-				let rotating_out = MinersByCohort::<T>::take(frame_id);
-				for miner in rotating_out {
-					let account_id = miner.account_id.clone();
-					AccountIndexLookup::<T>::remove(&account_id);
-					modify_count += 1;
-					// assume this window is already past
-					crate::Pallet::<T>::release_mining_seat_argonots(&miner, false);
-				}
-			} else {
-				let cohort_miners = MinersByCohort::<T>::get(frame_id).len();
-				log::info!("Keeping cohort frame {:?}, {} miners", frame_id, cohort_miners);
-				active_miners += cohort_miners;
-			}
-		}
-		let pool_frames = pallet_treasury::VaultPoolsByFrame::<T>::iter_keys().collect::<Vec<_>>();
-		for frame_id in pool_frames {
-			if frame_id < oldest_frame {
-				let vault_pool = pallet_treasury::VaultPoolsByFrame::<T>::take(frame_id);
-				modify_count += 1;
-				for (vault_id, pool) in vault_pool {
-					log::info!(
-						"Refunding treasury pool for vault {:?}, frame {:?}",
-						vault_id,
-						frame_id
-					);
-					for (account_id, holder) in pool.bond_holders {
-						pallet_treasury::Pallet::<T>::refund_fund_capital(
-							frame_id,
-							vault_id,
-							&account_id,
-							holder.pool_managed_balance(),
-						);
-						modify_count += 1;
-					}
-				}
-			}
-		}
-		ActiveMinersCount::<T>::put(active_miners as u16);
-		modify_count += 1;
 
 		T::DbWeight::get().reads_writes((modify_count) as u64, modify_count as u64)
 	}
@@ -106,48 +64,40 @@ impl<T: Config + pallet_treasury::Config> UncheckedOnRuntimeUpgrade for InnerMig
 	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
 		let original_keys = BoundedBTreeMap::<
 			FrameId,
-			BoundedVec<U256, T::MaxCohortSize>,
+			BoundedVec<old_storage::MinerNonceScoring<T>, T::MaxCohortSize>,
 			T::FramesPerMiningTerm,
 		>::decode(&mut &state[..])
 		.expect("Failed to decode pre-upgrade state");
 
 		let miner_nonce_scoring = MinerNonceScoringByCohort::<T>::get();
-		let mut count = 0u16;
 		for key in miner_nonce_scoring.keys() {
-			assert!(
-				MinersByCohort::<T>::contains_key(key),
-				"Cohort frame {:?} should exist after migration",
-				key
-			);
 			let orig = original_keys.get(key).unwrap().to_vec();
-			let new = miner_nonce_scoring
-				.get(key)
-				.unwrap()
-				.iter()
-				.map(|s| s.nonce)
-				.collect::<Vec<_>>();
-			assert_eq!(orig, new, "Cohort frame {:?} should exist in pre-upgrade state", key);
-			count += MinersByCohort::<T>::get(key).len() as u16;
-		}
-		assert_eq!(count, ActiveMinersCount::<T>::get());
-		log::info!("Post-migration active miners count: {}", count);
-
-		let pool_frames = pallet_treasury::VaultPoolsByFrame::<T>::iter_keys().collect::<Vec<_>>();
-		for frame_id in pool_frames {
-			assert!(
-				frame_id >= *original_keys.keys().min().unwrap(),
-				"Vault pool for frame {:?} should have been removed",
-				frame_id
-			);
+			let new = miner_nonce_scoring.get(key).unwrap();
+			for (i, n) in new.iter().enumerate() {
+				assert_eq!(
+					n.blocks_won_in_frame, 0,
+					"blocks_won_in_frame should be initialized to 0"
+				);
+				assert_eq!(
+					n.frame_start_blocks_won_surplus, 0,
+					"frame_start_blocks_won_surplus should be initialized to 0"
+				);
+				let matching_orig = &orig[i];
+				assert_eq!(n.nonce, matching_orig.nonce, "nonce should match pre-migration value");
+				assert_eq!(
+					n.last_win_block, matching_orig.last_win_block,
+					"last_win_block should match pre-migration value"
+				);
+			}
 		}
 
 		Ok(())
 	}
 }
 
-pub type MissedCohortsMigration<T> = frame_support::migrations::VersionedMigration<
-	7,
+pub type CohortFrameExpectedScoringMigration<T> = frame_support::migrations::VersionedMigration<
 	8,
+	9,
 	InnerMigrate<T>,
 	crate::Pallet<T>,
 	<T as frame_system::Config>::DbWeight,

--- a/pallets/mining_slot/src/migrations/v8.rs
+++ b/pallets/mining_slot/src/migrations/v8.rs
@@ -1,0 +1,176 @@
+use crate::{AccountIndexLookup, ActiveMinersCount, Config, MinersByCohort, Pallet};
+
+use frame_support::{storage_alias, traits::UncheckedOnRuntimeUpgrade};
+use pallet_prelude::*;
+
+pub struct InnerMigrate<T: crate::Config>(core::marker::PhantomData<T>);
+
+mod v8_storage {
+	use super::*;
+	use codec::{Decode, Encode};
+	use sp_core::U256;
+	use sp_runtime::RuntimeDebug;
+
+	#[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, RuntimeDebug, MaxEncodedLen)]
+	#[scale_info(skip_type_params(T))]
+	pub struct MinerNonceScoring<T: Config> {
+		pub nonce: U256,
+		pub last_win_block: Option<BlockNumberFor<T>>,
+		pub blocks_won: u32,
+	}
+
+	#[storage_alias]
+	pub type MinerNonceScoringByCohort<T: Config> = StorageValue<
+		Pallet<T>,
+		BoundedBTreeMap<
+			FrameId,
+			BoundedVec<MinerNonceScoring<T>, <T as Config>::MaxCohortSize>,
+			<T as Config>::FramesPerMiningTerm,
+		>,
+		ValueQuery,
+	>;
+}
+#[storage_alias]
+pub type MinerXorKeysByCohort<T: Config> = StorageValue<
+	Pallet<T>,
+	BoundedBTreeMap<
+		FrameId,
+		BoundedVec<U256, <T as Config>::MaxCohortSize>,
+		<T as Config>::FramesPerMiningTerm,
+	>,
+	ValueQuery,
+>;
+
+impl<T: Config + pallet_treasury::Config> UncheckedOnRuntimeUpgrade for InnerMigrate<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+		let xor_keys = MinerXorKeysByCohort::<T>::get();
+		Ok(xor_keys.encode())
+	}
+
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		log::info!("Migrating mining slots");
+		let mut modify_count = 0;
+		let xor_keys = MinerXorKeysByCohort::<T>::take();
+		let mut oldest_frame: Option<FrameId> = None;
+		v8_storage::MinerNonceScoringByCohort::<T>::mutate(|a| {
+			for (frame_id, xor_key) in &xor_keys {
+				if oldest_frame.is_none() {
+					oldest_frame = Some(*frame_id);
+				} else {
+					oldest_frame = Some((*frame_id).min(oldest_frame.unwrap()));
+				}
+				let mut scoring_vec =
+					BoundedVec::<v8_storage::MinerNonceScoring<T>, T::MaxCohortSize>::default();
+				for nonce in xor_key.into_iter() {
+					let _ = scoring_vec.try_push(v8_storage::MinerNonceScoring {
+						nonce: *nonce,
+						last_win_block: None,
+						blocks_won: 0,
+					});
+				}
+				let _ = a.try_insert(*frame_id, scoring_vec);
+			}
+		});
+		let oldest_frame = oldest_frame.expect("At least one cohort should exist");
+		log::info!("Oldest frame to keep: {:?}. {:#?}", oldest_frame, xor_keys);
+		modify_count += 1;
+		let cohort_frames = MinersByCohort::<T>::iter_keys().collect::<Vec<_>>();
+		let mut active_miners = 0;
+		for frame_id in cohort_frames {
+			if frame_id < oldest_frame {
+				log::info!("Cleaning up cohort frame {:?}", frame_id);
+				modify_count += 1;
+				let rotating_out = MinersByCohort::<T>::take(frame_id);
+				for miner in rotating_out {
+					let account_id = miner.account_id.clone();
+					AccountIndexLookup::<T>::remove(&account_id);
+					modify_count += 1;
+					// assume this window is already past
+					crate::Pallet::<T>::release_mining_seat_argonots(&miner, false);
+				}
+			} else {
+				let cohort_miners = MinersByCohort::<T>::get(frame_id).len();
+				log::info!("Keeping cohort frame {:?}, {} miners", frame_id, cohort_miners);
+				active_miners += cohort_miners;
+			}
+		}
+		let pool_frames = pallet_treasury::VaultPoolsByFrame::<T>::iter_keys().collect::<Vec<_>>();
+		for frame_id in pool_frames {
+			if frame_id < oldest_frame {
+				let vault_pool = pallet_treasury::VaultPoolsByFrame::<T>::take(frame_id);
+				modify_count += 1;
+				for (vault_id, pool) in vault_pool {
+					log::info!(
+						"Refunding treasury pool for vault {:?}, frame {:?}",
+						vault_id,
+						frame_id
+					);
+					for (account_id, holder) in pool.bond_holders {
+						pallet_treasury::Pallet::<T>::refund_fund_capital(
+							frame_id,
+							vault_id,
+							&account_id,
+							holder.pool_managed_balance(),
+						);
+						modify_count += 1;
+					}
+				}
+			}
+		}
+		ActiveMinersCount::<T>::put(active_miners as u16);
+		modify_count += 1;
+
+		T::DbWeight::get().reads_writes((modify_count) as u64, modify_count as u64)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		let original_keys = BoundedBTreeMap::<
+			FrameId,
+			BoundedVec<U256, T::MaxCohortSize>,
+			T::FramesPerMiningTerm,
+		>::decode(&mut &state[..])
+		.expect("Failed to decode pre-upgrade state");
+
+		let miner_nonce_scoring = v8_storage::MinerNonceScoringByCohort::<T>::get();
+		let mut count = 0u16;
+		for key in miner_nonce_scoring.keys() {
+			assert!(
+				MinersByCohort::<T>::contains_key(key),
+				"Cohort frame {:?} should exist after migration",
+				key
+			);
+			let orig = original_keys.get(key).unwrap().to_vec();
+			let new = miner_nonce_scoring
+				.get(key)
+				.unwrap()
+				.iter()
+				.map(|s| s.nonce)
+				.collect::<Vec<_>>();
+			assert_eq!(orig, new, "Cohort frame {:?} should exist in pre-upgrade state", key);
+			count += MinersByCohort::<T>::get(key).len() as u16;
+		}
+		assert_eq!(count, ActiveMinersCount::<T>::get());
+		log::info!("Post-migration active miners count: {}", count);
+
+		let pool_frames = pallet_treasury::VaultPoolsByFrame::<T>::iter_keys().collect::<Vec<_>>();
+		for frame_id in pool_frames {
+			assert!(
+				frame_id >= *original_keys.keys().min().unwrap(),
+				"Vault pool for frame {:?} should have been removed",
+				frame_id
+			);
+		}
+
+		Ok(())
+	}
+}
+
+pub type MissedCohortsMigration<T> = frame_support::migrations::VersionedMigration<
+	7,
+	8,
+	InnerMigrate<T>,
+	crate::Pallet<T>,
+	<T as frame_system::Config>::DbWeight,
+>;

--- a/pallets/mining_slot/src/mock.rs
+++ b/pallets/mining_slot/src/mock.rs
@@ -116,7 +116,7 @@ parameter_types! {
 	pub const BidPoolAccountId: u64 = 10000;
 
 	pub static LastBidPoolDistribution: (FrameId, Tick) = (0, 0);
-	pub static BlockSealer: BlockSealerInfo<u64> = BlockSealerInfo {
+	pub static BlockSealer: BlockSealerInfo<u64, UintAuthorityId> = BlockSealerInfo {
 		block_seal_authority: None,
 		block_vote_rewards_account: Some(1),
 		block_author_account_id: 1,
@@ -201,8 +201,8 @@ impl TickProvider<Block> for StaticTickProvider {
 }
 
 pub struct StaticBlockSealerProvider;
-impl BlockSealerProvider<u64> for StaticBlockSealerProvider {
-	fn get_sealer_info() -> BlockSealerInfo<u64> {
+impl BlockSealerProvider<u64, UintAuthorityId> for StaticBlockSealerProvider {
+	fn get_sealer_info() -> BlockSealerInfo<u64, UintAuthorityId> {
 		BlockSealer::get()
 	}
 	fn is_block_vote_seal() -> bool {

--- a/primitives/src/providers.rs
+++ b/primitives/src/providers.rs
@@ -20,7 +20,7 @@ use sp_arithmetic::{FixedI128, FixedPointNumber, traits::Zero};
 use sp_core::{H256, RuntimeDebug, U256};
 use sp_runtime::{
 	DispatchError, DispatchResult, FixedU128, Saturating,
-	traits::{AtLeast32BitUnsigned, Block as BlockT, CheckedDiv, NumberFor, OpaqueKeys},
+	traits::{AtLeast32BitUnsigned, Block as BlockT, CheckedDiv, OpaqueKeys},
 };
 
 pub trait NotebookProvider {
@@ -181,15 +181,15 @@ pub trait BlockSealSpecProvider<Block: BlockT> {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen, RuntimeDebug)]
-pub struct BlockSealerInfo<AccountId: FullCodec> {
+pub struct BlockSealerInfo<AccountId: FullCodec, AuthorityId: FullCodec = BlockSealAuthorityId> {
 	pub block_author_account_id: AccountId,
 	/// The voting account, if a block seal
 	pub block_vote_rewards_account: Option<AccountId>,
-	pub block_seal_authority: Option<BlockSealAuthorityId>,
+	pub block_seal_authority: Option<AuthorityId>,
 }
 
-pub trait BlockSealerProvider<AccountId: FullCodec> {
-	fn get_sealer_info() -> BlockSealerInfo<AccountId>;
+pub trait BlockSealerProvider<AccountId: FullCodec, AuthorityId: FullCodec = BlockSealAuthorityId> {
+	fn get_sealer_info() -> BlockSealerInfo<AccountId, AuthorityId>;
 	fn is_block_vote_seal() -> bool;
 }
 
@@ -223,7 +223,7 @@ where
 		seal_proof: U256,
 		authority_id: &AuthorityId,
 		account: &AccountId,
-		for_block_number: NumberFor<Block>,
+		at_tick: Tick,
 	) -> Option<U256>;
 }
 

--- a/runtime/common/src/config.rs
+++ b/runtime/common/src/config.rs
@@ -95,7 +95,7 @@ parameter_types! {
 	// ### pallet_mining_slot
 	pub const FramesPerMiningTerm: u32 = 10;
 	pub const MinCohortSize: u32 = 10;
-	pub const MaxCohortSize: u32 = 1000;
+	pub const MaxCohortSize: u32 = 144;
 	pub const MaxGrandpas: u32 = 1000;
 	pub const PricePerSeatAdjustmentDamper: FixedU128 = FixedU128::from_rational(20, 100);
 	pub const TargetPricePerSeat: Balance = 1000 * ARGON;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -87,7 +87,7 @@ macro_rules! inject_runtime_vars {
 			// `spec_name`,   `spec_version`, and `authoring_version` are the same between Wasm and
 			// native. This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 			//   the compatible custom types.
-			spec_version: 135,
+			spec_version: 136,
 			impl_version: 9,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 4,
@@ -129,7 +129,10 @@ macro_rules! inject_runtime_vars {
 		/// All migrations of the runtime, aside from the ones declared in the pallets.
 		///
 		/// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
-		type Migrations = (pallet_mining_slot::migrations::MissedCohortsMigration<Runtime>,);
+		type Migrations = (
+			pallet_mining_slot::migrations::v8::MissedCohortsMigration<Runtime>,
+			pallet_mining_slot::migrations::CohortFrameExpectedScoringMigration<Runtime>,
+		);
 
 		/// Unchecked extrinsic type as expected by this runtime.
 		pub type UncheckedExtrinsic =


### PR DESCRIPTION
This pull request updates the mining slot selection logic to improve fairness and allow for tie-breaking among miners with equal priority. The main changes include a significant refactor of the miner scoring algorithm, adjustments to test tolerances for distribution, and the addition of a new test to verify tie-breaking behavior.

### Mining slot selection logic improvements

* Refactored the `get_score` method in `ClosestMiner<T>` to use a new scoring algorithm based on how many blocks a miner has closest vs expected within a frame. At the end of each frame, every miner has an equal chance at blocks now (the previous algorithm overly favored new miners), with the only advantage going to any miners carrying through a deficit from previous frames.

### Testing improvements

* Added a new test `it_should_allow_a_tie` to verify that the mining slot selection logic can correctly handle tie situations between miners with equal scores.
* Fixed the iteration range in the same test to include the final block by changing the loop to `1..=10_000u64`.
This pull request introduces significant changes to the mining slot and block seal logic, primarily to improve miner scoring accuracy, adjust slot and seat parameters for scalability, and update the migration process for miner scoring data. The most important changes are grouped below by theme.

### Mining Slot and Cohort Parameters

* Increased the maximum number of mining slots and seats to 1,440 (from 10,000 and 1,000, respectively) in documentation and runtime config to better match network scaling requirements. (`docs/run-a-miner.md`, `.claude/mining-liquidity.md`) [[1]](diffhunk://#diff-e177be5b9c27fecbb3cf772a5ce14e392b81f8276120907038397da44b02839bL164-R164) [[2]](diffhunk://#diff-e177be5b9c27fecbb3cf772a5ce14e392b81f8276120907038397da44b02839bL216-R216) [[3]](diffhunk://#diff-e177be5b9c27fecbb3cf772a5ce14e392b81f8276120907038397da44b02839bL174-R175) [[4]](diffhunk://#diff-288944f6849f22ad52432a6b016f2295013661762fccf2a2084f56efd6d27fbcL271-R271)
* Updated the minimum argonots per seat to 1,440 in runtime config for improved accessibility. (`.claude/mining-liquidity.md`)

### Miner Scoring and Block Seal Logic

* Refactored miner scoring to use ticks instead of block numbers for more precise tracking and fairness. This affects the logic in both `block_seal` and `mining_slot` pallets. (`pallets/block_seal/src/lib.rs`, `pallets/mining_slot/src/lib.rs`) [[1]](diffhunk://#diff-a71e6cb744353a935cb3130ab4c7dfafb3da43ebf53153142fff9f7052be71a5L413-R418) [[2]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2L606-R617) [[3]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2L637-R645) [[4]](diffhunk://#diff-aee83607183262374474829a8892f076b397eb0302571f3da15b9b888f368e2aL104-R104) [[5]](diffhunk://#diff-a4b215bfb3b1521959fb803c7e6e9da4522a58213dd738de6540e1cd47c8b141L76-R76)
* Enhanced `MinerNonceScoring` to track `blocks_won_in_frame` and `frame_start_blocks_won_surplus`, enabling more accurate miner performance assessment and penalty application. (`pallets/mining_slot/src/lib.rs`) [[1]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2L1158-R1203) [[2]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2L696-R714) [[3]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2L758-R776)
* Improved scoring algorithm to apply bounded additive corrections based on deviation from expected wins, ensuring fairer distribution and reducing the risk of score collapse. (`pallets/mining_slot/src/lib.rs`)

### Migration and Storage Updates

* Added migration logic to upgrade miner scoring storage, including a new migration module and post-upgrade checks to ensure correct initialization of new scoring fields. (`pallets/mining_slot/src/migrations/mod.rs`) [[1]](diffhunk://#diff-a4ca03d683a7a9df5a46861457ce90d28f725de63d9f7ab4cbef749529c01fb2L1-L100) [[2]](diffhunk://#diff-a4ca03d683a7a9df5a46861457ce90d28f725de63d9f7ab4cbef749529c01fb2L109-R100)
* Updated storage version to 9 to reflect the new data structure for miner scoring. (`pallets/mining_slot/src/lib.rs`)

### API and Type Changes

* Modified trait bounds and method signatures to accommodate new authority and scoring logic, including the use of ticks and expanded trait parameters. (`pallets/mining_slot/src/lib.rs`) [[1]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2L164-R164) [[2]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2L659-R671)

### Frame and Miner Management

* Added logic to reset miner scoring at the start of each frame, recalculating surplus and resetting block win counters for accurate tracking across frames. (`pallets/mining_slot/src/lib.rs`) [[1]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2R733) [[2]](diffhunk://#diff-5659667661e5f9aefc1641a5833a23f92d817deadc5c8d8bcd92778d8a1521d2R819-R842)

These changes collectively improve mining slot management, scoring fairness, and pave the way for future scalability and maintainability.