### PR TITLE
fix(node): reconnect to disconnected notaries

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -93,7 +93,7 @@ macro_rules! inject_runtime_vars {
 			// `spec_name`,   `spec_version`, and `authoring_version` are the same between Wasm and
 			// native. This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 			//   the compatible custom types.
-			spec_version: 143,
+			spec_version: 144,
 			impl_version: 9,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 4,


### PR DESCRIPTION
If a notary disconnects, the node should reconnect before waiting for a best block

fix(node): ensure compute solves the same pre-hash puzzle The node compute worker was not locking the pre-hash puzzle for the entire “submit hash” block, which created heavy contention during very easy compute difficulty

fix(block_seal_spec): stop adjusting compute blocks The difficulty for compute blocks is adjusting based on a formula that is in contradiciton to how the node uses compute when there are “authorized work” miners. Since it doesn’t begin solving until a tick is up, it will never reach the goal of “1/2” of a tick, making the compute fall to the minimum (4). For now, we will disable the compute auto-adjusting until we can revisit a smarter strategy for adjusting it.