### PR TITLE
feat(security): harden bitcoin CLI secret handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,6 @@ dependencies = [
  "argon-bitcoin-cli-macros",
  "argon-client",
  "argon-primitives",
- "base58",
  "base64 0.22.1",
  "bip39",
  "bitcoin",

--- a/bitcoin/cli/Cargo.toml
+++ b/bitcoin/cli/Cargo.toml
@@ -25,7 +25,6 @@ clap = { workspace = true }
 inquire = { workspace = true }
 comfy-table = { workspace = true }
 hex = { workspace = true }
-base58 = { workspace = true }
 base64 = { workspace = true }
 bitcoin = { workspace = true, features = ["base64"] }
 bip39 = { workspace = true, features = ["default"] }

--- a/bitcoin/cli/src/helpers.rs
+++ b/bitcoin/cli/src/helpers.rs
@@ -1,20 +1,18 @@
 use anyhow::anyhow;
 use argon_client::{FetchAt, MainchainClient, api::storage};
 use argon_primitives::bitcoin::{BitcoinNetwork, OpaqueBitcoinXpub};
-use base58::FromBase58;
 use bitcoin::Network;
 use polkadot_sdk::*;
 use sp_runtime::FixedU128;
 
 pub fn read_bitcoin_xpub(xpub: &str) -> Result<OpaqueBitcoinXpub, String> {
-	let mut vpub_bytes = xpub.from_base58().map_err(|_| "Invalid Base58 string")?;
-	if vpub_bytes.len() == 82 {
-		vpub_bytes = vpub_bytes[0..78].to_vec();
-	}
+	let vpub_bytes = bitcoin::base58::decode_check(xpub)
+		.map_err(|e| format!("Invalid Base58Check string: {e}"))?;
 	if vpub_bytes.len() != 78 {
 		return Err(format!("Invalid byte length ({} should be 78)", vpub_bytes.len()));
 	}
-	let raw_bytes: [u8; 78] = vpub_bytes.try_into().unwrap();
+	let raw_bytes: [u8; 78] =
+		vpub_bytes.try_into().map_err(|_| "Invalid xpub bytes".to_string())?;
 	Ok(OpaqueBitcoinXpub(raw_bytes))
 }
 
@@ -33,4 +31,28 @@ pub async fn get_bitcoin_network(
 		.ok_or(anyhow!("No bitcoin network found"))?
 		.into();
 	Ok(network.into())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::read_bitcoin_xpub;
+
+	#[test]
+	fn read_bitcoin_xpub_requires_valid_base58check() {
+		let bytes = [42u8; 78];
+		let encoded = bitcoin::base58::encode_check(&bytes);
+		let decoded = read_bitcoin_xpub(&encoded).unwrap();
+		assert_eq!(decoded.0, bytes);
+
+		let mut invalid_checksum = encoded.clone();
+		let last = invalid_checksum.pop().unwrap();
+		invalid_checksum.push(if last == '1' { '2' } else { '1' });
+		assert!(read_bitcoin_xpub(&invalid_checksum).is_err());
+	}
+
+	#[test]
+	fn read_bitcoin_xpub_requires_expected_payload_length() {
+		let short = bitcoin::base58::encode_check(&[7u8; 77]);
+		assert!(read_bitcoin_xpub(&short).is_err());
+	}
 }

--- a/docs/bitcoin-lock.md
+++ b/docs/bitcoin-lock.md
@@ -98,7 +98,7 @@ keys.
 > [account setup](./account-setup.md).
 
 ```bash
-$ argon-bitcoin-cli xpriv master --xpriv-password=supersecret --xpriv-path=~/vault1.xpriv
+$ argon-bitcoin-cli xpriv master --xpriv-password-interactive --xpriv-path=~/vault1.xpriv
 ```
 
 > NOTE: for testnet, you must append `--bitcoin-network=signet`
@@ -112,7 +112,7 @@ to get your UtxoId in step 5 and recording alongside it).
 > You can use this XPriv again with a different HD Path for as many combinations as you'd like.
 
 ```bash
-$ argon-bitcoin-cli xpriv derive-pubkey --xpriv-password=supersecret --xpriv-path=~/vault1.xpriv --hd-path="m/84'/0'/0'"
+$ argon-bitcoin-cli xpriv derive-pubkey --xpriv-password-interactive --xpriv-path=~/vault1.xpriv --hd-path="m/84'/0'/0'"
 ```
 
 ### 3. Choose a Vault
@@ -297,7 +297,7 @@ This must be a trusted JSON-RPC endpoint (not REST or WebSocket). Example provid
 For testnet, you can use `https://bitcoin:bitcoin@electrs.testnet.argonprotocol.org`
 
 ```bash
-$ argon-bitcoin-cli lock owner-cosign-release --utxo-id=1 --xpriv-password=supersecret --xpriv-path=~/vault1.xpriv \
+$ argon-bitcoin-cli lock owner-cosign-release --utxo-id=1 --xpriv-password-interactive --xpriv-path=~/vault1.xpriv \
   --bitcoin-rpc-url=https://btc.getblock.io/mainnet/?api_key=your_api_key \
   --hd-path="m/84'/0'/0'" --wait
 ```

