### PR TITLE
feat: don’t submit default price index prices

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,7 +112,7 @@ jobs:
         run: df -h
 
       - name: Build
-        run: cargo build --features=simulated-prices --features=ci --features=try-runtime --bins
+        run: cargo build --features=ci --features=try-runtime --bins
         env:
           CARGO_INCREMENTAL: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -122,7 +122,7 @@ jobs:
         run: df -h
 
       - name: Run tests
-        run: cargo test --features=ci --features=simulated-prices --features=try-runtime --no-fail-fast --lib --bins -- --nocapture
+        run: cargo test --features=ci --features=try-runtime --no-fail-fast --lib --bins -- --nocapture
         timeout-minutes: 90
         env:
           CARGO_INCREMENTAL: 0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,7 +87,7 @@ jobs:
         run: cargo sqlx database setup
 
       - name: Build
-        run: cargo build --target=${{ matrix.target }} --features=simulated-prices --bins
+        run: cargo build --target=${{ matrix.target }} --bins
         env:
           CARGO_INCREMENTAL: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,8 +169,6 @@ jobs:
         if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu'))
         with:
           bin: argon-oracle
-          # TODO: deactivate building in this feature when we have price liquidity
-          features: simulated-prices
           target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -77,7 +77,7 @@ script = [
 [tasks.build]
 description = "Compiles the project"
 command = "cargo"
-args = ["build", "--features", "simulated-prices", "--features", "try-runtime"]
+args = ["build", "--features", "try-runtime"]
 dependencies = ["sqlx-setup"]
 
 [tasks.build-node]
@@ -105,7 +105,7 @@ script = "scripts/docker_minio.sh"
 [tasks.test]
 description = "Run tests with cargo,"
 command = "cargo"
-args = ["test", "--features", "try-runtime", "--features", "simulated-prices", "--lib", "--bins", "--no-fail-fast", "${@}"]
+args = ["test", "--features", "try-runtime", "--lib", "--bins", "--no-fail-fast", "${@}"]
 dependencies = ["build", "minio"]
 
 [tasks.nextest]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,7 +14,7 @@ ENV RUST_BACKTRACE=1 \
 RUN --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --locked --bin=argon-node --bin=argon-notary --bin=argon-oracle --features=simulated-prices \
+    cargo build --locked --bin=argon-node --bin=argon-notary --bin=argon-oracle \
     # copy artefacts *out of* the ephemeral cache
     && install -Dm755 target/debug/argon-node   /out/argon-node \
     && install -Dm755 target/debug/argon-notary /out/argon-notary \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -435,7 +435,31 @@ services:
        --keystore-path=/keystore
        --signer-crypto=sr25519
        --signer-address=5Hn1p9jNYatcvcyugRc3TRyfC6zvFGTAX4qe14RhqBYcfrkE
-      ${SIMULATE_PRICES:+--simulate-prices}
+       --from-file-path=/price_index.json
+    volumes:
+      - oracle-price-keystore:/keystore
+      - /tmp/oracle/data/:/tmp/oracle/data/
+      - ${PRICE_INDEX_FILE_PATH:-./oracle/test-price-index.json}:/price_index.json:ro
+    environment:
+      - TRUSTED_RPC_URL=ws://archive-node:9944
+    profiles:
+      - price-oracle
+      - all
+
+  # Live price oracle mode (no file override). Use with:
+  #   docker compose --profile price-oracle-live up -d oracle-price-live
+  oracle-price-live:
+    <<: *oracle
+    depends_on:
+      oracle-price-insert-key:
+        condition: service_completed_successfully
+      archive-node:
+        condition: service_healthy
+    command: >
+      price-index
+       --keystore-path=/keystore
+       --signer-crypto=sr25519
+       --signer-address=5Hn1p9jNYatcvcyugRc3TRyfC6zvFGTAX4qe14RhqBYcfrkE
     volumes:
       - oracle-price-keystore:/keystore
       - /tmp/oracle/data/:/tmp/oracle/data/
@@ -446,10 +470,8 @@ services:
       - BLS_API_KEY=${BLS_API_KEY}
       - INFURA_PROJECT_ID=${INFURA_PROJECT_ID}
       - ORACLE_CPI_CACHE_PATH=/tmp/oracle/data/US_CPI_State.json
-      - SIMULATE_PRICES=${SIMULATE_PRICES:-false}
     profiles:
-      - price-oracle
-      - all
+      - price-oracle-live
 
 networks:
   default:

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -49,6 +49,3 @@ argon-testing = { workspace = true }
 
 [build-dependencies]
 argon-primitives = { workspace = true, features = ["std"] }
-
-[features]
-simulated-prices = []

--- a/oracle/test-price-index.json
+++ b/oracle/test-price-index.json
@@ -1,0 +1,7 @@
+{
+  "argon_usd_target_price": 1.04,
+  "argon_usd_price": 1.04,
+  "argon_time_weighted_average_liquidity": 100000000,
+  "argonot_usd_price": 0.05,
+  "btc_usd_price": 100000.0
+}

--- a/pallets/price_index/src/lib.rs
+++ b/pallets/price_index/src/lib.rs
@@ -190,16 +190,6 @@ pub mod pallet {
 			}
 			T::DbWeight::get().reads_writes(3, 2)
 		}
