### PR TITLE
fix(bitcoin_locks): cosign signatures not properly verified

### DIFF
--- a/bitcoin/src/psbt_utils.rs
+++ b/bitcoin/src/psbt_utils.rs
@@ -11,7 +11,7 @@ use bitcoin::{
 	key::Secp256k1,
 	sighash::SighashCache,
 };
-use k256::ecdsa::signature::Verifier;
+use k256::ecdsa::signature::hazmat::PrehashVerifier;
 use log::trace;
 use miniscript::psbt::PsbtExt;
 
@@ -119,7 +119,7 @@ pub fn verify_signature_raw(
 	let pubkey = k256::ecdsa::VerifyingKey::from_sec1_bytes(&pubkey.0)
 		.map_err(|_| Error::InvalidCompressPubkeyBytes)?;
 
-	Ok(pubkey.verify(msg.as_ref(), &signature).is_ok())
+	Ok(pubkey.verify_prehash(msg.as_ref(), &signature).is_ok())
 }
 
 pub fn sign(psbt: &mut Psbt, privkey: PrivateKey) -> Result<(Signature, PublicKey), Error> {

--- a/pallets/bitcoin_locks/src/lib.rs
+++ b/pallets/bitcoin_locks/src/lib.rs
@@ -914,7 +914,9 @@ pub mod pallet {
 			)
 			.map_err(|_| Error::<T>::BitcoinUnableToBeDecodedForRelease)?;
 
-			T::BitcoinSignatureVerifier::verify_signature(releaser, vault_pubkey, &signature)?;
+			let is_valid =
+				T::BitcoinSignatureVerifier::verify_signature(releaser, vault_pubkey, &signature)?;
+			ensure!(is_valid, Error::<T>::BitcoinInvalidCosignature);
 
 			// burn the owner's held funds
 			let burn_amount = request.redemption_price;


### PR DESCRIPTION
Bitcoin cosign requests need to ensure signatures are properly verified before clearing out the request.