### PR TITLE
fix: easy up minimum difficulty in ci

### DIFF
--- a/node/src/chain_spec/development.rs
+++ b/node/src/chain_spec/development.rs
@@ -20,7 +20,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 	properties.insert("ss58Format".into(), ADDRESS_PREFIX.into());
 
 	// Lower CI difficulty to reduce flakiness from slower runners.
-	let hashes_per_second: u64 = if env::var("CI").is_ok() { 100 } else { 400 };
+	let hashes_per_second: u64 = if env::var("CI").is_ok() { 50 } else { 400 };
 	const TICK_MILLIS: u64 = 2000;
 
 	let ticker = Ticker::new(TICK_MILLIS, 2);

--- a/pallets/block_seal_spec/src/lib.rs
+++ b/pallets/block_seal_spec/src/lib.rs
@@ -22,7 +22,7 @@ pub mod weights;
 const MAX_ADJUST_UP: u128 = 4; // Represents 4x adjustment
 const MAX_ADJUST_DOWN: u128 = 4; // Represents 1/4 adjustment
 const MAX_COMPUTE_DIFFICULTY: u128 = u128::MAX;
-const MIN_COMPUTE_DIFFICULTY: u128 = 200;
+const MIN_COMPUTE_DIFFICULTY: u128 = if option_env!("CI").is_some() { 25 } else { 200 };
 const MAX_TAX_MINIMUM: u128 = u128::MAX;
 const MIN_TAX_MINIMUM: u128 = ABSOLUTE_TAX_VOTE_MINIMUM;
 pub(crate) const KEY_BLOCK_ROTATION: u32 = 1440;


### PR DESCRIPTION
This pull request adjusts several parameters and logging details to improve test reliability and reduce flakiness when running in continuous integration (CI) environments. The main changes involve lowering mining difficulty and increasing wait times in CI, as well as improving test output for easier debugging.

**CI-specific parameter tuning:**

- Reduced the `hashes_per_second` value for development configuration in CI from 100 to 50 to further lower mining difficulty and mitigate test flakiness on slower CI runners (`node/src/chain_spec/development.rs`).
- Lowered the `MIN_COMPUTE_DIFFICULTY` constant to 25 (from 200) when running in CI, making mining easier and tests more reliable in that environment (`pallets/block_seal_spec/src/lib.rs`).

**Test stability and diagnostics:**

- Increased the maximum wait ticks in the vote mining end-to-end test for CI from 60 to 90 (and from 20 to 30 for local runs), and added logic to ignore finalized blocks prior to the test's start, reducing test flakiness and improving accuracy (`end-to-end/src/vote_mining.rs`).
- Enhanced logging in the vote mining test to include the starting finalized block and current block number, making it easier to diagnose test timing issues and block progression (`end-to-end/src/vote_mining.rs`). [[1]](diffhunk://#diff-46cc10c4f429331a9bcc85554e890dabbec1e3dc9d9759db963560afce7753e7L179-R186) [[2]](diffhunk://#diff-46cc10c4f429331a9bcc85554e890dabbec1e3dc9d9759db963560afce7753e7L206-R220)