### PR TITLE
feat: make mining slot argonots cap 40% of circ

### DIFF
--- a/.claude/mining-liquidity.md
+++ b/.claude/mining-liquidity.md
@@ -267,7 +267,7 @@ little, requirements decrease to encourage more participation.
 
 - **Target**: 20 bids per slot
 - **Damping**: 20% maximum change per frame
-- **Bounds**: 0.01 argonots minimum to 80% of total network argonots
+- **Bounds**: 0.01 argonots minimum to 40% of total network argonots
 - **Found in**: Runtime config `TargetBidsPerSeatPercent = 20`, `MinimumArgonotsPerSeat = 10,000`
   (micro-units, = 0.01 argonots)
 

--- a/pallets/mining_slot/src/mock.rs
+++ b/pallets/mining_slot/src/mock.rs
@@ -36,7 +36,7 @@ parameter_types! {
 	pub static SlotBiddingStartAfterTicks: u64 = 3;
 	pub static TargetBidsPerSeatPercent: FixedU128 = FixedU128::from_u32(5);
 	pub static MinOwnershipBondAmount: Balance = 1;
-	pub static MaxOwnershipPercent: Percent = Percent::from_float(0.8);
+	pub static MaxOwnershipPercent: Percent = Percent::from_float(0.4);
 	pub const ArgonotsPercentAdjustmentDamper: FixedU128 = FixedU128::from_rational(20, 100);
 	pub const PricePerSeatAdjustmentDamper: FixedU128 = FixedU128::from_rational(20, 100);
 	pub static TargetPricePerSeat: Balance = 10 * 1_000_000; // 10 Argons

--- a/pallets/mining_slot/src/tests.rs
+++ b/pallets/mining_slot/src/tests.rs
@@ -1636,7 +1636,7 @@ fn it_adjusts_locked_argonots() {
 			]);
 			MiningSlots::adjust_argonots_per_seat();
 			let next = ArgonotsPerMiningSeat::<Test>::get();
-			if next == 400_000 {
+			if next == 200_000 {
 				break;
 			}
 			assert_eq!(next, (last as f64 * 1.2) as u128);
@@ -1644,7 +1644,7 @@ fn it_adjusts_locked_argonots() {
 		}
 
 		// max increase is to a set amount of the total issuance
-		assert_eq!(ArgonotsPerMiningSeat::<Test>::get(), (500_000.0 * 0.8) as u128);
+		assert_eq!(ArgonotsPerMiningSeat::<Test>::get(), (500_000.0 * 0.4) as u128);
 	});
 }
 

--- a/runtime/common/src/config.rs
+++ b/runtime/common/src/config.rs
@@ -100,7 +100,7 @@ parameter_types! {
 	pub const PricePerSeatAdjustmentDamper: FixedU128 = FixedU128::from_rational(20, 100);
 	pub const TargetPricePerSeat: Balance = 1000 * ARGON;
 	pub const ArgonotsPercentAdjustmentDamper: FixedU128 = FixedU128::from_rational(20, 100);
-	pub const MaximumArgonotProrataPercent: Percent = Percent::from_percent(80);
+	pub const MaximumArgonotProrataPercent: Percent = Percent::from_percent(40);
 	pub const TargetBidsPerSeatPercent: FixedU128 = FixedU128::from_rational(2, 1); // Ideally we want 2x bids per seat
 	pub const GrandpaRotationBlocks: BlockNumber = 260;
 	pub const MiningSlotBidIncrement: Balance = 10 * MILLIGONS;


### PR DESCRIPTION
The argonot max percent of circulation is now capped at 40% in preparation for requiring vaults to have argonots.