-
-		fn on_finalize(_: BlockNumberFor<T>) {
-			let Some(current) = Current::<T>::get() else {
-				return;
-			};
-			let current_tick = T::CurrentTick::get();
-			if current.tick < current_tick.saturating_sub(T::MaxDowntimeTicksBeforeReset::get()) {
-				Current::<T>::take();
-			}
-		}
 	}
 
 	#[pallet::call]
@@ -283,7 +273,9 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		fn get_current() -> Option<PriceIndex> {
 			let price = <Current<T>>::get()?;
-			if price.tick < T::CurrentTick::get().saturating_sub(T::MaxPriceAgeInTicks::get()) {
+			if price.tick <
+				T::CurrentTick::get().saturating_sub(T::MaxDowntimeTicksBeforeReset::get())
+			{
 				return None;
 			}
 			Some(price)

--- a/scripts/local_testnet/start.sh
+++ b/scripts/local_testnet/start.sh
@@ -137,7 +137,7 @@ echo -e "Starting a pricing oracle...\n\n"
 "$BASEDIR/target/debug/argon-oracle" insert-key --crypto-type=sr25519 --keystore-path /tmp/price_keystore  --suri //Eve
 ORACLE_CPI_CACHE_PATH=/tmp/oracle/data/US_CPI_State.json RUST_LOG=info "$BASEDIR/target/debug/argon-oracle" --keystore-path /tmp/price_keystore \
   --signer-crypto=sr25519 --signer-address=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw \
-  -t ws://127.0.0.1:9944 price-index --simulate-prices   2>&1 | \
+  -t ws://127.0.0.1:9944 price-index --from-file-path=./oracle/test-price-index.json   2>&1 | \
   awk -v name="orclprc" '{printf "%-8s %s\n", name, $0; fflush()}' &
 
 wait

--- a/testing/nodejs/src/TestOracle.ts
+++ b/testing/nodejs/src/TestOracle.ts
@@ -44,8 +44,6 @@ export default class TestOracle implements ITeardownable {
         throw new Error('Bitcoin RPC URL is required for bitcoin oracle');
       }
       execArgs.push('--bitcoin-rpc-url', bitcoinRpcUrl);
-    } else {
-      execArgs.push('--simulate-prices');
     }
     this.#childProcess = child_process.spawn(binPath, execArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
The oracle should never submit default prices for Argon/Argonot if a price cannot be decoded.

fix: oracle should handle rounding to zero
The oracle should properly handle rounding so that price denominator doesn’t appear to be zero

feat: don’t clear price index
Never clear out the price index from the prices pallet. Just expire it inside the runtime.

feat: development should load price index from a file During development, the simulated price schedule is not useful. This allows the price index to load from a file instead of trying to hit live services.

chore: remove simulated prices
Remove the old simulated prices. It currently only makes things unpredictable and is not used. So this just removes it.