### PR TITLE
fix(notaries): select signing key by effective tick

### DIFF
--- a/pallets/notaries/src/lib.rs
+++ b/pallets/notaries/src/lib.rs
@@ -370,12 +370,12 @@ pub mod pallet {
 		) -> bool {
 			let key_history = <NotaryKeyHistory<T>>::get(notary_id);
 
-			// find the first key that is valid at the given block height
-			let mut public =
-				key_history.iter().find(|(tick, _)| *tick >= at_tick).map(|(_, public)| public);
-			if public.is_none() && !key_history.is_empty() && key_history[0].0 < at_tick {
-				public = key_history.first().map(|(_, public)| public);
-			}
+			// Choose the latest effective key at or before `at_tick`.
+			let public = key_history
+				.iter()
+				.filter(|(tick, _)| *tick <= at_tick)
+				.max_by_key(|(tick, _)| *tick)
+				.map(|(_, public)| public);
 
 			if let Some(public) = public {
 				return public.verify(message, signature);

--- a/pallets/notaries/src/tests.rs
+++ b/pallets/notaries/src/tests.rs
@@ -289,6 +289,28 @@ fn it_verifies_notary_signatures_matching_block_heights() {
 
 		let hash: H256 = [1u8; 32].into();
 
+		// Before the first key activation tick, no signature should verify.
+		assert!(!<Notaries as NotaryProvider<Block, u64>>::verify_signature(
+			1,
+			1,
+			&hash,
+			&Ed25519Keyring::Alice.sign(&hash[..]),
+		));
+
+		// Between rotations, we should keep using the previous key.
+		assert!(<Notaries as NotaryProvider<Block, u64>>::verify_signature(
+			1,
+			3,
+			&hash,
+			&Ed25519Keyring::Alice.sign(&hash[..]),
+		));
+		assert!(!<Notaries as NotaryProvider<Block, u64>>::verify_signature(
+			1,
+			3,
+			&hash,
+			&Ed25519Keyring::Bob.sign(&hash[..]),
+		));
+
 		assert!(!<Notaries as NotaryProvider<Block, u64>>::verify_signature(
 			1,
 			4,


### PR DESCRIPTION
## Problem
Notary signature verification was selecting the first key with key_tick greater than or equal to at_tick. That is forward-looking and can select a future key instead of the key active at that tick.

## Fix
Select the latest key with key_tick less than or equal to at_tick.
If no key exists at or before at_tick, verification returns false.

## Boundary behavior
- before first key tick: verification fails
- between rotation ticks: previous key is used
- at and after rotation tick: new key is used

## Scope
- pallets/notaries key-selection logic only
- no storage changes
- no migration