--- a/docs/running-a-vault.md
+++ b/docs/running-a-vault.md
@@ -141,7 +141,7 @@ in next step), your key is impossible to uncover through the vault activities.
 > will need to manage your XPriv key as a password encrypted file.
 
 ```bash
-$ argon-bitcoin-cli xpriv master --xpriv-password=supersecret --xpriv-path=/tmp/vault1.xpriv
+$ argon-bitcoin-cli xpriv master --xpriv-password-interactive --xpriv-path=/tmp/vault1.xpriv
 ```
 
 > NOTE: on testnet, you must add `--bitcoin-network=signet` to the command above to create a Signet
@@ -165,7 +165,7 @@ Let's generate the XPub key.
 > path also needs to be hardened to ensure the key is secure.
 
 ```bash
-$ argon-bitcoin-cli xpriv derive-xpub --xpriv-path=~/.xpriv/vault1.xpriv --xpriv-password=supersecret --hd-path="m/84'/0'/0'"
+$ argon-bitcoin-cli xpriv derive-xpub --xpriv-path=~/.xpriv/vault1.xpriv --xpriv-password-interactive --hd-path="m/84'/0'/0'"
 ```
 
 ### 3. Create a Vault
@@ -237,7 +237,7 @@ When you encounter a LockedBitcoin Cosign Request, you will need to know:
 
 ```bash
 $ argon-bitcoin-cli lock vault-cosign-release --utxo-id=1 \
-  --xpriv-path=~/.xpriv/vault.xpub --xpriv-password=supersecret --hd-path="m/84'/0'/0'" \
+  --xpriv-path=~/.xpriv/vault.xpriv --xpriv-password-interactive --hd-path="m/84'/0'/0'" \
   --trusted-rpc-url wss://rpc.testnet.argonprotocol.org
 ```
 
@@ -261,7 +261,7 @@ https://mempool.space/testnet.
 
 ```bash
 $ argon-bitcoin-cli lock claim-utxo-psbt --utxo-id=1 \
-  --xpriv-path=~/.xpriv/vault.xpub --xpriv-password=supersecret --hd-path="m/84'/0'/0'" \
+  --xpriv-path=~/.xpriv/vault.xpriv --xpriv-password-interactive --hd-path="m/84'/0'/0'" \
   --dest_pubkey=tb1q3hkkt02k975ddxzeeeupy9cpysr2cy929ck4qp \
   --fee-rate-sats-per-vb=3 \
   --trusted-rpc-url wss://rpc.testnet.argonprotocol.org \

--- a/end-to-end/src/bitcoin.rs
+++ b/end-to-end/src/bitcoin.rs
@@ -443,6 +443,7 @@ async fn test_bitcoin_xpriv_lock_e2e() {
 		vec![
 			"lock",
 			"owner-cosign-release",
+			"--allow-insecure-cli-secrets",
 			"--utxo-id",
 			&utxo_id.to_string(),
 			"--hd-path",
@@ -541,6 +542,7 @@ async fn create_xpriv_and_derive(
 		vec![
 			"xpriv",
 			"master",
+			"--allow-insecure-cli-secrets",
 			"--xpriv-password",
 			password,
 			"--xpriv-path",
@@ -557,6 +559,7 @@ async fn create_xpriv_and_derive(
 		vec![
 			"xpriv",
 			"derive-pubkey",
+			"--allow-insecure-cli-secrets",
 			"--xpriv-path",
 			path.to_str().unwrap(),
 			"--xpriv-password",
@@ -594,6 +597,7 @@ async fn create_xpriv_and_master_xpub(
 		vec![
 			"xpriv",
 			"master",
+			"--allow-insecure-cli-secrets",
 			"--xpriv-password",
 			password,
 			"--xpriv-path",
@@ -610,6 +614,7 @@ async fn create_xpriv_and_master_xpub(
 		vec![
 			"xpriv",
 			"derive-xpub",
+			"--allow-insecure-cli-secrets",
 			"--xpriv-path",
 			path.to_str().unwrap(),
 			"--xpriv-password",
@@ -1000,6 +1005,7 @@ async fn vault_cosigns_release(
 		vec![
 			"lock",
 			"vault-cosign-release",
+			"--allow-insecure-cli-secrets",
 			"--utxo-id",
 			&utxo_id.to_string(),
 			"--xpriv-path",

--- a/localchain/src/cli.rs
+++ b/localchain/src/cli.rs
@@ -660,7 +660,8 @@ pub struct EmbeddedKeyPassword {
 
   /// File that contains the password used by the embedded keystore.
   #[arg(
-    long,
+    long = "key-password-file",
+    alias = "key-password-filename",
     value_name = "PATH",
     conflicts_with_all = &["key_password_interactive", "key_password"]
   )]


### PR DESCRIPTION
Various security measures to make sure bitcoin cli is more secure. This isn't a main use of bitcoin locking, but securing it ensures the patterns are established for how we want to operate and secure secrets and the like.

- gate argv-based mnemonic/private key/xpriv password flags behind explicit unsafe override

- normalize *-file flag naming with compatibility aliases

- update localchain/primitives secret input paths and docs/e2e command usage