### PR TITLE
fix: impose a penalty for recent block closers

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -87,7 +87,7 @@ macro_rules! inject_runtime_vars {
 			// `spec_name`,   `spec_version`, and `authoring_version` are the same between Wasm and
 			// native. This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 			//   the compatible custom types.
-			spec_version: 137,
+			spec_version: 138,
 			impl_version: 9,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 4,


### PR DESCRIPTION
The most recent 10% of block closers should have a penalty imposed so that you can’t hold out and win the last consecutive blocks. Also allows for a max deficit of 5