### PR TITLE
fix(nodejs/client): bitcoin txid reversed

### DIFF
--- a/client/nodejs/src/BitcoinLock.ts
+++ b/client/nodejs/src/BitcoinLock.ts
@@ -82,13 +82,13 @@ export class BitcoinLock implements IBitcoinLock {
     client: IQueryableClient,
   ): Promise<{ txid: string; vout: number; bitcoinTxid: string } | undefined> {
     const refRaw = await client.query.bitcoinUtxos.utxoIdToRef(this.utxoId);
-    if (!refRaw) {
+    if (!refRaw || refRaw.isNone) {
       return;
     }
     const ref = refRaw.unwrap();
 
     const txid = u8aToHex(ref.txid);
-    const bitcoinTxid = u8aToHex(ref.txid.reverse());
+    const bitcoinTxid = u8aToHex(ref.txid.slice().reverse());
     const vout = ref.outputIndex.toNumber();
     return { txid, vout, bitcoinTxid };
   }


### PR DESCRIPTION
The reverse() call on the txid of a polkadotjs result to the utxoRef is causing manipulation to the underlying buffer, which under load for this same request can serve an inverted response.