### PR TITLE
Harden deferred notebook import/replay to avoid sync stalls and retry thrash

### DIFF
--- a/node/consensus/src/error.rs
+++ b/node/consensus/src/error.rs
@@ -77,11 +77,28 @@ pub enum Error {
 	#[error("Notary sync missing notebook dependencies: {0}")]
 	MissingNotebooksError(String),
 
+	#[error("Notebook audit deferred: {0}")]
+	NotaryAuditDeferred(String),
+
+	#[error("Pending import replay cannot safely defer this block: {0}")]
+	PendingImportUnsupported(String),
+
 	#[error("A duplicate block was created by this author {0} for the given {1} key {2}")]
 	DuplicateAuthoredBlock(AccountId, String, String),
+}
 
-	#[error("The block state is not available")]
-	StateUnavailableError,
+impl Error {
+	pub(crate) fn is_retryable_notebook_audit_error(&self) -> bool {
+		matches!(
+			self,
+			Self::MissingNotebooksError(_) |
+				Self::NotebookAuditBeforeTick(_) |
+				Self::UnableToSyncNotary(_) |
+				Self::NotaryAuditDeferred(_) |
+				Self::NotaryError(_) |
+				Self::NotaryArchiveError(_)
+		)
+	}
 }
 
 impl From<String> for Error {

--- a/node/consensus/src/import_queue.rs
+++ b/node/consensus/src/import_queue.rs
@@ -1,8 +1,15 @@
-use crate::{NotaryClient, aux_client::ArgonAux, compute_worker::BlockComputeNonce, error::Error};
+use crate::{
+	NotaryClient,
+	aux_client::ArgonAux,
+	compute_worker::BlockComputeNonce,
+	error::Error,
+	notary_client::{NotaryApisExt, NotebookAuditMode},
+	pending_import_replay::{PendingImportReplayQueue, spawn_pending_import_replay_task},
+};
 use argon_bitcoin_utxo_tracker::{UtxoTracker, get_bitcoin_inherent};
 use argon_primitives::{
 	AccountId, Balance, BitcoinApis, BlockCreatorApis, BlockImportApis, BlockSealApis,
-	BlockSealAuthorityId, BlockSealDigest, NotaryApis, NotebookApis, TickApis,
+	BlockSealAuthorityId, BlockSealDigest, NotaryApis, NotebookApis, NotebookAuditResult, TickApis,
 	digests::ArgonDigests,
 	fork_power::ForkPower,
 	inherents::{BitcoinInherentDataProvider, BlockSealInherentDataProvider},
@@ -31,8 +38,10 @@ use sp_runtime::{
 	Justification,
 	traits::{Block as BlockT, Header as HeaderT, NumberFor},
 };
-use std::{fmt, marker::PhantomData, sync::Arc};
-use tracing::error;
+use std::{collections::HashSet, fmt, marker::PhantomData, sync::Arc, time::Duration};
+use tracing::{error, warn};
+
+const IMPORT_NOTEBOOK_AUDIT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone)]
 pub struct ImportMetrics {
@@ -81,16 +90,22 @@ impl ImportMetrics {
 	}
 }
 
-pub trait ImportApisExt<B: BlockT>: HeaderBackend<B> + BlockBackend<B> {
+pub trait ImportApisExt<B: BlockT, AC>: HeaderBackend<B> + BlockBackend<B> {
 	fn has_new_bitcoin_tip(&self, hash: B::Hash) -> bool;
 	fn has_new_price_index(&self, hash: B::Hash) -> bool;
+	fn runtime_digest_notebooks(
+		&self,
+		parent_hash: B::Hash,
+		digest: &sp_runtime::Digest,
+	) -> Result<Vec<NotebookAuditResult<NotebookVerifyError>>, Error>;
 }
 
-impl<B: BlockT, C> ImportApisExt<B> for C
+impl<B: BlockT, C, AC> ImportApisExt<B, AC> for C
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B> + HeaderBackend<B> + BlockBackend<B>,
-	C::Api: BlockImportApis<B>,
+	C::Api: BlockImportApis<B> + BlockCreatorApis<B, AC, NotebookVerifyError>,
+	AC: Codec + Clone,
 {
 	fn has_new_bitcoin_tip(&self, hash: B::Hash) -> bool {
 		self.runtime_api().has_new_bitcoin_tip(hash).unwrap_or(false)
@@ -99,20 +114,37 @@ where
 	fn has_new_price_index(&self, hash: B::Hash) -> bool {
 		self.runtime_api().has_new_price_index(hash).unwrap_or(false)
 	}
+
+	fn runtime_digest_notebooks(
+		&self,
+		parent_hash: B::Hash,
+		digest: &sp_runtime::Digest,
+	) -> Result<Vec<NotebookAuditResult<NotebookVerifyError>>, Error> {
+		self.runtime_api()
+			.digest_notebooks(parent_hash, digest)
+			.map_err(|e| {
+				Error::MissingRuntimeData(format!("Error calling digest notebooks api: {e:?}"))
+			})?
+			.map_err(|e| {
+				Error::MissingRuntimeData(format!("Failed to get digest notebooks: {e:?}"))
+			})
+	}
 }
 
 /// A block importer for argon.
 pub struct ArgonBlockImport<B: BlockT, I, C: AuxStore, AC> {
 	inner: I,
-	client: Arc<C>,
+	pub(crate) client: Arc<C>,
 	aux_client: ArgonAux<B, C>,
+	pub(crate) notary_client: Arc<NotaryClient<B, C, AC>>,
 	import_lock: Arc<tokio::sync::Mutex<()>>,
+	pub(crate) pending_full_import_queue: PendingImportReplayQueue<B, C>,
 	metrics: Arc<Option<ImportMetrics>>,
 	_phantom: PhantomData<AC>,
 }
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ImportContext<B: BlockT> {
 	hash: B::Hash,
 	number: NumberFor<B>,
@@ -123,6 +155,7 @@ struct ImportContext<B: BlockT> {
 	block_header_status: sp_blockchain::BlockStatus,
 	state_action: ImportStateAction,
 	skip_execution_checks: bool,
+	has_body: bool,
 	origin: BlockOrigin,
 	finalized: bool,
 }
@@ -183,21 +216,33 @@ impl<B: BlockT> ImportContext<B> {
 			block_header_status,
 			state_action,
 			skip_execution_checks: block.state_action.skip_execution_checks(),
+			has_body: block.body.is_some(),
 			origin: block.origin,
 			finalized: block.finalized,
 		}
+	}
+
+	fn refresh<C>(&mut self, client: &C, block: &mut BlockImportParams<B>)
+	where
+		C: HeaderBackend<B> + BlockBackend<B>,
+	{
+		*self = Self::from_block(client, block);
 	}
 
 	fn is_parent_state_available(&self) -> bool {
 		self.parent_block_state == BlockStatus::InChainWithState
 	}
 
-	fn parent_is_genesis(&self) -> bool {
-		self.parent_hash == self.info.genesis_hash
+	fn is_parent_unknown(&self) -> bool {
+		self.parent_block_state == BlockStatus::Unknown
 	}
 
 	fn is_initial_sync(&self) -> bool {
 		self.origin == BlockOrigin::NetworkInitialSync
+	}
+
+	fn is_my_block(&self) -> bool {
+		self.origin == BlockOrigin::Own
 	}
 
 	fn is_header_already_imported(&self) -> bool {
@@ -208,18 +253,48 @@ impl<B: BlockT> ImportContext<B> {
 		!self.skip_execution_checks
 	}
 
-	fn should_return_missing_state_for_execution(&self) -> bool {
-		self.state_action == ImportStateAction::ExecuteIfPossible &&
-			!self.is_parent_state_available() &&
-			!self.is_initial_sync() &&
-			!self.parent_is_genesis()
+	fn can_defer_full_import(&self) -> bool {
+		self.has_body && !self.finalized && !self.is_my_block()
 	}
 
-	fn should_short_circuit_known_header(&self) -> bool {
-		self.is_header_already_imported() &&
-			!self.has_state_or_block() &&
+	fn supports_deferred_full_import(&self) -> bool {
+		matches!(
+			self.state_action,
+			ImportStateAction::Execute | ImportStateAction::ExecuteIfPossible
+		)
+	}
+
+	fn can_defer_notebook_verification(&self) -> bool {
+		self.supports_deferred_full_import() && self.can_defer_full_import()
+	}
+
+	fn are_import_details_already_queued(
+		&self,
+		is_full_import_already_queued: bool,
+		has_justifications: bool,
+	) -> bool {
+		self.has_body &&
 			!self.finalized &&
-			!self.is_block_gap
+			!has_justifications &&
+			self.supports_deferred_full_import() &&
+			self.is_header_already_imported() &&
+			is_full_import_already_queued
+	}
+
+	fn can_execute_if_possible_now(&self) -> bool {
+		if self.state_action == ImportStateAction::ExecuteIfPossible {
+			self.is_parent_state_available()
+		} else {
+			true
+		}
+	}
+
+	fn should_verify_notebooks(&self) -> bool {
+		!self.skip_execution_checks &&
+			!self.is_initial_sync() &&
+			!self.is_my_block() &&
+			self.number > self.info.finalized_number &&
+			!self.finalized
 	}
 
 	fn can_finalize_import(&self, is_finalized_descendent: bool) -> bool {
@@ -227,8 +302,9 @@ impl<B: BlockT> ImportContext<B> {
 	}
 }
 
+#[allow(clippy::large_enum_variant)]
 enum PreImportOutcome<B: BlockT> {
-	ContinueImport { import_context: ImportContext<B> },
+	ContinueImport { block: BlockImportParams<B>, import_context: ImportContext<B> },
 	ReturnResult(ImportResult),
 }
 
@@ -238,10 +314,38 @@ impl<B: BlockT, I: Clone, C: AuxStore, AC: Codec> Clone for ArgonBlockImport<B, 
 			inner: self.inner.clone(),
 			client: self.client.clone(),
 			aux_client: self.aux_client.clone(),
+			notary_client: self.notary_client.clone(),
 			import_lock: self.import_lock.clone(),
+			pending_full_import_queue: self.pending_full_import_queue.clone(),
 			metrics: self.metrics.clone(),
 			_phantom: PhantomData,
 		}
+	}
+}
+
+impl<B: BlockT, I, C: AuxStore, AC> ArgonBlockImport<B, I, C, AC> {
+	pub(crate) fn new_with_components(
+		inner: I,
+		client: Arc<C>,
+		aux_client: ArgonAux<B, C>,
+		notary_client: Arc<NotaryClient<B, C, AC>>,
+		metrics: Arc<Option<ImportMetrics>>,
+	) -> Self {
+		Self {
+			inner,
+			client: client.clone(),
+			aux_client,
+			notary_client,
+			import_lock: Default::default(),
+			pending_full_import_queue: PendingImportReplayQueue::new(client),
+			metrics,
+			_phantom: PhantomData,
+		}
+	}
+
+	#[cfg(test)]
+	pub(crate) async fn pending_full_imports_len(&self) -> usize {
+		self.pending_full_import_queue.len().await
 	}
 }
 
@@ -250,11 +354,23 @@ where
 	B: BlockT,
 	I: BlockImport<B> + Send + Sync,
 	I::Error: Into<ConsensusError>,
-	C: ImportApisExt<B> + AuxStore + Send + Sync + 'static,
+	C: ImportApisExt<B, AC> + NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
 	AC: Clone + Codec + Send + Sync + 'static,
 {
-	fn finish_pre_import(import_context: ImportContext<B>) -> PreImportOutcome<B> {
-		if import_context.should_short_circuit_known_header() {
+	fn finish_pre_import(
+		block: BlockImportParams<B>,
+		import_context: ImportContext<B>,
+	) -> PreImportOutcome<B> {
+		let has_justifications = block
+			.justifications
+			.as_ref()
+			.is_some_and(|justifications| justifications.iter().next().is_some());
+		if import_context.is_header_already_imported() &&
+			!import_context.has_state_or_block() &&
+			!import_context.finalized &&
+			!import_context.is_block_gap &&
+			!has_justifications
+		{
 			tracing::debug!(
 				context = ?import_context,
 				"Skipping reimport of known block without state or finalization"
@@ -262,33 +378,174 @@ where
 			return PreImportOutcome::ReturnResult(ImportResult::AlreadyInChain);
 		}
 
-		PreImportOutcome::ContinueImport { import_context }
+		PreImportOutcome::ContinueImport { block, import_context }
 	}
 
-	fn evaluate_pre_import(import_context: ImportContext<B>) -> PreImportOutcome<B> {
-		if import_context.should_return_missing_state_for_execution() {
-			tracing::debug!(
-				context = ?import_context,
-				"Parent state missing; returning missing state action"
-			);
-			return PreImportOutcome::ReturnResult(ImportResult::MissingState);
+	async fn defer_or_return_missing_state(
+		&self,
+		block: BlockImportParams<B>,
+		import_context: &mut ImportContext<B>,
+	) -> Result<PreImportOutcome<B>, Error> {
+		match self.pending_full_import_queue.defer_full_import(block).await {
+			Ok(mut queued_block) => {
+				import_context.refresh(&*self.client, &mut queued_block);
+				Ok(Self::finish_pre_import(queued_block, import_context.clone()))
+			},
+			Err(Error::PendingImportUnsupported(reason)) => {
+				warn!(
+					context = ?import_context,
+					?reason,
+					"Deferred replay unsupported for this block; returning MissingState"
+				);
+				Ok(PreImportOutcome::ReturnResult(ImportResult::MissingState))
+			},
+			Err(err) => Err(err),
 		}
-
-		Self::finish_pre_import(import_context)
 	}
-}
 
-#[cfg(test)]
-impl<B: BlockT, I, C: AuxStore, AC> ArgonBlockImport<B, I, C, AC> {
-	pub(crate) fn new_for_tests(inner: I, client: Arc<C>, aux_client: ArgonAux<B, C>) -> Self {
-		Self {
-			inner,
-			client,
-			aux_client,
-			import_lock: Default::default(),
-			metrics: Default::default(),
-			_phantom: PhantomData,
+	async fn evaluate_pre_import(
+		&self,
+		block: BlockImportParams<B>,
+		mut import_context: ImportContext<B>,
+	) -> Result<PreImportOutcome<B>, Error> {
+		let has_justifications = block
+			.justifications
+			.as_ref()
+			.is_some_and(|justifications| justifications.iter().next().is_some());
+		let queued_before_import =
+			self.pending_full_import_queue.has_hash(import_context.hash).await;
+
+		if import_context
+			.are_import_details_already_queued(queued_before_import, has_justifications)
+		{
+			return Ok(PreImportOutcome::ReturnResult(ImportResult::AlreadyInChain));
 		}
+
+		if !import_context.can_execute_if_possible_now() {
+			if import_context.is_parent_unknown() || !import_context.can_defer_full_import() {
+				tracing::debug!(
+					context = ?import_context,
+					"Parent state missing; returning missing state action"
+				);
+				return Ok(PreImportOutcome::ReturnResult(ImportResult::MissingState));
+			}
+			return self.defer_or_return_missing_state(block, &mut import_context).await;
+		}
+
+		if !import_context.should_verify_notebooks() {
+			return Ok(Self::finish_pre_import(block, import_context));
+		}
+
+		if !import_context.is_parent_state_available() {
+			if import_context.is_parent_unknown() ||
+				!import_context.can_defer_notebook_verification()
+			{
+				return Ok(PreImportOutcome::ReturnResult(ImportResult::MissingState));
+			}
+			return self.defer_or_return_missing_state(block, &mut import_context).await;
+		}
+
+		let digest_notebooks = self
+			.client
+			.runtime_digest_notebooks(import_context.parent_hash, block.header.digest())?;
+		if digest_notebooks.is_empty() {
+			return Ok(Self::finish_pre_import(block, import_context));
+		}
+
+		if let Err(err) = self
+			.notary_client
+			.verify_notebook_audits(
+				&import_context.parent_hash,
+				digest_notebooks,
+				NotebookAuditMode::Import { max_wait: IMPORT_NOTEBOOK_AUDIT_TIMEOUT },
+			)
+			.await
+		{
+			match err {
+				err if err.is_retryable_notebook_audit_error() =>
+					if import_context.can_defer_notebook_verification() {
+						return self.defer_or_return_missing_state(block, &mut import_context).await;
+					} else {
+						return Err(err);
+					},
+				Error::InvalidNotebookDigest(_) => {
+					warn!(
+						number = ?import_context.number,
+						block_hash = ?import_context.hash,
+						parent_hash = ?import_context.parent_hash,
+						origin = ?import_context.origin,
+						"Rejecting block with invalid notebook digest: {err}"
+					);
+					return Ok(PreImportOutcome::ReturnResult(ImportResult::KnownBad));
+				},
+				err => return Err(err),
+			}
+		}
+
+		Ok(Self::finish_pre_import(block, import_context))
+	}
+
+	pub(crate) async fn replay_pending_full_imports(&self) -> Result<(), Error> {
+		let mut attempted_hashes = HashSet::new();
+		while let Some((pending_import, replay_context)) = self
+			.pending_full_import_queue
+			.dequeue_ready_for_replay_excluding(&self.notary_client, &attempted_hashes)
+			.await?
+		{
+			attempted_hashes.insert(replay_context.hash);
+			let mut replay_retry_block =
+				PendingImportReplayQueue::<B, C>::retry_block_from_pending(&pending_import);
+			match <Self as BlockImport<B>>::import_block(self, pending_import.block).await {
+				Ok(ImportResult::KnownBad) => {
+					warn!(
+						block_hash = ?replay_context.hash,
+						number = ?replay_context.number,
+						"Pending full block import replay resolved as known-bad"
+					);
+				},
+				Ok(ImportResult::MissingState) => {
+					warn!(
+						block_hash = ?replay_context.hash,
+						number = ?replay_context.number,
+						"Pending full block replay still missing state; requeueing"
+					);
+					if let Some(block) = replay_retry_block.take() {
+						self.pending_full_import_queue.requeue_retry_block(block).await?;
+					}
+				},
+				Ok(ImportResult::AlreadyInChain) => {
+					let state_status = self
+						.client
+						.block_status(replay_context.hash)
+						.unwrap_or(BlockStatus::Unknown);
+					if state_status != BlockStatus::InChainWithState {
+						warn!(
+						block_hash = ?replay_context.hash,
+						number = ?replay_context.number,
+						?state_status,
+						"Pending full block replay returned AlreadyInChain without state; requeueing"
+						);
+						if let Some(block) = replay_retry_block.take() {
+							self.pending_full_import_queue.requeue_retry_block(block).await?;
+						}
+					}
+				},
+				Ok(_) => {},
+				Err(err) => {
+					warn!(
+					block_hash = ?replay_context.hash,
+					number = ?replay_context.number,
+					error = ?err,
+					"Pending full block replay failed; requeueing"
+					);
+					if let Some(block) = replay_retry_block.take() {
+						self.pending_full_import_queue.requeue_retry_block(block).await?;
+					}
+				},
+			}
+			tokio::task::yield_now().await;
+		}
+		Ok(())
 	}
 }
 
@@ -298,7 +555,7 @@ where
 	B: BlockT,
 	I: BlockImport<B> + Send + Sync,
 	I::Error: Into<ConsensusError>,
-	C: ImportApisExt<B> + AuxStore + Send + Sync + 'static,
+	C: ImportApisExt<B, AC> + NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
 	AC: Clone + Codec + Send + Sync + 'static,
 {
 	type Error = ConsensusError;
@@ -377,8 +634,11 @@ where
 		// imported. Various sync strategies will access this path without state set yet
 		tracing::trace!(context = ?import_context, "Begin import.");
 
-		let import_context = match Self::evaluate_pre_import(import_context) {
-			PreImportOutcome::ContinueImport { import_context } => import_context,
+		let import_context = match self.evaluate_pre_import(block, import_context).await? {
+			PreImportOutcome::ContinueImport { block: next_block, import_context } => {
+				block = next_block;
+				import_context
+			},
 			PreImportOutcome::ReturnResult(result) => return Ok(result),
 		};
 		let info = &import_context.info;
@@ -593,10 +853,9 @@ where
 #[allow(dead_code)]
 struct Verifier<B: BlockT, C: AuxStore, AC> {
 	client: Arc<C>,
-	notary_client: Arc<NotaryClient<B, C, AC>>,
 	utxo_tracker: Arc<UtxoTracker>,
 	telemetry: Option<TelemetryHandle>,
-	_phantom: PhantomData<AC>,
+	_phantom: PhantomData<(B, AC)>,
 }
 
 #[async_trait::async_trait]
@@ -705,33 +964,6 @@ where
 				}
 			}
 
-			// if we're importing a non-finalized block from someone else, verify the notebook
-			// audits
-			let latest_verified_finalized = self.client.info().finalized_number;
-			if !matches!(block_params.origin, BlockOrigin::Own | BlockOrigin::NetworkInitialSync) &&
-				block_number > latest_verified_finalized &&
-				!block_params.finalized
-			{
-				let digest_notebooks = runtime_api
-					.digest_notebooks(parent_hash, digest)
-					.map_err(|e| format!("Error calling digest notebooks api {e:?}"))?
-					.map_err(|e| format!("Failed to get digest notebooks: {e:?}"))?;
-				self.notary_client
-					.verify_notebook_audits(&parent_hash, digest_notebooks)
-					.await
-					.inspect_err(|e| {
-						error!(
-						?block_number,
-						block_hash=?post_hash,
-						?parent_hash,
-						origin = ?block_params.origin,
-						import_existing = block_params.import_existing,
-						finalized = block_params.finalized,
-						has_justification = block_params.justifications.is_some(),
-						"Failed to verify notebook audits {}", e.to_string())
-					})?;
-			}
-
 			let check_block = B::new(block_params.header.clone(), inner_body);
 
 			let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
@@ -804,18 +1036,21 @@ where
 	let metrics = registry.and_then(|r| ImportMetrics::new(r).ok());
 	let metrics = Arc::new(metrics);
 
-	let importer = ArgonBlockImport {
-		inner: block_import,
-		client: client.clone(),
+	let importer = ArgonBlockImport::new_with_components(
+		block_import,
+		client.clone(),
 		aux_client,
-		import_lock: Default::default(),
+		notary_client.clone(),
 		metrics,
-		_phantom: PhantomData,
-	};
+	);
+	let replay_importer = importer.clone();
+	spawn_pending_import_replay_task(spawner, move || {
+		let replay_importer = replay_importer.clone();
+		async move { replay_importer.replay_pending_full_imports().await }
+	});
 	let verifier = Verifier::<B, C, AC> {
 		client: client.clone(),
 		utxo_tracker,
-		notary_client,
 		telemetry,
 		_phantom: PhantomData,
 	};

--- a/node/consensus/src/import_queue_test.rs
+++ b/node/consensus/src/import_queue_test.rs
@@ -1,5 +1,11 @@
-use crate::mock_importer::{create_params, has_state, new_importer};
-use argon_primitives::prelude::*;
+use crate::{
+	mock_importer::{
+		create_params, has_state, new_importer, new_importer_from_client, new_importer_with_notary,
+		new_importer_with_notary_from_client, pending_import_count,
+	},
+	pending_import_replay::PENDING_IMPORTS_ADVISORY_LIMIT,
+};
+use argon_primitives::{NotebookAuditResult, prelude::*};
 use polkadot_sdk::{
 	frame_support::assert_ok,
 	sc_client_api::{BlockBackend, KeyValueStates},
@@ -7,7 +13,7 @@ use polkadot_sdk::{
 	sp_core::H256,
 };
 use sc_consensus::{BlockImport, ImportResult, StateAction, StorageChanges};
-use sp_blockchain::{BlockGap, BlockGapType, HeaderBackend};
+use sp_blockchain::{BlockGap, BlockGapType, BlockStatus, HeaderBackend};
 use sp_consensus::BlockOrigin;
 
 #[tokio::test]
@@ -388,4 +394,398 @@ async fn test_reorg_to_lower_power_then_recover() {
 	importer.import_block(p).await.unwrap();
 
 	assert_eq!(client.info().best_hash, hash130);
+}
+
+#[tokio::test]
+async fn test_missing_parent_state_returns_missing_state_for_execute_if_possible() {
+	let (importer, _client) = new_importer();
+	let unknown_parent = H256::repeat_byte(1);
+	let mut params = create_params(
+		1,
+		unknown_parent,
+		1,
+		None,
+		BlockOrigin::NetworkBroadcast,
+		StateAction::ExecuteIfPossible,
+		None,
+	);
+	params.body = Some(Vec::new());
+
+	let result = importer.import_block(params).await.unwrap();
+	assert!(matches!(result, ImportResult::MissingState));
+}
+
+#[tokio::test]
+async fn test_execute_if_possible_sync_block_with_pruned_parent_is_deferred_header_only() {
+	let (importer, client) = new_importer();
+	let genesis_hash = client.info().best_hash;
+
+	let parent = create_params(
+		1,
+		genesis_hash,
+		1,
+		None,
+		BlockOrigin::NetworkInitialSync,
+		StateAction::Skip,
+		None,
+	);
+	let parent_hash = parent.post_hash();
+	let _ = importer.import_block(parent).await.unwrap();
+	assert!(!has_state(&client, parent_hash));
+
+	let mut child = create_params(
+		2,
+		parent_hash,
+		1,
+		None,
+		BlockOrigin::NetworkInitialSync,
+		StateAction::ExecuteIfPossible,
+		None,
+	);
+	child.body = Some(Vec::new());
+	let child_hash = child.post_hash();
+
+	let result = importer.import_block(child).await.unwrap();
+	assert!(matches!(result, ImportResult::Imported(_)));
+	assert_eq!(pending_import_count(&importer).await, 1);
+	assert_eq!(client.status(child_hash).unwrap(), BlockStatus::InChain);
+	assert!(!has_state(&client, child_hash));
+}
+
+#[tokio::test]
+async fn test_deferred_execute_if_possible_recovers_after_importer_restart() {
+	let (importer, client) = new_importer();
+	let genesis_hash = client.info().best_hash;
+
+	let parent = create_params(
+		1,
+		genesis_hash,
+		1,
+		None,
+		BlockOrigin::NetworkInitialSync,
+		StateAction::Skip,
+		None,
+	);
+	let parent_hash = parent.post_hash();
+	let _ = importer.import_block(parent).await.unwrap();
+	assert!(!has_state(&client, parent_hash));
+
+	let mut child = create_params(
+		2,
+		parent_hash,
+		1,
+		None,
+		BlockOrigin::NetworkBroadcast,
+		StateAction::ExecuteIfPossible,
+		None,
+	);
+	child.body = Some(Vec::new());
+	let child_hash = child.post_hash();
+	let result = importer.import_block(child).await.unwrap();
+	assert!(matches!(result, ImportResult::Imported(_)));
+	assert_eq!(pending_import_count(&importer).await, 1);
+	drop(importer);
+
+	let importer = new_importer_from_client(client.clone());
+	assert_eq!(
+		pending_import_count(&importer).await,
+		1,
+		"deferred queue should survive importer restart",
+	);
+
+	client.set_state(parent_hash, sp_consensus::BlockStatus::InChainWithState);
+	importer.replay_pending_full_imports().await.unwrap();
+
+	assert!(has_state(&client, child_hash), "replayed import should recover full block state");
+	assert_eq!(pending_import_count(&importer).await, 0);
+}
+
+#[tokio::test]
+async fn test_replay_initial_sync_with_pruned_parent_state_does_not_spin() {
+	let (importer, client) = new_importer();
+	let genesis_hash = client.info().best_hash;
+
+	let parent = create_params(
+		1,
+		genesis_hash,
+		1,
+		None,
+		BlockOrigin::NetworkInitialSync,
+		StateAction::Skip,
+		None,
+	);
+	let parent_hash = parent.post_hash();
+	let _ = importer.import_block(parent).await.unwrap();
+	assert!(!has_state(&client, parent_hash));
+
+	let mut child = create_params(
+		2,
+		parent_hash,
+		1,
+		None,
+		BlockOrigin::NetworkInitialSync,
+		StateAction::ExecuteIfPossible,
+		None,
+	);
+	child.body = Some(Vec::new());
+	let child_hash = child.post_hash();
+	let result = importer.import_block(child).await.unwrap();
+	assert!(matches!(result, ImportResult::Imported(_)));
+	assert_eq!(pending_import_count(&importer).await, 1);
+
+	let replay_result = tokio::time::timeout(
+		std::time::Duration::from_millis(100),
+		importer.replay_pending_full_imports(),
+	)
+	.await;
+
+	assert!(matches!(replay_result, Ok(Ok(()))));
+	assert_eq!(pending_import_count(&importer).await, 1);
+	assert!(!has_state(&client, child_hash));
+}
+
+#[tokio::test]
+async fn test_queue_growth_persists_over_advisory_capacity() {
+	let (importer, client) = new_importer();
+	let genesis_hash = client.info().best_hash;
+
+	let parent = create_params(
+		1,
+		genesis_hash,
+		1,
+		None,
+		BlockOrigin::NetworkInitialSync,
+		StateAction::Skip,
+		None,
+	);
+	let parent_hash = parent.post_hash();
+	let _ = importer.import_block(parent).await.unwrap();
+	assert!(!has_state(&client, parent_hash));
+
+	for n in 2..=(PENDING_IMPORTS_ADVISORY_LIMIT as u32 + 1) {
+		let mut child = create_params(
+			n,
+			parent_hash,
+			1,
+			None,
+			BlockOrigin::NetworkInitialSync,
+			StateAction::ExecuteIfPossible,
+			None,
+		);
+		child.body = Some(Vec::new());
+		let result = importer.import_block(child).await.unwrap();
+		assert!(matches!(result, ImportResult::Imported(_)));
+	}
+	assert_eq!(pending_import_count(&importer).await, PENDING_IMPORTS_ADVISORY_LIMIT);
+
+	let mut overflow = create_params(
+		PENDING_IMPORTS_ADVISORY_LIMIT as u32 + 2,
+		parent_hash,
+		1,
+		None,
+		BlockOrigin::NetworkInitialSync,
+		StateAction::ExecuteIfPossible,
+		None,
+	);
+	overflow.body = Some(Vec::new());
+	let overflow_hash = overflow.post_hash();
+	let overflow_result = importer.import_block(overflow).await.unwrap();
+	assert!(matches!(overflow_result, ImportResult::Imported(_)));
+	assert_eq!(pending_import_count(&importer).await, PENDING_IMPORTS_ADVISORY_LIMIT + 1);
+	assert_eq!(client.status(overflow_hash).unwrap(), BlockStatus::InChain);
+	assert!(
+		!has_state(&client, overflow_hash),
+		"overflow block should remain deferred header-only"
+	);
+}
+
+#[tokio::test]
+async fn test_defers_notebook_verification_and_replays_full_import() {
+	let (importer, client) = new_importer_with_notary();
+	let parent = client.info().best_hash;
+	client.set_runtime_notebooks(
+		parent,
+		vec![NotebookAuditResult {
+			notary_id: 1,
+			notebook_number: 1,
+			tick: 1,
+			audit_first_failure: None,
+		}],
+	);
+
+	let mut params = create_params(
+		1,
+		parent,
+		1,
+		None,
+		BlockOrigin::NetworkBroadcast,
+		StateAction::Execute,
+		None,
+	);
+	params.body = Some(Vec::new());
+	let block_hash = params.post_hash();
+
+	let start = std::time::Instant::now();
+	let first_result = importer.import_block(params).await.unwrap();
+	let elapsed = start.elapsed();
+	assert!(matches!(first_result, ImportResult::Imported(_)));
+	assert!(
+		elapsed >= std::time::Duration::from_secs(2),
+		"expected notebook defer timeout path to run, got {elapsed:?}",
+	);
+	assert!(
+		elapsed < std::time::Duration::from_secs(5),
+		"notebook defer path should fail fast to avoid long import lock stalls, got {elapsed:?}"
+	);
+	assert!(!has_state(&client, block_hash), "initial import should be header-only");
+	assert_eq!(
+		client.status(block_hash).unwrap(),
+		BlockStatus::InChain,
+		"initial import should store a header-only placeholder",
+	);
+	assert_eq!(pending_import_count(&importer).await, 1);
+
+	client.set_runtime_notebooks(parent, Vec::new());
+	importer.replay_pending_full_imports().await.unwrap();
+
+	assert!(has_state(&client, block_hash), "pending import replay should apply full state");
+	assert_eq!(pending_import_count(&importer).await, 0);
+}
+
+#[tokio::test]
+async fn test_deferred_notebook_import_recovers_after_importer_restart() {
+	let (importer, client) = new_importer_with_notary();
+	let parent = client.info().best_hash;
+	client.set_runtime_notebooks(
+		parent,
+		vec![NotebookAuditResult {
+			notary_id: 1,
+			notebook_number: 1,
+			tick: 1,
+			audit_first_failure: None,
+		}],
+	);
+
+	let mut params = create_params(
+		1,
+		parent,
+		1,
+		None,
+		BlockOrigin::NetworkBroadcast,
+		StateAction::Execute,
+		None,
+	);
+	params.body = Some(Vec::new());
+	let block_hash = params.post_hash();
+
+	let first_result = importer.import_block(params).await.unwrap();
+	assert!(matches!(first_result, ImportResult::Imported(_)));
+	assert!(!has_state(&client, block_hash), "initial import should be header-only");
+	assert_eq!(pending_import_count(&importer).await, 1);
+	drop(importer);
+
+	let importer = new_importer_with_notary_from_client(client.clone());
+	assert_eq!(
+		pending_import_count(&importer).await,
+		1,
+		"deferred queue should survive importer restart",
+	);
+
+	client.set_runtime_notebooks(parent, Vec::new());
+	importer.replay_pending_full_imports().await.unwrap();
+
+	assert!(has_state(&client, block_hash), "replayed import should recover full block state");
+	assert_eq!(pending_import_count(&importer).await, 0);
+}
+
+#[tokio::test]
+async fn test_deferred_notebook_import_stays_pending_when_notary_is_unavailable() {
+	let (importer, client) = new_importer_with_notary();
+	let parent = client.info().best_hash;
+	client.set_runtime_notebooks(
+		parent,
+		vec![NotebookAuditResult {
+			notary_id: 1,
+			notebook_number: 1,
+			tick: 1,
+			audit_first_failure: None,
+		}],
+	);
+
+	let mut params = create_params(
+		1,
+		parent,
+		1,
+		None,
+		BlockOrigin::NetworkBroadcast,
+		StateAction::Execute,
+		None,
+	);
+	params.body = Some(Vec::new());
+	let block_hash = params.post_hash();
+
+	let first_result = importer.import_block(params).await.unwrap();
+	assert!(matches!(first_result, ImportResult::Imported(_)));
+	assert_eq!(pending_import_count(&importer).await, 1);
+	importer.replay_pending_full_imports().await.unwrap();
+
+	assert_eq!(
+		pending_import_count(&importer).await,
+		1,
+		"replay should keep deferred full import queued while notebook audit is unavailable",
+	);
+	assert!(!has_state(&client, block_hash));
+}
+
+#[tokio::test]
+async fn test_imports_with_intermediates_do_not_defer_to_replay_queue() {
+	let (importer, client) = new_importer();
+	let genesis_hash = client.info().best_hash;
+
+	let parent = create_params(
+		1,
+		genesis_hash,
+		1,
+		None,
+		BlockOrigin::NetworkInitialSync,
+		StateAction::Skip,
+		None,
+	);
+	let parent_hash = parent.post_hash();
+	let _ = importer.import_block(parent).await.unwrap();
+	assert!(!has_state(&client, parent_hash));
+
+	let mut child = create_params(
+		2,
+		parent_hash,
+		1,
+		None,
+		BlockOrigin::NetworkBroadcast,
+		StateAction::ExecuteIfPossible,
+		None,
+	);
+	child.body = Some(Vec::new());
+	child.insert_intermediate(b"defer-marker", 1u8);
+	let child_hash = child.post_hash();
+
+	let result = importer.import_block(child).await.unwrap();
+	assert!(matches!(result, ImportResult::MissingState));
+	assert_eq!(pending_import_count(&importer).await, 0);
+	assert_eq!(client.status(child_hash).unwrap(), BlockStatus::Unknown);
+}
+
+#[tokio::test]
+async fn test_justification_upgrade_reimports() {
+	let (importer, client) = new_importer();
+	let parent = client.info().best_hash;
+	let params1 =
+		create_params(1, parent, 1, None, BlockOrigin::NetworkBroadcast, StateAction::Skip, None);
+	let _ = importer.import_block(params1).await.unwrap();
+
+	let mut params2 =
+		create_params(1, parent, 1, None, BlockOrigin::NetworkBroadcast, StateAction::Skip, None);
+	params2.justifications = Some(sp_runtime::Justifications::from(([1, 2, 3, 4], vec![1u8])));
+
+	let res2 = importer.import_block(params2).await.unwrap();
+	assert!(matches!(res2, ImportResult::Imported(_)));
 }

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -47,6 +47,7 @@ pub mod import_queue;
 pub(crate) mod metrics;
 pub(crate) mod notary_client;
 pub(crate) mod notebook_sealer;
+pub(crate) mod pending_import_replay;
 pub mod state_anchor;
 
 pub use notary_client::{NotaryClient, NotebookDownloader, run_notary_sync};

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -248,7 +248,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 	let consensus_metrics_finder = consensus_metrics.clone();
 
 	let block_finder_task = async move {
-		*notary_client.pause_queue_processing.write().await = true;
+		*notary_client.pause_notebook_audits.write().await = true;
 		let mut import_stream = client.every_import_notification_stream();
 		let mut finalized_stream = client.finality_notification_stream();
 		let idle_delay = if ticker.tick_duration_millis <= 10_000 { 100 } else { 1000 };
@@ -333,7 +333,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 
 			// don't try to check for blocks during a sync
 			if sync_oracle.is_major_syncing() {
-				*notary_client.pause_queue_processing.write().await = true;
+				*notary_client.pause_notebook_audits.write().await = true;
 				continue;
 			}
 
@@ -344,7 +344,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 			let state_status =
 				client.block_status(best_hash).unwrap_or(sp_consensus::BlockStatus::Unknown);
 			if state_status != sp_consensus::BlockStatus::InChainWithState {
-				*notary_client.pause_queue_processing.write().await = true;
+				*notary_client.pause_notebook_audits.write().await = true;
 				debug!(
 					?best_hash,
 					?state_status,
@@ -353,13 +353,13 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 				continue;
 			}
 
-			if *notary_client.pause_queue_processing.read().await {
+			if *notary_client.pause_notebook_audits.read().await {
 				info!(
 					?best_hash,
 					?best_number,
 					"🏁 Node state is synched. Activating notary sync."
 				);
-				*notary_client.pause_queue_processing.write().await = false;
+				*notary_client.pause_notebook_audits.write().await = false;
 			}
 
 			let mut notebooks_to_check = notebook_ticks_recheck.get_ready();

--- a/node/consensus/src/mock_importer.rs
+++ b/node/consensus/src/mock_importer.rs
@@ -1,18 +1,22 @@
 use crate::{
+	NotaryClient,
 	aux_client::ArgonAux,
+	error::Error,
 	import_queue::{ArgonBlockImport, ImportApisExt},
+	notary_client::{NotaryApisExt, NotebookDownloader},
 };
+use argon_notary_apis::DownloadTrustMode;
 use argon_primitives::{
 	BlockSealAuthoritySignature, BlockSealDigest, ComputeDifficulty, Digestset, FORK_POWER_DIGEST,
-	HashOutput as BlockHash, NotebookDigest, PARENT_VOTING_KEY_DIGEST, ParentVotingKeyDigest,
-	VotingKey,
+	HashOutput as BlockHash, NotebookAuditResult, NotebookDigest, PARENT_VOTING_KEY_DIGEST,
+	ParentVotingKeyDigest, VotingKey,
 	fork_power::ForkPower,
 	prelude::{
 		sp_runtime::{generic::SignedBlock, traits::BlakeTwo256},
 		*,
 	},
 };
-use argon_runtime::NotebookVerifyError;
+use argon_runtime::{NotaryRecordT, NotebookVerifyError};
 use async_trait::async_trait;
 use codec::Encode;
 use polkadot_sdk::{
@@ -24,7 +28,7 @@ use sc_client_api::{BlockBackend, backend::AuxStore};
 use sc_consensus::{
 	BlockCheckParams, BlockImportParams, ImportResult, ImportedAux, StateAction, StateAction::*,
 };
-use sp_blockchain::{BlockGap, BlockStatus, Error as BlockchainError, HeaderBackend};
+use sp_blockchain::{BlockStatus, Error as BlockchainError, HeaderBackend};
 use sp_consensus::{BlockOrigin, Error as ConsensusError};
 use sp_runtime::{
 	Digest, OpaqueExtrinsic as UncheckedExtrinsic, generic,
@@ -34,6 +38,12 @@ use std::{
 	collections::{BTreeMap, HashMap},
 	sync::{Arc, Mutex},
 };
+
+impl<B: BlockT, I, C: AuxStore, AC> ArgonBlockImport<B, I, C, AC> {
+	pub(crate) async fn pending_import_count_for_tests(&self) -> usize {
+		self.pending_full_imports_len().await
+	}
+}
 // -------------------------------------------
 // Tiny in–memory client & mini importer
 // -------------------------------------------
@@ -42,7 +52,9 @@ use std::{
 pub(crate) struct MemChain {
 	headers: Arc<Mutex<HashMap<BlockHash, Header>>>,
 	block_state: Arc<Mutex<HashMap<BlockHash, sp_consensus::BlockStatus>>>,
-	block_gap: Arc<Mutex<Option<BlockGap<BlockNumber>>>>,
+	runtime_notebooks:
+		Arc<Mutex<HashMap<BlockHash, Vec<NotebookAuditResult<NotebookVerifyError>>>>>,
+	block_gap: Arc<Mutex<Option<sp_blockchain::BlockGap<BlockNumber>>>>,
 	genesis_hash: BlockHash,
 	best: Arc<Mutex<(BlockNumber, BlockHash)>>,
 	finalized: Arc<Mutex<(BlockNumber, BlockHash)>>,
@@ -56,6 +68,7 @@ impl MemChain {
 			block_state: Arc::new(Mutex::new(
 				[(h, sp_consensus::BlockStatus::InChainWithState)].into(),
 			)),
+			runtime_notebooks: Arc::new(Mutex::new(HashMap::new())),
 			block_gap: Arc::new(Mutex::new(None)),
 			genesis_hash: h,
 			best: Arc::new(Mutex::new((0u32, h))),
@@ -75,12 +88,21 @@ impl MemChain {
 	pub(crate) fn set_state(&self, h: BlockHash, state: sp_consensus::BlockStatus) {
 		self.block_state.lock().unwrap().insert(h, state);
 	}
+
+	pub(crate) fn set_runtime_notebooks(
+		&self,
+		parent_hash: BlockHash,
+		notebooks: Vec<NotebookAuditResult<NotebookVerifyError>>,
+	) {
+		self.runtime_notebooks.lock().unwrap().insert(parent_hash, notebooks);
+	}
+
 	pub(crate) fn force_best(&self, best_number: BlockNumber, best_hash: BlockHash) {
 		*self.best.lock().unwrap() = (best_number, best_hash);
 	}
 
-	pub(crate) fn set_block_gap(&self, gap: Option<BlockGap<BlockNumber>>) {
-		*self.block_gap.lock().unwrap() = gap;
+	pub(crate) fn set_block_gap(&self, block_gap: Option<sp_blockchain::BlockGap<BlockNumber>>) {
+		*self.block_gap.lock().unwrap() = block_gap;
 	}
 }
 impl HeaderBackend<Block> for MemChain {
@@ -90,14 +112,13 @@ impl HeaderBackend<Block> for MemChain {
 	fn info(&self) -> sp_blockchain::Info<Block> {
 		let best = *self.best.lock().unwrap();
 		let fin = *self.finalized.lock().unwrap();
-		let block_gap = *self.block_gap.lock().unwrap();
 		sp_blockchain::Info {
 			finalized_hash: fin.1,
 			finalized_number: fin.0,
 			finalized_state: None,
 			best_hash: best.1,
 			best_number: best.0,
-			block_gap,
+			block_gap: *self.block_gap.lock().unwrap(),
 			genesis_hash: self.genesis_hash,
 			number_leaves: 0,
 		}
@@ -125,13 +146,104 @@ impl HeaderBackend<Block> for MemChain {
 	}
 }
 
-impl ImportApisExt<Block> for MemChain {
+impl ImportApisExt<Block, H256> for MemChain {
 	fn has_new_bitcoin_tip(&self, _hash: BlockHash) -> bool {
 		false
 	}
 
 	fn has_new_price_index(&self, _hash: BlockHash) -> bool {
 		false
+	}
+
+	fn runtime_digest_notebooks(
+		&self,
+		parent_hash: BlockHash,
+		_digest: &sp_runtime::Digest,
+	) -> Result<Vec<NotebookAuditResult<NotebookVerifyError>>, Error> {
+		Ok(self
+			.runtime_notebooks
+			.lock()
+			.unwrap()
+			.get(&parent_hash)
+			.cloned()
+			.unwrap_or_default())
+	}
+}
+
+impl NotaryApisExt<Block, H256> for MemChain {
+	fn has_block_state(&self, block_hash: BlockHash) -> bool {
+		matches!(self.block_status(block_hash), Ok(sp_consensus::BlockStatus::InChainWithState))
+	}
+
+	fn notaries(&self, _block_hash: BlockHash) -> Result<Vec<NotaryRecordT>, Error> {
+		Ok(Vec::new())
+	}
+
+	fn latest_notebook_by_notary(
+		&self,
+		_block_hash: BlockHash,
+	) -> Result<
+		BTreeMap<
+			argon_primitives::NotaryId,
+			(argon_primitives::notebook::NotebookNumber, argon_primitives::tick::Tick),
+		>,
+		Error,
+	> {
+		Ok(BTreeMap::new())
+	}
+
+	fn current_tick(&self, _block_hash: BlockHash) -> Result<argon_primitives::tick::Tick, Error> {
+		Ok(0)
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	fn audit_notebook_and_get_votes(
+		&self,
+		_block_hash: BlockHash,
+		_version: u32,
+		_notary_id: argon_primitives::NotaryId,
+		_notebook_number: argon_primitives::notebook::NotebookNumber,
+		_notebook_tick: argon_primitives::tick::Tick,
+		_header_hash: H256,
+		_notebook: &[u8],
+		_notebook_dependencies: Vec<argon_primitives::notary::NotaryNotebookAuditSummary>,
+		_block_hashes: &[BlockHash],
+	) -> Result<Result<argon_primitives::notary::NotaryNotebookRawVotes, NotebookVerifyError>, Error>
+	{
+		Err(Error::StringError("not used in import queue unit tests".into()))
+	}
+
+	fn vote_minimum(&self, _block_hash: BlockHash) -> Result<argon_primitives::VoteMinimum, Error> {
+		Err(Error::StringError("not used in import queue unit tests".into()))
+	}
+
+	fn decode_signed_raw_notebook_header(
+		&self,
+		_block_hash: &BlockHash,
+		_raw_header: Vec<u8>,
+	) -> Result<
+		Result<
+			argon_primitives::notary::NotaryNotebookDetails<BlockHash>,
+			sp_runtime::DispatchError,
+		>,
+		Error,
+	> {
+		Err(Error::StringError("not used in import queue unit tests".into()))
+	}
+
+	fn best_hash(&self) -> BlockHash {
+		self.info().best_hash
+	}
+
+	fn finalized_hash(&self) -> BlockHash {
+		self.info().finalized_hash
+	}
+
+	fn parent_hash(&self, hash: &BlockHash) -> Result<BlockHash, Error> {
+		let header = self
+			.header(*hash)?
+			.ok_or_else(|| Error::StringError("Parent not found".into()))?;
+		Ok(*header.parent_hash())
 	}
 }
 
@@ -341,13 +453,51 @@ fn create_digest(
 pub(crate) fn new_importer() -> (ArgonBlockImport<Block, MemChain, MemChain, H256>, MemChain) {
 	let genesis = Header::new(0, H256::zero(), H256::zero(), H256::zero(), Digest::default());
 	let client = MemChain::new(genesis.clone());
+	let importer = new_importer_from_client(client.clone());
+	(importer, client)
+}
+
+pub(crate) fn new_importer_with_notary()
+-> (ArgonBlockImport<Block, MemChain, MemChain, H256>, MemChain) {
+	let genesis = Header::new(0, H256::zero(), H256::zero(), H256::zero(), Digest::default());
+	let client = MemChain::new(genesis.clone());
+	let importer = new_importer_with_notary_from_client(client.clone());
+	(importer, client)
+}
+
+pub(crate) fn new_importer_from_client(
+	client: MemChain,
+) -> ArgonBlockImport<Block, MemChain, MemChain, H256> {
 	let db_arc = Arc::new(client.clone());
-	let importer = ArgonBlockImport::<Block, _, _, _>::new_for_tests(
-		client.clone(),
+	let notary_client = new_notary_client_for_tests(&db_arc);
+	ArgonBlockImport::<Block, _, _, _>::new_with_components(
+		client,
 		db_arc.clone(),
 		ArgonAux::new(db_arc.clone()),
-	);
-	(importer, client)
+		notary_client,
+		Arc::new(None),
+	)
+}
+
+pub(crate) fn new_importer_with_notary_from_client(
+	client: MemChain,
+) -> ArgonBlockImport<Block, MemChain, MemChain, H256> {
+	new_importer_from_client(client)
+}
+
+fn new_notary_client_for_tests(client: &Arc<MemChain>) -> Arc<NotaryClient<Block, MemChain, H256>> {
+	let notebook_downloader =
+		NotebookDownloader::new(Vec::<String>::new(), DownloadTrustMode::Dev, None, None)
+			.expect("notebook downloader should initialize");
+	let ticker = argon_primitives::tick::Ticker::new(2_000, 2);
+	Arc::new(NotaryClient::new(
+		client.clone(),
+		ArgonAux::new(client.clone()),
+		notebook_downloader,
+		Arc::new(None),
+		ticker,
+		true,
+	))
 }
 
 pub(crate) fn create_params(
@@ -367,4 +517,10 @@ pub(crate) fn create_params(
 	params.post_digests.push(post_digest);
 	params.post_hash = Some(header.hash());
 	params
+}
+
+pub(crate) async fn pending_import_count(
+	importer: &ArgonBlockImport<Block, MemChain, MemChain, H256>,
+) -> usize {
+	importer.pending_import_count_for_tests().await
 }

--- a/node/consensus/src/mock_importer.rs
+++ b/node/consensus/src/mock_importer.rs
@@ -37,6 +37,7 @@ use sp_runtime::{
 use std::{
 	collections::{BTreeMap, HashMap},
 	sync::{Arc, Mutex},
+	time::Duration,
 };
 
 impl<B: BlockT, I, C: AuxStore, AC> ArgonBlockImport<B, I, C, AC> {
@@ -496,6 +497,8 @@ fn new_notary_client_for_tests(client: &Arc<MemChain>) -> Arc<NotaryClient<Block
 		notebook_downloader,
 		Arc::new(None),
 		ticker,
+		None,
+		Duration::from_millis(250),
 		true,
 	))
 }

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -56,6 +56,7 @@ use tracing::error;
 const MAX_PARALLEL_NOTARY_DOWNLOADS: usize = 8;
 const MAX_PARALLEL_NOTARY_AUDITS: usize = 4;
 const HEADER_PREFETCH_WINDOW: usize = MAX_PARALLEL_NOTARY_DOWNLOADS;
+const MAX_NOTEBOOK_SUBSCRIPTION_TICK_LAG: Tick = 2;
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
@@ -605,6 +606,8 @@ struct NotaryWorker {
 	archive_host: RwLock<Option<String>>,
 	subscription: Mutex<Option<Pin<Box<RawHeadersSubscription>>>>,
 	pending: Mutex<NotebookAuditState>,
+	last_notebook_tick: RwLock<Option<Tick>>,
+	last_connection_attempt_tick: RwLock<Option<Tick>>,
 	connection_lock: Arc<Mutex<()>>,
 	processing_lock: Arc<Mutex<()>>,
 	background_task_started: AtomicBool,
@@ -619,6 +622,8 @@ impl NotaryWorker {
 			archive_host: Default::default(),
 			subscription: Default::default(),
 			pending: Default::default(),
+			last_notebook_tick: Default::default(),
+			last_connection_attempt_tick: Default::default(),
 			connection_lock: Arc::new(Mutex::new(())),
 			processing_lock: Arc::new(Mutex::new(())),
 			background_task_started: AtomicBool::new(false),
@@ -688,6 +693,7 @@ impl NotaryWorker {
 		let _connection_guard = self.connection_lock.lock().await;
 		self.client.write().await.take();
 		self.clear_subscription().await;
+		self.last_notebook_tick.write().await.take();
 	}
 
 	async fn has_client(&self) -> bool {
@@ -698,7 +704,7 @@ impl NotaryWorker {
 		self.subscription.lock().await.is_some()
 	}
 
-	async fn ensure_connected_subscription(&self) -> Result<(), Error> {
+	async fn ensure_connected_subscription(&self, current_tick: Tick) -> Result<(), Error> {
 		let _connection_guard = self.connection_lock.lock().await;
 		let can_connect = {
 			let record = self.record.read().await;
@@ -712,16 +718,54 @@ impl NotaryWorker {
 		}
 
 		let notary_id = self.notary_id;
-		if !self.has_client().await {
+		let needs_client = !self.has_client().await;
+		let needs_subscription = !self.has_subscription().await;
+		if !needs_client && !needs_subscription {
+			return Ok(());
+		}
+
+		{
+			let mut last_connection_attempt_tick = self.last_connection_attempt_tick.write().await;
+			if *last_connection_attempt_tick == Some(current_tick) {
+				trace!(
+					"Skipping notary connection attempt. notary_id={notary_id} current_tick={current_tick}"
+				);
+				return Ok(());
+			}
+			*last_connection_attempt_tick = Some(current_tick);
+		}
+
+		if needs_client {
 			info!("Connecting to notary id={notary_id}");
 			self.connect().await?;
 		}
 
-		if !self.has_subscription().await {
+		if needs_subscription {
 			self.subscribe().await?;
 		}
 
 		Ok(())
+	}
+
+	async fn disconnect_if_subscription_stale(&self, current_tick: Tick) {
+		if !self.has_subscription().await {
+			return;
+		}
+
+		let Some(last_notebook_tick) = *self.last_notebook_tick.read().await else {
+			return;
+		};
+
+		let tick_lag = current_tick.saturating_sub(last_notebook_tick);
+		if tick_lag <= MAX_NOTEBOOK_SUBSCRIPTION_TICK_LAG {
+			return;
+		}
+
+		warn!(
+			"Disconnecting stale notary subscription. notary_id={} last_notebook_tick={last_notebook_tick} current_tick={current_tick} tick_lag={tick_lag}",
+			self.notary_id,
+		);
+		self.clear_connection().await;
 	}
 
 	async fn poll_subscription<B, C, AC>(
@@ -741,6 +785,7 @@ impl NotaryWorker {
 
 		match next {
 			Poll::Ready(Some(Ok(download_info))) => {
+				*self.last_notebook_tick.write().await = Some(download_info.tick);
 				if let Some(metrics) = worker_context.metrics.as_ref() {
 					metrics.notebook_notification_received(
 						self.notary_id,
@@ -792,7 +837,20 @@ impl NotaryWorker {
 			self.clear_subscription().await;
 			return Ok(false);
 		}
-		self.ensure_connected_subscription().await?;
+		let current_tick = if let Some(block_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			worker_context.client.as_ref(),
+			worker_context.client.best_hash(),
+		)? {
+			Some(worker_context.client.current_tick(block_hash)?)
+		} else {
+			None
+		};
+		if let Some(current_tick) = current_tick {
+			self.disconnect_if_subscription_stale(current_tick).await;
+			self.ensure_connected_subscription(current_tick).await?;
+		} else if !self.has_client().await || !self.has_subscription().await {
+			return Ok(false);
+		}
 		let saw_subscription = self.poll_subscription(worker_context).await.is_some();
 		let has_more_work = self.process_background_work(worker_context).await;
 		Ok(saw_subscription || has_more_work)
@@ -848,6 +906,7 @@ impl NotaryWorker {
 		})?;
 		*self.archive_host.write().await = Some(archive_host);
 		if notebook_meta.last_closed_notebook_number > 0 {
+			*self.last_notebook_tick.write().await = Some(notebook_meta.last_closed_notebook_tick);
 			trace!(
 				"Tracking latest notebook {} for notary {}",
 				notebook_meta.last_closed_notebook_number, self.notary_id
@@ -1472,6 +1531,7 @@ where
 			return Ok(());
 		};
 		let notaries = self.worker_context.client.notaries(block_hash)?;
+		let current_tick = self.worker_context.client.current_tick(block_hash)?;
 		let active_ids = notaries.iter().map(|notary| notary.notary_id).collect::<BTreeSet<_>>();
 		let existing_workers = self
 			.workers_by_id
@@ -1521,10 +1581,11 @@ where
 				continue;
 			}
 
+			worker.disconnect_if_subscription_stale(current_tick).await;
 			let is_connected = worker.has_client().await && worker.has_subscription().await;
 
 			if !is_connected || host_changed {
-				if let Err(e) = worker.ensure_connected_subscription().await {
+				if let Err(e) = worker.ensure_connected_subscription(current_tick).await {
 					self.disconnect(
 						&notary_id,
 						Some(format!("Notary {notary_id} sync failed. {e:?}")),
@@ -2517,7 +2578,16 @@ mod test {
 		assert!(!has_worker_client(&notary_client, 1).await);
 		assert!(!has_worker_subscription(&notary_client, 1).await);
 
-		// Periodic notary refreshes reuse the same best hash when no new block has arrived.
+		// Periodic notary refreshes reuse the same best hash when no new block has arrived,
+		// but connection attempts are limited to once per tick.
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not refresh notaries");
+		assert!(!has_worker_client(&notary_client, 1).await);
+		assert!(!has_worker_subscription(&notary_client, 1).await);
+
+		*client.current_tick.lock() = 1;
 		notary_client
 			.update_notaries(&client.best_hash())
 			.await
@@ -2530,6 +2600,63 @@ mod test {
 			.await
 			.expect("worker should resubscribe without a new block");
 		assert_eq!(next, (1, 1));
+	}
+
+	#[tokio::test]
+	async fn disconnects_stale_worker_subscription_after_missing_ticks() {
+		let (mut test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		test_notary.create_notebook_header(vec![]).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500)).await.unwrap();
+		assert_eq!(next, (1, 1));
+
+		let worker = worker(&notary_client, 1).await.expect("worker should exist");
+		assert_eq!(*worker.last_notebook_tick.read().await, Some(1));
+
+		*client.current_tick.lock() = 3;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert_eq!(*worker.last_notebook_tick.read().await, Some(1));
+		assert!(worker.has_client().await);
+		assert!(worker.has_subscription().await);
+
+		test_notary.stop().await;
+		*client.current_tick.lock() = 4;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		assert_eq!(*worker.last_notebook_tick.read().await, None);
+		assert!(!worker.has_client().await);
+		assert!(!worker.has_subscription().await);
+		assert_eq!(*worker.last_connection_attempt_tick.read().await, Some(4));
+
+		test_notary.start().await.expect("could not restart notary");
+		client.notaries.lock()[0].meta.hosts = bounded_vec![test_notary.addr.clone().into()];
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		assert!(!worker.has_client().await);
+		assert!(!worker.has_subscription().await);
+
+		*client.current_tick.lock() = 5;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		assert_eq!(*worker.last_connection_attempt_tick.read().await, Some(5));
+		assert!(worker.has_client().await);
+		assert!(worker.has_subscription().await);
 	}
 
 	#[tokio::test]
@@ -2880,6 +3007,7 @@ mod test {
 		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 
 		*notary_client.pause_notebook_audits.write().await = false;
+		*client.current_tick.lock() = 1;
 		notary_client
 			.update_notaries(&client.best_hash())
 			.await

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -877,7 +877,7 @@ impl NotaryWorker {
 		let idle_delay = background_idle_delay;
 
 		spawn_handle.spawn("notary_worker_task", "notary_worker", async move {
-			let mut delay = idle_delay;
+			let mut delay = Duration::ZERO;
 			loop {
 				time::sleep(delay).await;
 				delay = match worker.run_background_pass(worker_context.as_ref()).await {
@@ -2708,7 +2708,6 @@ mod test {
 
 		// still missing number 9
 		assert!(matches!(result, Error::MissingNotebooksError(_)),);
-		println!("result: {result}");
 		assert!(result.to_string().contains("#9..=9"));
 
 		for _ in 0..9 {
@@ -2986,7 +2985,7 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn paused_queue_processing_drops_subscription_backlog() {
+	async fn paused_notebook_audits_disable_subscriptions_until_resumed() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
 			.update_notaries(&client.best_hash())

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -1,8 +1,6 @@
 use crate::{
-	aux_client::ArgonAux,
-	error::Error,
-	metrics::ConsensusMetrics,
-	state_anchor::{DEFAULT_STATE_LOOKBACK_DEPTH, StateAnchorClient},
+	aux_client::ArgonAux, error::Error, metrics::ConsensusMetrics,
+	state_anchor::DEFAULT_STATE_LOOKBACK_DEPTH,
 };
 use argon_notary_apis::{
 	ArchiveHost, Client, DownloadKind, DownloadPolicy, DownloadTrustMode, SystemRpcClient,
@@ -25,7 +23,6 @@ use codec::Codec;
 use futures::{Stream, StreamExt, future::join_all, task::noop_waker_ref};
 use log::{info, trace, warn};
 use polkadot_sdk::*;
-use rand::prelude::SliceRandom;
 use sc_client_api::{AuxStore, BlockchainEvents};
 use sc_service::TaskManager;
 use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender, tracing_unbounded};
@@ -42,18 +39,23 @@ use std::{
 	marker::PhantomData,
 	ops::Range,
 	pin::Pin,
-	sync::Arc,
+	sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	},
 	task::{Context, Poll},
 	time::{Duration, Instant},
 };
 use substrate_prometheus_endpoint::Registry;
 use tokio::{
-	sync::{Mutex, RwLock},
+	sync::{Mutex, RwLock, Semaphore},
 	time,
 };
 use tracing::error;
 
-const MAX_QUEUE_DEPTH: usize = 1440 * 2; // a notary can be down 2 days before we start dropping history
+const MAX_PARALLEL_NOTARY_DOWNLOADS: usize = 8;
+const MAX_PARALLEL_NOTARY_AUDITS: usize = 4;
+const HEADER_PREFETCH_WINDOW: usize = MAX_PARALLEL_NOTARY_DOWNLOADS;
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
@@ -208,10 +210,11 @@ where
 		notebook_downloader,
 		metrics,
 		ticker,
+		Some(task_manager.spawn_handle()),
+		Duration::from_millis(no_work_delay_millis),
 		is_solving_blocks,
 	));
 
-	let notary_client_clone = Arc::clone(&notary_client);
 	let notary_client_poll = Arc::clone(&notary_client);
 	let best_block = client.best_hash();
 	let notary_sync_task = async move {
@@ -244,9 +247,6 @@ where
 
 		loop {
 			tokio::select! {
-				Some((notary_id, notebook_number)) =  notary_client_poll.poll_subscriptions() => {
-					trace!( "Next notebook pushed (notary {notary_id}, notebook {notebook_number})");
-				},
 				Some(ref block) = best_block.next() => {
 					if block.is_new_best {
 						let best_hash = block.hash;
@@ -288,645 +288,754 @@ where
 			}
 		}
 	};
-
-	let notary_queue_task = async move {
-		let notary_client = notary_client_clone;
-		loop {
-			let has_more_work = notary_client
-				.process_queues(None)
-				.await
-				.inspect_err(|err| {
-					warn!("Error while processing notary queues: {err:?}");
-				})
-				.unwrap_or(false);
-
-			let mut delay = 20;
-			if !has_more_work {
-				delay = no_work_delay_millis
-			}
-			tokio::time::sleep(Duration::from_millis(delay)).await;
-		}
-	};
 	let handle = task_manager.spawn_essential_handle();
 	handle.spawn("notary_sync_task", "notary_sync", notary_sync_task);
-	// Making this blocking due to the runtime calls and potentially heavy decodes
-	handle.spawn_blocking("notary_queue_task", "notary_queue", notary_queue_task);
 
 	notary_client
 }
 
-type PendingNotebook = (NotebookNumber, Option<SignedHeaderBytes>, Instant);
+type WorkerHandle = Arc<NotaryWorker>;
+type WorkersById = Arc<RwLock<BTreeMap<NotaryId, WorkerHandle>>>;
 type ProcessingHashes<Hash> = (Hash, Hash);
 
 type NotebookCount = u32;
 pub type VotingPowerInfo = (Tick, BlockVotingPower, NotebookCount);
 
-pub struct NotaryClient<B: BlockT, C: AuxStore, AC> {
+struct MissingAuditCatchup {
+	by_notary: BTreeMap<NotaryId, Vec<NotebookNumber>>,
+	needs_notary_updates: bool,
+}
+
+struct NotebookAuditTarget {
+	notebook_number: NotebookNumber,
+	header_bytes: Option<SignedHeaderBytes>,
+	known_since: Instant,
+}
+
+struct NotebookAuditSelection {
+	target: Option<NotebookAuditTarget>,
+	finalized_notebooks_trimmed: u32,
+	tracked_range: Range<NotebookNumber>,
+}
+
+#[derive(Default)]
+struct NotebookAuditState {
+	next_notebook_number: Option<NotebookNumber>,
+	highest_notebook_number: Option<NotebookNumber>,
+	known_since_by_notebook: BTreeMap<NotebookNumber, Instant>,
+	cached_headers: BTreeMap<NotebookNumber, SignedHeaderBytes>,
+}
+
+impl NotebookAuditState {
+	fn track_notebook(
+		&mut self,
+		notebook_number: NotebookNumber,
+		header_bytes: Option<SignedHeaderBytes>,
+		known_since: Option<Instant>,
+	) {
+		let known_since = known_since.unwrap_or_else(Instant::now);
+		match self.bounds() {
+			Some((next_notebook_number, highest_notebook_number)) => {
+				if notebook_number < next_notebook_number {
+					self.record_known_range(notebook_number, next_notebook_number - 1, known_since);
+					self.next_notebook_number = Some(notebook_number);
+				}
+
+				if notebook_number > highest_notebook_number {
+					self.record_known_range(
+						highest_notebook_number + 1,
+						notebook_number,
+						known_since,
+					);
+					self.highest_notebook_number = Some(notebook_number);
+				}
+			},
+			None => self.initialize(notebook_number, notebook_number, known_since),
+		}
+
+		if let Some(header_bytes) = header_bytes {
+			self.cached_headers.entry(notebook_number).or_insert(header_bytes);
+		}
+	}
+
+	fn track_range(
+		&mut self,
+		first_notebook_number: NotebookNumber,
+		last_notebook_number: NotebookNumber,
+	) {
+		let known_since = Instant::now();
+		if first_notebook_number > last_notebook_number {
+			return;
+		}
+
+		match self.bounds() {
+			Some((next_notebook_number, highest_notebook_number)) => {
+				if first_notebook_number < next_notebook_number {
+					self.record_known_range(
+						first_notebook_number,
+						next_notebook_number - 1,
+						known_since,
+					);
+					self.next_notebook_number = Some(first_notebook_number);
+				}
+				if last_notebook_number > highest_notebook_number {
+					self.record_known_range(
+						highest_notebook_number + 1,
+						last_notebook_number,
+						known_since,
+					);
+					self.highest_notebook_number = Some(last_notebook_number);
+				}
+			},
+			None => self.initialize(first_notebook_number, last_notebook_number, known_since),
+		}
+	}
+
+	fn clear(&mut self) {
+		self.next_notebook_number = None;
+		self.highest_notebook_number = None;
+		self.known_since_by_notebook.clear();
+		self.cached_headers.clear();
+	}
+
+	fn len(&self) -> usize {
+		match self.bounds() {
+			Some((next, highest)) if highest >= next => (highest - next + 1) as usize,
+			_ => 0,
+		}
+	}
+
+	fn range(&self) -> Range<NotebookNumber> {
+		match self.bounds() {
+			Some((start, end)) => Range { start, end },
+			_ => 0..0,
+		}
+	}
+
+	#[cfg(test)]
+	fn snapshot(&self) -> Vec<(NotebookNumber, bool)> {
+		let Some((next, highest)) = self.bounds() else {
+			return Vec::new();
+		};
+
+		(next..=highest)
+			.map(|number| {
+				let has_header = self.cached_headers.contains_key(&number);
+				(number, has_header)
+			})
+			.collect()
+	}
+
+	fn rewind_to(&mut self, notebook_number: NotebookNumber) {
+		let known_since = Instant::now();
+		match self.bounds() {
+			Some((next_notebook_number, highest_notebook_number)) => {
+				if notebook_number < next_notebook_number {
+					self.record_known_range(notebook_number, next_notebook_number - 1, known_since);
+					self.next_notebook_number = Some(notebook_number);
+				} else if notebook_number > highest_notebook_number {
+					self.record_known_range(
+						highest_notebook_number + 1,
+						notebook_number,
+						known_since,
+					);
+					self.highest_notebook_number = Some(notebook_number);
+				}
+			},
+			None => self.initialize(notebook_number, notebook_number, known_since),
+		}
+		self.cached_headers.remove(&notebook_number);
+	}
+
+	fn prefetch_targets(&self, window: usize) -> Vec<NotebookNumber> {
+		let Some((next, highest)) = self.bounds() else {
+			return Vec::new();
+		};
+		if highest <= next {
+			return Vec::new();
+		}
+
+		let last = highest.min(next.saturating_add(window as NotebookNumber));
+		((next + 1)..=last)
+			.filter(|number| !self.cached_headers.contains_key(number))
+			.collect()
+	}
+
+	fn cache_header(&mut self, notebook_number: NotebookNumber, header_bytes: SignedHeaderBytes) {
+		let Some((next, highest)) = self.bounds() else {
+			return;
+		};
+		if notebook_number < next || notebook_number > highest {
+			return;
+		}
+
+		self.cached_headers.entry(notebook_number).or_insert(header_bytes);
+	}
+
+	fn select_next_audit(
+		&mut self,
+		finalized_notebook_number: NotebookNumber,
+	) -> NotebookAuditSelection {
+		let tracked_range = self.range();
+		let Some((mut next, highest)) = self.bounds() else {
+			return NotebookAuditSelection {
+				target: None,
+				finalized_notebooks_trimmed: 0,
+				tracked_range,
+			};
+		};
+
+		let mut finalized_notebooks_trimmed = 0;
+		if next <= finalized_notebook_number {
+			let new_next = finalized_notebook_number.saturating_add(1);
+			if new_next > highest {
+				finalized_notebooks_trimmed = highest - next + 1;
+				self.clear();
+				return NotebookAuditSelection {
+					target: None,
+					finalized_notebooks_trimmed,
+					tracked_range,
+				};
+			}
+
+			finalized_notebooks_trimmed = new_next - next;
+			next = new_next;
+			self.advance_to(new_next);
+		}
+
+		NotebookAuditSelection {
+			target: Some(NotebookAuditTarget {
+				notebook_number: next,
+				header_bytes: self.cached_headers.get(&next).cloned(),
+				known_since: self.known_since(next),
+			}),
+			finalized_notebooks_trimmed,
+			tracked_range,
+		}
+	}
+
+	fn bounds(&self) -> Option<(NotebookNumber, NotebookNumber)> {
+		Some((self.next_notebook_number?, self.highest_notebook_number?))
+	}
+
+	fn initialize(
+		&mut self,
+		first_notebook_number: NotebookNumber,
+		last_notebook_number: NotebookNumber,
+		known_since: Instant,
+	) {
+		self.next_notebook_number = Some(first_notebook_number);
+		self.highest_notebook_number = Some(last_notebook_number);
+		self.known_since_by_notebook.clear();
+		self.known_since_by_notebook.insert(first_notebook_number, known_since);
+	}
+
+	fn mark_processed(&mut self, notebook_number: NotebookNumber) {
+		if self.next_notebook_number != Some(notebook_number) {
+			return;
+		}
+
+		let Some(highest_notebook_number) = self.highest_notebook_number else {
+			return;
+		};
+		self.cached_headers.remove(&notebook_number);
+		if notebook_number >= highest_notebook_number {
+			self.clear();
+			return;
+		}
+		self.advance_to(notebook_number + 1);
+	}
+
+	fn advance_to(&mut self, next_notebook_number: NotebookNumber) {
+		let Some(highest_notebook_number) = self.highest_notebook_number else {
+			return;
+		};
+		if next_notebook_number > highest_notebook_number {
+			self.clear();
+			return;
+		}
+
+		let known_since = self.known_since(next_notebook_number);
+		self.next_notebook_number = Some(next_notebook_number);
+		self.cached_headers.retain(|number, _| *number >= next_notebook_number);
+		self.known_since_by_notebook.retain(|number, _| *number >= next_notebook_number);
+		self.known_since_by_notebook.insert(next_notebook_number, known_since);
+	}
+
+	fn record_known_range(
+		&mut self,
+		first_notebook_number: NotebookNumber,
+		last_notebook_number: NotebookNumber,
+		known_since: Instant,
+	) {
+		if first_notebook_number > last_notebook_number {
+			return;
+		}
+		self.known_since_by_notebook.entry(first_notebook_number).or_insert(known_since);
+	}
+
+	fn known_since(&self, notebook_number: NotebookNumber) -> Instant {
+		self.known_since_by_notebook
+			.range(..=notebook_number)
+			.next_back()
+			.map(|(_, known_since)| *known_since)
+			.unwrap_or_else(Instant::now)
+	}
+}
+
+struct WorkerContext<B: BlockT, C: AuxStore, AC> {
 	client: Arc<C>,
-	pub notary_client_by_id: Arc<RwLock<BTreeMap<NotaryId, Arc<Client>>>>,
-	pub notary_archive_host_by_id: Arc<RwLock<BTreeMap<NotaryId, String>>>,
-	pub notaries_by_id: Arc<RwLock<BTreeMap<NotaryId, NotaryRecordT>>>,
-	pub subscriptions_by_id: Arc<RwLock<BTreeMap<NotaryId, Pin<Box<RawHeadersSubscription>>>>>,
-	tick_voting_power_sender: Arc<Mutex<TracingUnboundedSender<VotingPowerInfo>>>,
-	pub tick_voting_power_receiver: Arc<Mutex<TracingUnboundedReceiver<VotingPowerInfo>>>,
-	notebook_queue_by_id: Arc<RwLock<BTreeMap<NotaryId, Vec<PendingNotebook>>>>,
 	aux_client: ArgonAux<B, C>,
 	notebook_downloader: NotebookDownloader,
-	pub(crate) metrics: Arc<Option<ConsensusMetrics<C>>>,
-	pub pause_queue_processing: Arc<RwLock<bool>>,
+	metrics: Arc<Option<ConsensusMetrics<C>>>,
+	pause_notebook_audits: Arc<RwLock<bool>>,
 	ticker: Ticker,
-	queue_lock: Arc<Mutex<()>>,
-	_block: PhantomData<AC>,
+	tick_voting_power_sender: Arc<Mutex<TracingUnboundedSender<VotingPowerInfo>>>,
+	download_slots: Arc<Semaphore>,
+	audit_slots: Arc<Semaphore>,
 	is_solving_blocks: bool,
+	_phantom: PhantomData<AC>,
 }
 
-impl<B, C, AC> StateAnchorClient<B::Hash> for NotaryClient<B, C, AC>
-where
-	B: BlockT,
-	C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
-	AC: Clone + Codec + Send + Sync + 'static,
-{
-	type Error = Error;
-
-	fn has_block_state(&self, hash: B::Hash) -> bool {
-		self.client.has_block_state(hash)
-	}
-
-	fn parent_hash(&self, hash: &B::Hash) -> Result<Option<B::Hash>, Self::Error> {
-		match self.client.parent_hash(hash) {
-			Ok(parent_hash) => Ok(Some(parent_hash)),
-			Err(Error::BlockNotFound(_)) => Ok(None),
-			Err(error) => Err(error),
-		}
-	}
+/// Owns the per-notary connection state and tracked notebook audits so stalls stay local.
+struct NotaryWorker {
+	notary_id: NotaryId,
+	record: RwLock<Option<NotaryRecordT>>,
+	client: RwLock<Option<Arc<Client>>>,
+	archive_host: RwLock<Option<String>>,
+	subscription: Mutex<Option<Pin<Box<RawHeadersSubscription>>>>,
+	pending: Mutex<NotebookAuditState>,
+	connection_lock: Arc<Mutex<()>>,
+	processing_lock: Arc<Mutex<()>>,
+	background_task_started: AtomicBool,
 }
 
-impl<B, C, AC> NotaryClient<B, C, AC>
-where
-	B: BlockT,
-	C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
-	AC: Clone + Codec + Send + Sync + 'static,
-{
-	pub fn new(
-		client: Arc<C>,
-		aux_client: ArgonAux<B, C>,
-		notebook_downloader: NotebookDownloader,
-		metrics: Arc<Option<ConsensusMetrics<C>>>,
-		ticker: Ticker,
-		is_solving_blocks: bool,
-	) -> Self {
-		let (tick_voting_power_sender, tick_voting_power_receiver) =
-			tracing_unbounded("node::consensus::notebook_tick_stream", 100);
-
+impl NotaryWorker {
+	fn new(notary_id: NotaryId) -> Self {
 		Self {
-			client,
-			subscriptions_by_id: Default::default(),
-			notary_client_by_id: Default::default(),
-			notary_archive_host_by_id: Default::default(),
-			notaries_by_id: Default::default(),
-			notebook_queue_by_id: Default::default(),
-			tick_voting_power_sender: Arc::new(Mutex::new(tick_voting_power_sender)),
-			tick_voting_power_receiver: Arc::new(Mutex::new(tick_voting_power_receiver)),
-			pause_queue_processing: Default::default(),
-			aux_client,
-			notebook_downloader,
-			metrics,
-			ticker,
-			queue_lock: Arc::new(Mutex::new(())),
-			is_solving_blocks,
-			_block: PhantomData,
+			notary_id,
+			record: Default::default(),
+			client: Default::default(),
+			archive_host: Default::default(),
+			subscription: Default::default(),
+			pending: Default::default(),
+			connection_lock: Arc::new(Mutex::new(())),
+			processing_lock: Arc::new(Mutex::new(())),
+			background_task_started: AtomicBool::new(false),
 		}
 	}
 
-	pub async fn update_notaries(&self, block_hash: &B::Hash) -> Result<(), Error> {
-		let Some(block_hash) =
-			resolve_client_stateful_hash::<B, _, AC>(self.client.as_ref(), *block_hash)?
-		else {
-			return Ok(());
-		};
-		let notaries = self.client.notaries(block_hash)?;
-		let mut reconnect_ids = BTreeSet::new();
+	async fn update_record(&self, record: NotaryRecordT) -> bool {
+		let mut current = self.record.write().await;
+		let previous_host = current.as_ref().and_then(|record| record.meta.hosts.first()).cloned();
+		let next_host = record.meta.hosts.first().cloned();
+		let host_changed = previous_host.is_some() && previous_host != next_host;
+		*current = Some(record);
+		host_changed
+	}
 
-		{
-			let next_notaries_by_id =
-				notaries.iter().map(|n| (n.notary_id, n.clone())).collect::<BTreeMap<_, _>>();
-			let mut notaries_by_id = self.notaries_by_id.write().await;
-			if next_notaries_by_id != *notaries_by_id {
-				for notary in &notaries {
-					if let Some(existing) = notaries_by_id.get(&notary.notary_id) {
-						if existing.meta.hosts[0] != notary.meta.hosts[0] {
-							reconnect_ids.insert(notary.notary_id);
-						}
-					}
-				}
-				*notaries_by_id = next_notaries_by_id.clone();
+	async fn clear_record(&self) {
+		self.record.write().await.take();
+	}
 
-				let existing_notary_ids =
-					self.notary_client_by_id.read().await.keys().copied().collect::<Vec<_>>();
-				for id in existing_notary_ids {
-					if let Some(entry) = notaries_by_id.get(&id) {
-						if Self::should_connect_to_notary(entry) {
-							continue;
-						}
-					}
-					self.disconnect(&id, None).await;
-				}
+	async fn host(&self) -> Result<String, Error> {
+		let record = self.record.read().await;
+		let record = record
+			.as_ref()
+			.ok_or_else(|| Error::NotaryError("No rpc endpoints found for notary".to_string()))?;
+		let host =
+			record.meta.hosts.first().ok_or_else(|| {
+				Error::NotaryError("No rpc endpoint found for notary".to_string())
+			})?;
+		host.clone().try_into().map_err(|e| {
+			Error::NotaryError(format!(
+				"Could not convert host to string for notary {} - {e:?}",
+				self.notary_id
+			))
+		})
+	}
+
+	async fn prefetch_headers<B, C, AC>(&self, worker_context: &WorkerContext<B, C, AC>) -> bool
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let targets = self.pending.lock().await.prefetch_targets(HEADER_PREFETCH_WINDOW);
+		let mut prefetched = false;
+		for notebook_number in targets {
+			match self.download_header(worker_context, notebook_number, None).await {
+				Ok(header_bytes) => {
+					self.pending.lock().await.cache_header(notebook_number, header_bytes);
+					prefetched = true;
+				},
+				Err(error) => {
+					trace!(
+						"Unable to prefetch notebook header for notary {} notebook {} - {error:?}",
+						self.notary_id, notebook_number,
+					);
+				},
 			}
 		}
+		prefetched
+	}
 
-		for notary in notaries {
-			let notary_id = notary.notary_id;
-			match notary.state {
-				NotaryState::Locked { .. } => {
-					// don't reconnect to a locked notary
-					continue;
-				},
-				NotaryState::Reactivated { reprocess_notebook_number } => {
-					if let Some(queue) = self.notebook_queue_by_id.write().await.get_mut(&notary_id)
-					{
-						for (n, body, _) in queue.iter_mut() {
-							if *n == reprocess_notebook_number {
-								body.take();
-								break;
-							}
-						}
-					}
-					self.aux_client.reprocess_notebook(notary_id, reprocess_notebook_number)?;
-				},
-				_ => {},
-			}
+	async fn clear_subscription(&self) {
+		self.subscription.lock().await.take();
+	}
 
-			// don't connect if exceeded queue depth
-			if self.queue_depth(notary_id).await > MAX_QUEUE_DEPTH {
-				continue;
-			}
+	async fn clear_connection(&self) {
+		let _connection_guard = self.connection_lock.lock().await;
+		self.client.write().await.take();
+		self.clear_subscription().await;
+	}
 
-			let is_connected =
-				self.has_client(notary_id).await && self.has_subscription(notary_id).await;
+	async fn has_client(&self) -> bool {
+		self.client.read().await.is_some()
+	}
 
-			if !is_connected || reconnect_ids.contains(&notary_id) {
-				info!("Connecting to notary id={notary_id}");
-				if let Err(e) = self.connect_to_notary(notary_id).await {
-					self.disconnect(
-						&notary_id,
-						Some(format!("Notary {notary_id} sync failed. {e:?}")),
-					)
-					.await;
-					continue;
-				}
+	async fn has_subscription(&self) -> bool {
+		self.subscription.lock().await.is_some()
+	}
 
-				if let Err(e) = self.subscribe_to_notebooks(notary_id).await {
-					self.disconnect(
-						&notary_id,
-						Some(format!("Notary {notary_id} subscription failed. {e:?}")),
-					)
-					.await;
-				}
-			}
+	async fn ensure_connected_subscription(&self) -> Result<(), Error> {
+		let _connection_guard = self.connection_lock.lock().await;
+		let can_connect = {
+			let record = self.record.read().await;
+			let Some(record) = record.as_ref() else {
+				return Ok(());
+			};
+			!matches!(record.state, NotaryState::Locked { .. })
+		};
+		if !can_connect {
+			return Ok(());
+		}
+
+		let notary_id = self.notary_id;
+		if !self.has_client().await {
+			info!("Connecting to notary id={notary_id}");
+			self.connect().await?;
+		}
+
+		if !self.has_subscription().await {
+			self.subscribe().await?;
 		}
 
 		Ok(())
 	}
 
-	pub async fn next_subscription(
+	async fn poll_subscription<B, C, AC>(
 		&self,
-		wait_duration: Duration,
-	) -> Option<(NotaryId, NotebookNumber)> {
-		let now = Instant::now();
-		loop {
-			if let Some((notary_id, notebook_number)) = self.poll_subscriptions().await {
-				return Some((notary_id, notebook_number));
-			}
-			if now.elapsed() > wait_duration {
-				return None;
-			}
-			// yield thread
-			tokio::task::yield_now().await;
+		worker_context: &WorkerContext<B, C, AC>,
+	) -> Option<NotebookNumber>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let next = {
+			let mut subscription = self.subscription.lock().await;
+			let subscription = subscription.as_mut()?;
+			subscription.as_mut().poll_next(&mut Context::from_waker(noop_waker_ref()))
+		};
+
+		match next {
+			Poll::Ready(Some(Ok(download_info))) => {
+				if let Some(metrics) = worker_context.metrics.as_ref() {
+					metrics.notebook_notification_received(
+						self.notary_id,
+						download_info.tick,
+						&worker_context.ticker,
+					);
+				}
+				trace!(
+					"Tracking notebook {} for notary {}",
+					download_info.notebook_number, self.notary_id
+				);
+				self.pending
+					.lock()
+					.await
+					.track_notebook(download_info.notebook_number, None, None);
+				Some(download_info.notebook_number)
+			},
+			Poll::Ready(Some(Err(error))) => {
+				self.clear_connection().await;
+				info!(
+					"Notary client disconnected from notary #{} (or could not connect). Reason? {:?}",
+					self.notary_id,
+					Some(error.to_string())
+				);
+				None
+			},
+			Poll::Ready(None) => {
+				self.clear_connection().await;
+				info!(
+					"Notary client disconnected from notary #{} (or could not connect). Reason? {:?}",
+					self.notary_id, None::<String>
+				);
+				None
+			},
+			Poll::Pending => None,
 		}
 	}
 
-	pub async fn poll_subscriptions(&self) -> Option<(NotaryId, NotebookNumber)> {
-		let mut subscription_ids =
-			self.subscriptions_by_id.read().await.keys().copied().collect::<Vec<_>>();
+	async fn run_background_pass<B, C, AC>(
+		self: &Arc<Self>,
+		worker_context: &WorkerContext<B, C, AC>,
+	) -> Result<bool, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if *worker_context.pause_notebook_audits.read().await {
+			self.clear_subscription().await;
+			return Ok(false);
+		}
+		self.ensure_connected_subscription().await?;
+		let saw_subscription = self.poll_subscription(worker_context).await.is_some();
+		let has_more_work = self.process_background_work(worker_context).await;
+		Ok(saw_subscription || has_more_work)
+	}
 
-		// If there are no subscriptions, return early
-		if subscription_ids.is_empty() {
-			return None;
+	fn start_background_task<B, C, AC>(
+		self: &Arc<Self>,
+		worker_context: Arc<WorkerContext<B, C, AC>>,
+		spawn_handle: Option<sc_service::SpawnTaskHandle>,
+		background_idle_delay: Duration,
+	) where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if self.background_task_started.swap(true, Ordering::AcqRel) {
+			return;
+		}
+		let Some(spawn_handle) = spawn_handle else {
+			self.background_task_started.store(false, Ordering::Release);
+			return;
+		};
+		let worker = Arc::clone(self);
+		let idle_delay = background_idle_delay;
+
+		spawn_handle.spawn("notary_worker_task", "notary_worker", async move {
+			let mut delay = idle_delay;
+			loop {
+				time::sleep(delay).await;
+				delay = match worker.run_background_pass(worker_context.as_ref()).await {
+					Ok(true) => Duration::from_millis(20),
+					Ok(false) => idle_delay,
+					Err(error) => {
+						warn!(
+							"Error driving notary {} in background task: {error:?}",
+							worker.notary_id,
+						);
+						worker.clear_connection().await;
+						idle_delay
+					},
+				};
+			}
+		});
+	}
+
+	async fn connect(&self) -> Result<(), Error> {
+		let client = self.get_or_connect_client().await?;
+		let notebook_meta = client.metadata().await.map_err(|error| {
+			Error::NotaryError(format!("Could not get metadata from notary - {error:?}"))
+		})?;
+		let archive_host = client.get_archive_base_url().await.map_err(|error| {
+			Error::NotaryError(format!("Could not get archive host from notary - {error:?}"))
+		})?;
+		*self.archive_host.write().await = Some(archive_host);
+		if notebook_meta.last_closed_notebook_number > 0 {
+			trace!(
+				"Tracking latest notebook {} for notary {}",
+				notebook_meta.last_closed_notebook_number, self.notary_id
+			);
+			self.pending.lock().await.track_notebook(
+				notebook_meta.last_closed_notebook_number,
+				None,
+				None,
+			);
+		}
+		Ok(())
+	}
+
+	async fn subscribe(&self) -> Result<(), Error> {
+		let client = self.get_or_connect_client().await?;
+		let stream: RawHeadersSubscription = client.subscribe_headers().await.map_err(|error| {
+			Error::NotaryError(format!("Could not subscribe to notebooks from notary - {error:?}"))
+		})?;
+		self.subscription.lock().await.replace(Box::pin(stream));
+		info!("Subscribed to notary id={}", self.notary_id);
+		Ok(())
+	}
+
+	async fn next_for_processing<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		finalized_notebook_number: NotebookNumber,
+	) -> Option<(NotebookNumber, SignedHeaderBytes, Instant)>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let NotebookAuditSelection { target, finalized_notebooks_trimmed, tracked_range } =
+			self.pending.lock().await.select_next_audit(finalized_notebook_number);
+
+		if tracing::enabled!(tracing::Level::TRACE) {
+			tracing::trace!(
+				?finalized_notebooks_trimmed,
+				notary_id = self.notary_id,
+				"Selecting notebook audit target for notary. Range: {:?}",
+				tracked_range,
+			);
 		}
 
-		// Shuffle the subscriptions to randomize the polling order
-		subscription_ids.shuffle(&mut rand::rng());
-
-		// Poll each subscription in the randomized order
-		for notary_id in subscription_ids {
-			let next = {
-				let mut subscriptions = self.subscriptions_by_id.write().await;
-				if let Some(sub) = subscriptions.get_mut(&notary_id) {
-					sub.as_mut().poll_next(&mut Context::from_waker(noop_waker_ref()))
-				} else {
-					continue;
-				}
-			};
-
-			match next {
-				Poll::Ready(Some(Ok(download_info))) => {
-					let notebook_number = download_info.notebook_number;
-					if let Some(metrics) = self.metrics.as_ref() {
-						metrics.notebook_notification_received(
-							notary_id,
-							download_info.tick,
-							&self.ticker,
-						);
-					}
-					if let Ok(did_overflow) =
-						self.enqueue_notebook(notary_id, notebook_number, None, None).await
-					{
-						if did_overflow {
-							info!("Overflowed queue for notary {notary_id}");
-							self.unsubscribe_if_overflowed(notary_id).await;
-						}
-					}
-					return Some((notary_id, notebook_number));
-				},
-				Poll::Ready(Some(Err(e))) => self.disconnect(&notary_id, Some(e.to_string())).await,
-				Poll::Ready(None) => self.disconnect(&notary_id, None).await, // Subscription ended
-				_ => {},
+		let NotebookAuditTarget { notebook_number, mut header_bytes, known_since } = target?;
+		if header_bytes.is_none() {
+			header_bytes = self.download_header(worker_context, notebook_number, None).await.ok();
+			if let Some(header_bytes) = header_bytes.as_ref() {
+				self.pending.lock().await.cache_header(notebook_number, header_bytes.clone());
 			}
+		}
+		if let Some(header_bytes) = header_bytes {
+			return Some((notebook_number, header_bytes, known_since));
 		}
 		None
 	}
 
-	pub async fn process_queues(
+	async fn process_for_hashes<B, C, AC>(
 		self: &Arc<Self>,
-		importing_with_parent_hash: Option<B::Hash>,
-	) -> Result<bool, Error> {
-		// Only respect pause flag when running under normal sync.
-		// When importing a specific block (e.g. during verification), always allow processing.
-		if *self.pause_queue_processing.read().await && importing_with_parent_hash.is_none() {
+		worker_context: &WorkerContext<B, C, AC>,
+		best_hash: B::Hash,
+		finalized_hash: B::Hash,
+	) -> Result<bool, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if self.pending.lock().await.len() == 0 {
 			return Ok(false);
 		}
-		let Some(_lock) = self.queue_lock.try_lock().ok() else {
+		let Some(_processing_guard) = self.processing_lock.clone().try_lock_owned().ok() else {
 			return Ok(true);
 		};
-		let is_import_context = importing_with_parent_hash.is_some();
-		let block_hash = importing_with_parent_hash.unwrap_or(self.client.best_hash());
-		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
-			return Ok(is_import_context);
-		};
-		self.process_queues_at_hash(best_hash, finalized_hash).await
-	}
-
-	pub async fn process_queues_at(self: &Arc<Self>, block_hash: B::Hash) -> Result<bool, Error> {
-		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
-			return Ok(true);
-		};
-		self.process_queues_at_hash(best_hash, finalized_hash).await
-	}
-
-	async fn process_selected_queues_at(
-		self: &Arc<Self>,
-		block_hash: B::Hash,
-		notary_ids: &BTreeSet<NotaryId>,
-	) -> Result<bool, Error> {
-		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
-			return Ok(true);
-		};
-		self.process_selected_queues_at_hash(best_hash, finalized_hash, notary_ids)
-			.await
-	}
-
-	fn resolve_processing_hashes(
-		&self,
-		block_hash: B::Hash,
-	) -> Result<Option<ProcessingHashes<B::Hash>>, Error> {
-		let Some(best_hash) =
-			resolve_client_stateful_hash::<B, _, AC>(self.client.as_ref(), block_hash)?
+		let finalized_notebook_number =
+			Self::latest_notebook_in_runtime(worker_context, finalized_hash, self.notary_id);
+		let Some((notebook_number, raw_header, known_since)) =
+			self.next_for_processing(worker_context, finalized_notebook_number).await
 		else {
-			return Ok(None);
+			return Ok(false);
+		};
+
+		let has_more_work = match self
+			.process_notebook(
+				worker_context,
+				notebook_number,
+				finalized_notebook_number,
+				&best_hash,
+				raw_header.clone(),
+				known_since,
+			)
+			.await
+		{
+			Ok(()) => {
+				self.pending.lock().await.mark_processed(notebook_number);
+				let has_more_work = self.pending.lock().await.len() > 0;
+				trace!(
+					"Processed notebook {notebook_number} for notary {}. More work? {has_more_work}",
+					self.notary_id,
+				);
+				has_more_work
+			},
+			Err(error) => {
+				if matches!(
+					error,
+					Error::MissingNotebooksError(_) |
+						Error::NotebookAuditBeforeTick(_) |
+						Error::NotaryAuditDeferred(_)
+				) {
+					trace!("Will retry notebook audit for notary {} - {error:?}", self.notary_id,);
+					tokio::time::sleep(Duration::from_secs(1)).await;
+					true
+				} else {
+					self.pending.lock().await.mark_processed(notebook_number);
+					return Err(error);
+				}
+			},
+		};
+		let prefetched = self.prefetch_headers(worker_context).await;
+		Ok(has_more_work || prefetched)
+	}
+
+	async fn process_background_work<B, C, AC>(
+		self: &Arc<Self>,
+		worker_context: &WorkerContext<B, C, AC>,
+	) -> bool
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if *worker_context.pause_notebook_audits.read().await {
+			return false;
+		}
+		let Some(best_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			worker_context.client.as_ref(),
+			worker_context.client.best_hash(),
+		)
+		.unwrap_or_else(|error| {
+			warn!(
+				"Could not resolve stateful best hash for notary {} background processing - {error:?}",
+				self.notary_id,
+			);
+			None
+		}) else {
+			return false;
 		};
 		let Some(finalized_hash) = resolve_client_stateful_hash::<B, _, AC>(
-			self.client.as_ref(),
-			self.client.finalized_hash(),
-		)?
-		else {
-			return Ok(None);
-		};
-		Ok(Some((best_hash, finalized_hash)))
-	}
-
-	async fn process_queues_at_hash(
-		self: &Arc<Self>,
-		best_hash: B::Hash,
-		finalized_hash: B::Hash,
-	) -> Result<bool, Error> {
-		let notary_ids =
-			self.notebook_queue_by_id.read().await.keys().copied().collect::<BTreeSet<_>>();
-		let has_more_work = self
-			.process_selected_queues_at_hash(best_hash, finalized_hash, &notary_ids)
-			.await?;
-		self.log_queue_depth().await;
-		Ok(has_more_work)
-	}
-
-	async fn process_selected_queues_at_hash(
-		self: &Arc<Self>,
-		best_hash: B::Hash,
-		finalized_hash: B::Hash,
-		notary_ids: &BTreeSet<NotaryId>,
-	) -> Result<bool, Error> {
-		let queued_notaries = self
-			.notebook_queue_by_id
-			.read()
-			.await
-			.keys()
-			.copied()
-			.filter(|notary_id| notary_ids.contains(notary_id))
-			.collect::<Vec<_>>();
-
-		let handles = queued_notaries.into_iter().map(|notary_id| {
-			let finalized_notebook_number =
-				self.latest_notebook_in_runtime(finalized_hash, notary_id);
-
-			let self_clone: Arc<Self> = Arc::clone(self);
-			tokio::spawn(async move {
-				let Some((notebook_number, raw_header, time)) =
-					self_clone.get_next(notary_id, finalized_notebook_number).await
-				else {
-					return Ok::<_, Error>(false);
-				};
-				match self_clone
-					.process_notebook(
-						notary_id,
-						notebook_number,
-						finalized_notebook_number,
-						&best_hash,
-						raw_header.clone(),
-						time,
-					)
-					.await
-				{
-					Ok(()) => {
-						let has_more_work = self_clone.queue_depth(notary_id).await > 0;
-						trace!(
-							"Processed notebook {notebook_number} for notary {notary_id}. More work? {has_more_work}"
-						);
-						Ok::<_, Error>(has_more_work)
-					},
-					Err(e) => {
-						if matches!(
-							e,
-							Error::MissingNotebooksError(_) |
-								Error::NotebookAuditBeforeTick(_) |
-								Error::NotaryAuditDeferred(_)
-						) {
-							trace!("In queue, re-queuing notebook for notary {notary_id} - {e:?}");
-							self_clone
-								.enqueue_notebook(
-									notary_id,
-									notebook_number,
-									Some(raw_header),
-									Some(time),
-								)
-								.await?;
-							// wait for continue processing
-							tokio::time::sleep(Duration::from_secs(1)).await;
-							return Ok::<_, Error>(true);
-						}
-						Err(e)
-					},
-				}
-			})
-		});
-		let results = join_all(handles).await;
-
-		let mut has_more_work = false;
-		for result in results {
-			match result {
-				Ok(inner_result) => match inner_result {
-					Ok(x) => has_more_work = has_more_work || x,
-					Err(err) => warn!("Error processing notebooks for a notary {err:?}"),
-				},
-				Err(join_error) => {
-					warn!("Error while processing notary queue - {join_error:?}");
-				},
-			}
-		}
-		Ok(has_more_work)
-	}
-
-	async fn log_queue_depth(&self) {
-		if let Some(metrics) = self.metrics.as_ref() {
-			let notary_queue = self.notebook_queue_by_id.read().await;
-			for (notary_id, queue) in notary_queue.iter() {
-				metrics.record_queue_depth(*notary_id, queue.len() as u64);
-			}
-		}
-	}
-
-	async fn queue_depth(&self, notary_id: NotaryId) -> usize {
-		let notary_queue = self.notebook_queue_by_id.read().await;
-		notary_queue.get(&notary_id).map_or(0usize, |q| q.len())
-	}
-
-	async fn get_next(
-		&self,
-		notary_id: NotaryId,
-		finalized_notebook_number: NotebookNumber,
-	) -> Option<(NotebookNumber, SignedHeaderBytes, Instant)> {
-		let (notebook_number, mut bytes, queue_time) = {
-			let mut queues = self.notebook_queue_by_id.write().await;
-			let mut next = None;
-			let mut finalized_notebooks_trimmed = 0u32;
-			let mut queue_range: Range<NotebookNumber> = 0..0;
-			while let Some(queue) = queues.get_mut(&notary_id) {
-				if queue.is_empty() {
-					return None;
-				}
-				queue_range = Range { start: queue[0].0, end: queue[queue.len() - 1].0 };
-
-				let (notebook_number, bytes, queue_time) = queue.remove(0);
-				if notebook_number > finalized_notebook_number {
-					next = Some((notebook_number, bytes, queue_time));
-					break;
-				} else {
-					finalized_notebooks_trimmed += 1;
-				}
-			}
-
-			if tracing::enabled!(tracing::Level::TRACE) {
-				tracing::trace!(
-					?finalized_notebooks_trimmed,
-					notary_id,
-					"Dequeuing notebook for notary. Queue: {:?}",
-					queue_range,
-				);
-			}
-			next?
-		};
-
-		if bytes.is_none() {
-			bytes = self.download_header(notary_id, notebook_number, None).await.ok();
-		}
-		if let Some(bytes) = bytes {
-			Some((notebook_number, bytes, queue_time))
-		} else {
-			self.enqueue_notebook(notary_id, notebook_number, None, Some(queue_time))
-				.await
-				.ok();
-			None
-		}
-	}
-
-	/// Enqueue the notebook and return true if the queue overflowed
-	async fn enqueue_notebook(
-		&self,
-		notary_id: NotaryId,
-		notebook_number: NotebookNumber,
-		header_bytes: Option<SignedHeaderBytes>,
-		enqueue_time: Option<Instant>,
-	) -> Result<bool, Error> {
-		let mut notebook_queue_by_id = self.notebook_queue_by_id.write().await;
-
-		let queue = notebook_queue_by_id.entry(notary_id).or_insert_with(Vec::new);
-		let entry = queue.iter().position(|(n, _, _)| *n == notebook_number);
-		if let Some(index) = entry {
-			// only overwrite if missing
-			if queue[index].1.is_none() {
-				trace!(
-					"Overwriting notebook {} header in queue for notary {} with header? {}",
-					notebook_number,
-					notary_id,
-					header_bytes.is_some()
-				);
-				queue[index].1 = header_bytes;
-			}
-			Ok(false)
-		} else {
-			trace!(
-				"Queuing notebook {} for notary {} with header? {}",
-				notebook_number,
-				notary_id,
-				header_bytes.is_some()
+			worker_context.client.as_ref(),
+			worker_context.client.finalized_hash(),
+		)
+		.unwrap_or_else(|error| {
+			warn!(
+				"Could not resolve stateful finalized hash for notary {} background processing - {error:?}",
+				self.notary_id,
 			);
-			// look from back of list since we're normally appending
-			let pos = queue
-				.iter()
-				.rposition(|(n, _, _)| *n < notebook_number)
-				.map(|p| p + 1)
-				.unwrap_or(0);
-			queue.insert(
-				pos,
-				(notebook_number, header_bytes, enqueue_time.unwrap_or(Instant::now())),
-			);
-
-			Ok(queue.len() > MAX_QUEUE_DEPTH)
-		}
-	}
-
-	async fn unsubscribe_if_overflowed(&self, notary_id: NotaryId) {
-		if self.queue_depth(notary_id).await <= MAX_QUEUE_DEPTH {
-			return;
-		}
-
-		self.subscriptions_by_id.write().await.remove(&notary_id);
-	}
-
-	async fn download_header(
-		&self,
-		notary_id: NotaryId,
-		notebook_number: NotebookNumber,
-		mut download_url: Option<String>,
-	) -> Result<SignedHeaderBytes, Error> {
-		let expected_archive_origin =
-			self.notary_archive_host_by_id.read().await.get(&notary_id).cloned();
-		if download_url.is_none() {
-			if let Some(archive_host) = expected_archive_origin.as_ref() {
-				download_url = Some(get_header_url(archive_host, notary_id, notebook_number));
-			}
-		}
-		self.notebook_downloader
-			.get_header(notary_id, notebook_number, download_url, expected_archive_origin)
-			.await
-			.map_err(|e| {
-				Error::NotaryError(format!(
-					"Could not get notary {notary_id}, notebook {notebook_number} from notebook downloader - {e:?}"
-				))
-			})
-	}
-
-	async fn download_notebook(
-		&self,
-		notary_id: NotaryId,
-		notebook_number: NotebookNumber,
-	) -> Result<NotebookBytes, Error> {
-		let expected_archive_origin =
-			self.notary_archive_host_by_id.read().await.get(&notary_id).cloned();
-		let download_url = if let Some(archive_host) = expected_archive_origin.as_ref() {
-			Some(get_notebook_url(archive_host, notary_id, notebook_number))
-		} else if self.notebook_downloader.is_strict() {
 			None
-		} else {
-			let client = self.get_or_connect_to_client(notary_id).await.ok();
-			if let Some(client) = client {
-				client.get_notebook_download_url(notebook_number).await.ok()
-			} else {
-				None
-			}
+		}) else {
+			return false;
 		};
-		let bytes = self
-			.notebook_downloader
-			.get_body(notary_id, notebook_number, download_url, expected_archive_origin)
-			.await
-			.map_err(|e| {
-				Error::NotaryError(format!(
-					"Could not download notebook {notebook_number} from notary {notary_id} - {e:?}"
-				))
-			})?;
-		Ok(bytes)
-	}
-
-	async fn connect_to_notary(&self, id: NotaryId) -> Result<(), Error> {
-		let client = self.get_or_connect_to_client(id).await?;
-		let notebook_meta = client.metadata().await.map_err(|e| {
-			Error::NotaryError(format!("Could not get metadata from notary - {e:?}"))
-		})?;
-		let archive_host = client.get_archive_base_url().await.map_err(|e| {
-			Error::NotaryError(format!("Could not get archive host from notary - {e:?}"))
-		})?;
-		self.notary_archive_host_by_id.write().await.insert(id, archive_host.clone());
-		if notebook_meta.last_closed_notebook_number > 0 {
-			self.enqueue_notebook(id, notebook_meta.last_closed_notebook_number, None, None)
-				.await?;
+		match self.process_for_hashes(worker_context, best_hash, finalized_hash).await {
+			Ok(has_more_work) => has_more_work,
+			Err(error) => {
+				warn!(
+					"Error processing notebooks for notary {} in background task: {error:?}",
+					self.notary_id,
+				);
+				self.pending.lock().await.len() > 0
+			},
 		}
-		Ok(())
 	}
 
-	pub async fn disconnect(&self, notary_id: &NotaryId, reason: Option<String>) {
-		info!(
-			"Notary client disconnected from notary #{notary_id} (or could not connect). Reason? {reason:?}"
-		);
-		self.notary_client_by_id.write().await.remove(notary_id);
-		self.subscriptions_by_id.write().await.remove(notary_id);
-	}
-
-	async fn subscribe_to_notebooks(&self, id: NotaryId) -> Result<(), Error> {
-		let client = self.get_or_connect_to_client(id).await?;
-		let stream: RawHeadersSubscription = client.subscribe_headers().await.map_err(|e| {
-			Error::NotaryError(format!("Could not subscribe to notebooks from notary - {e:?}"))
-		})?;
-		self.subscriptions_by_id.write().await.insert(id, Box::pin(stream));
-		Ok(())
-	}
-
-	pub async fn process_notebook(
+	async fn process_notebook<B, C, AC>(
 		&self,
-		notary_id: NotaryId,
+		worker_context: &WorkerContext<B, C, AC>,
 		notebook_number: NotebookNumber,
 		finalized_notebook_number: NotebookNumber,
 		best_hash: &B::Hash,
 		raw_header: SignedHeaderBytes,
-		enqueue_time: Instant,
-	) -> Result<(), Error> {
+		known_since: Instant,
+	) -> Result<(), Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
 		let mut best_hash = *best_hash;
 		if notebook_number <= finalized_notebook_number {
 			tracing::info!(
@@ -938,13 +1047,12 @@ where
 			return Ok(());
 		}
 
-		let mut latest_notebook_in_runtime = self.latest_notebook_in_runtime(best_hash, notary_id);
+		let mut latest_notebook_in_runtime =
+			Self::latest_notebook_in_runtime(worker_context, best_hash, notary_id);
 		if latest_notebook_in_runtime >= notebook_number {
 			let mut counter = 0;
 			while latest_notebook_in_runtime >= notebook_number {
 				counter += 1;
-				// NOTE: if this goes past 256 finalized blocks, it will hit the limit that nodes
-				// store by default
 				if counter >= 500 {
 					return Err(Error::NotaryError(format!(
 						"Could not find place to audit this notebook {notebook_number} in runtime"
@@ -958,19 +1066,20 @@ where
 					trying_block_hash = ?best_hash,
 					"Checking if we can audit at parent block",
 				);
-				let parent_hash = self.client.parent_hash(&best_hash)?;
+				let parent_hash = worker_context.client.parent_hash(&best_hash)?;
 				if parent_hash == best_hash {
 					return Err(Error::NotaryAuditDeferred(format!(
 						"Missing state while locating audit parent. Notary={notary_id}, notebook={notebook_number}, block={best_hash:?}"
 					)));
 				}
-				best_hash = parent_hash;
-				if !self.client.has_block_state(best_hash) {
+				if !worker_context.client.has_block_state(parent_hash) {
 					return Err(Error::NotaryAuditDeferred(format!(
-						"Missing state while locating audit parent. Notary={notary_id}, notebook={notebook_number}, block={best_hash:?}"
+						"Missing state while locating audit parent. Notary={notary_id}, notebook={notebook_number}, block={parent_hash:?}"
 					)));
 				}
-				latest_notebook_in_runtime = self.latest_notebook_in_runtime(best_hash, notary_id);
+				best_hash = parent_hash;
+				latest_notebook_in_runtime =
+					Self::latest_notebook_in_runtime(worker_context, best_hash, notary_id);
 			}
 			tracing::info!(
 				notary_id,
@@ -981,17 +1090,22 @@ where
 			);
 		}
 
-		let notebook_details = self
+		let _audit_slot = worker_context.audit_slots.acquire().await.map_err(|error| {
+			Error::NotaryError(format!(
+				"Could not acquire audit processing slot for notary {notary_id} - {error:?}",
+			))
+		})?;
+
+		let notebook_details = worker_context
 			.client
 			.decode_signed_raw_notebook_header(&best_hash, raw_header.0.clone())?
-			.map_err(|e| {
+			.map_err(|error| {
 				Error::NotaryError(format!(
-					"Unable to decode notebook header in runtime. Notary={notary_id}, notebook={notebook_number} -> {e:?}"
+					"Unable to decode notebook header in runtime. Notary={notary_id}, notebook={notebook_number} -> {error:?}",
 				))
 			})?;
 
 		let tick = notebook_details.tick;
-
 		ensure!(
 			notary_id == notebook_details.notary_id,
 			Error::NotaryError("Notary ID mismatch".to_string())
@@ -1001,9 +1115,10 @@ where
 			Error::NotaryError("Notebook number mismatch".to_string())
 		);
 
-		let audit_result = self.audit_notebook(&best_hash, &notebook_details).await?;
-		let runtime_tick = self.client.current_tick(best_hash)?;
-		let voting_power = self.aux_client.store_notebook_result(
+		let audit_result =
+			self.audit_notebook(worker_context, &best_hash, &notebook_details).await?;
+		let runtime_tick = worker_context.client.current_tick(best_hash)?;
+		let voting_power = worker_context.aux_client.store_notebook_result(
 			audit_result,
 			raw_header,
 			notebook_details,
@@ -1011,22 +1126,538 @@ where
 			runtime_tick,
 		)?;
 
-		if let Some(metrics) = self.metrics.as_ref() {
-			metrics.notebook_processed(notary_id, tick, enqueue_time, &self.ticker);
+		if let Some(metrics) = worker_context.metrics.as_ref() {
+			metrics.notebook_processed(notary_id, tick, known_since, &worker_context.ticker);
 		}
 
-		if self.is_solving_blocks {
-			self.tick_voting_power_sender
+		if worker_context.is_solving_blocks {
+			worker_context
+				.tick_voting_power_sender
 				.lock()
 				.await
 				.unbounded_send(voting_power)
-				.map_err(|e| {
+				.map_err(|error| {
 					Error::NotaryError(format!(
-						"Could not send tick state to sender (notary {notary_id}, notebook {notebook_number}) - {e:?}"
+						"Could not send tick state to sender (notary {notary_id}, notebook {notebook_number}) - {error:?}",
 					))
 				})?;
 		}
 		Ok(())
+	}
+
+	async fn audit_notebook<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		best_hash: &B::Hash,
+		notebook_details: &NotaryNotebookDetails<B::Hash>,
+	) -> Result<NotebookAuditResult<NotebookVerifyError>, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
+		let tick = notebook_details.tick;
+		let notebook_number = notebook_details.notebook_number;
+		let notebook_dependencies = self
+			.get_notebook_dependencies(worker_context, notebook_number, best_hash)
+			.await?;
+		tracing::trace!(
+			notary_id,
+			notebook_number,
+			best_hash = ?best_hash,
+			tick,
+			notebook_dependencies = notebook_dependencies.len(),
+			"Attempting to audit notebook",
+		);
+
+		let full_notebook = self.download_notebook(worker_context, notebook_number).await?;
+		tracing::trace!(
+			notary_id,
+			notebook_number,
+			bytes = full_notebook.0.len(),
+			"Notebook downloaded.",
+		);
+
+		let audit_failure_reason = match worker_context.client.audit_notebook_and_get_votes(
+			*best_hash,
+			notebook_details.version,
+			notary_id,
+			notebook_number,
+			tick,
+			notebook_details.header_hash,
+			&full_notebook.0,
+			notebook_dependencies.clone(),
+			&notebook_details.blocks_with_votes,
+		)? {
+			Ok(votes) => {
+				let vote_count = votes.raw_votes.len();
+				worker_context.aux_client.store_votes(tick, votes)?;
+				tracing::info!(
+					notary_id,
+					notebook_number,
+					tick,
+					"Notebook audit successful. {vote_count} block vote(s).",
+				);
+				None
+			},
+			Err(error) => {
+				if error == NotebookVerifyError::CatchupNotebooksMissing {
+					tracing::warn!(
+						notary_id,
+						notebook_number,
+						?notebook_dependencies,
+						?best_hash,
+						"Notebook audit failed for notary. Incorrect catchup provided",
+					);
+					return Err(Error::MissingNotebooksError(format!(
+						"Possibly missing notebooks? Invalid catchup notebooks provided to audit. Notary {notary_id}, #{notebook_number}, tick {tick}.",
+					)));
+				}
+
+				if tick > worker_context.client.current_tick(*best_hash)? {
+					return Err(Error::NotebookAuditBeforeTick(format!(
+						"Notebook tick is > runtime. Notary={notary_id}, notebook={notebook_number}, tick={tick}",
+					)));
+				}
+
+				tracing::warn!(notary_id, notebook_number, tick, "Notebook audit failed ({error})",);
+				Some(error)
+			},
+		};
+
+		Ok(NotebookAuditResult {
+			notary_id,
+			tick,
+			notebook_number,
+			audit_first_failure: audit_failure_reason,
+		})
+	}
+
+	async fn get_or_connect_client(&self) -> Result<Arc<Client>, Error> {
+		if let Some(client) = self.client.read().await.clone() {
+			return Ok(client);
+		}
+		let notary_id = self.notary_id;
+		let host = self.host().await?;
+		let client = Arc::new(argon_notary_apis::create_client(&host).await.map_err(|error| {
+			Error::NotaryError(format!(
+				"Could not connect to notary {notary_id} ({host}) for audit - {error:?}",
+			))
+		})?);
+		*self.client.write().await = Some(client.clone());
+		Ok(client)
+	}
+
+	async fn download_header<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		notebook_number: NotebookNumber,
+		mut download_url: Option<String>,
+	) -> Result<SignedHeaderBytes, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
+		let _download_slot = worker_context.download_slots.acquire().await.map_err(|error| {
+			Error::NotaryError(format!(
+				"Could not acquire header download slot for notary {notary_id} - {error:?}",
+			))
+		})?;
+		let expected_archive_origin = self.archive_host.read().await.clone();
+		if download_url.is_none() {
+			if let Some(archive_host) = expected_archive_origin.as_ref() {
+				download_url = Some(get_header_url(archive_host, notary_id, notebook_number));
+			}
+		}
+		worker_context
+			.notebook_downloader
+			.get_header(notary_id, notebook_number, download_url, expected_archive_origin)
+			.await
+			.map_err(|error| {
+				Error::NotaryError(format!(
+					"Could not get notary {notary_id}, notebook {notebook_number} from notebook downloader - {error:?}",
+				))
+			})
+	}
+
+	async fn download_notebook<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		notebook_number: NotebookNumber,
+	) -> Result<NotebookBytes, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
+		let _download_slot = worker_context.download_slots.acquire().await.map_err(|error| {
+			Error::NotaryError(format!(
+				"Could not acquire notebook download slot for notary {notary_id} - {error:?}",
+			))
+		})?;
+		let expected_archive_origin = self.archive_host.read().await.clone();
+		let download_url = if let Some(archive_host) = expected_archive_origin.as_ref() {
+			Some(get_notebook_url(archive_host, notary_id, notebook_number))
+		} else if worker_context.notebook_downloader.is_strict() {
+			None
+		} else {
+			let client = self.get_or_connect_client().await.ok();
+			if let Some(client) = client {
+				client.get_notebook_download_url(notebook_number).await.ok()
+			} else {
+				None
+			}
+		};
+		worker_context
+			.notebook_downloader
+			.get_body(notary_id, notebook_number, download_url, expected_archive_origin)
+			.await
+			.map_err(|error| {
+				Error::NotaryError(format!(
+					"Could not download notebook {notebook_number} from notary {notary_id} - {error:?}",
+				))
+			})
+	}
+
+	async fn get_notebook_dependencies<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		notebook_number: NotebookNumber,
+		best_hash: &B::Hash,
+	) -> Result<Vec<NotaryNotebookAuditSummary>, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
+		let mut notebook_dependencies = vec![];
+		let mut missing_notebooks = vec![];
+		let latest_block_notebook =
+			Self::latest_notebook_in_runtime(worker_context, *best_hash, notary_id);
+
+		if latest_block_notebook < notebook_number - 1 {
+			let notary_notebooks = worker_context.aux_client.get_audit_summaries(notary_id)?.get();
+			for notebook_number_needed in (latest_block_notebook + 1)..notebook_number {
+				if let Some(summary) =
+					notary_notebooks.iter().find(|s| s.notebook_number == notebook_number_needed)
+				{
+					notebook_dependencies.push(summary.clone());
+				} else {
+					missing_notebooks.push(notebook_number_needed);
+				}
+			}
+		}
+
+		if !missing_notebooks.is_empty() {
+			let first_missing = missing_notebooks[0];
+			let last_missing = missing_notebooks[missing_notebooks.len() - 1];
+			trace!(
+				"Tracking notebook range {}..{} for notary {}",
+				first_missing, last_missing, self.notary_id,
+			);
+			self.pending.lock().await.track_range(first_missing, last_missing);
+			let notebook_range = first_missing..last_missing;
+			info!(
+				"Missing notebooks for notary {notary_id}. Tracking dependency catchup range: {notebook_range:?}",
+			);
+			return Err(Error::MissingNotebooksError(format!(
+				"Missing notebooks #{notebook_range:?} to audit {notebook_number} for notary {notary_id}"
+			)));
+		}
+
+		Ok(notebook_dependencies)
+	}
+
+	fn latest_notebook_in_runtime<B, C, AC>(
+		worker_context: &WorkerContext<B, C, AC>,
+		block_hash: B::Hash,
+		notary_id: NotaryId,
+	) -> NotebookNumber
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if let Ok(latest_notebooks_in_runtime) =
+			worker_context.client.latest_notebook_by_notary(block_hash)
+		{
+			if let Some((latest_notebook, _)) = latest_notebooks_in_runtime.get(&notary_id) {
+				return *latest_notebook;
+			}
+		}
+		0
+	}
+}
+
+pub struct NotaryClient<B: BlockT, C: AuxStore, AC> {
+	worker_context: Arc<WorkerContext<B, C, AC>>,
+	workers_by_id: WorkersById,
+	pub(crate) metrics: Arc<Option<ConsensusMetrics<C>>>,
+	pub tick_voting_power_receiver: Arc<Mutex<TracingUnboundedReceiver<VotingPowerInfo>>>,
+	pub pause_notebook_audits: Arc<RwLock<bool>>,
+	background_idle_delay: Duration,
+	spawn_handle: Option<sc_service::SpawnTaskHandle>,
+}
+
+impl<B, C, AC> NotaryClient<B, C, AC>
+where
+	B: BlockT,
+	C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+	AC: Clone + Codec + Send + Sync + 'static,
+{
+	#[allow(clippy::too_many_arguments)]
+	pub fn new(
+		client: Arc<C>,
+		aux_client: ArgonAux<B, C>,
+		notebook_downloader: NotebookDownloader,
+		metrics: Arc<Option<ConsensusMetrics<C>>>,
+		ticker: Ticker,
+		spawn_handle: Option<sc_service::SpawnTaskHandle>,
+		background_idle_delay: Duration,
+		is_solving_blocks: bool,
+	) -> Self {
+		let (tick_voting_power_sender, tick_voting_power_receiver) =
+			tracing_unbounded("node::consensus::notebook_tick_stream", 100);
+		let pause_notebook_audits = Arc::new(RwLock::new(false));
+		let worker_context = Arc::new(WorkerContext {
+			client,
+			aux_client,
+			notebook_downloader,
+			metrics: metrics.clone(),
+			pause_notebook_audits: pause_notebook_audits.clone(),
+			ticker,
+			tick_voting_power_sender: Arc::new(Mutex::new(tick_voting_power_sender)),
+			download_slots: Arc::new(Semaphore::new(MAX_PARALLEL_NOTARY_DOWNLOADS)),
+			audit_slots: Arc::new(Semaphore::new(MAX_PARALLEL_NOTARY_AUDITS)),
+			is_solving_blocks,
+			_phantom: PhantomData,
+		});
+
+		Self {
+			worker_context,
+			workers_by_id: Default::default(),
+			metrics,
+			tick_voting_power_receiver: Arc::new(Mutex::new(tick_voting_power_receiver)),
+			pause_notebook_audits,
+			background_idle_delay,
+			spawn_handle,
+		}
+	}
+
+	async fn worker(&self, notary_id: NotaryId) -> Option<WorkerHandle> {
+		self.workers_by_id.read().await.get(&notary_id).cloned()
+	}
+
+	async fn ensure_worker(&self, notary_id: NotaryId) -> WorkerHandle {
+		if let Some(worker) = self.worker(notary_id).await {
+			return worker;
+		}
+		let mut workers = self.workers_by_id.write().await;
+		workers
+			.entry(notary_id)
+			.or_insert_with(|| Arc::new(NotaryWorker::new(notary_id)))
+			.clone()
+	}
+
+	pub async fn update_notaries(self: &Arc<Self>, block_hash: &B::Hash) -> Result<(), Error> {
+		let Some(block_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			self.worker_context.client.as_ref(),
+			*block_hash,
+		)?
+		else {
+			return Ok(());
+		};
+		let notaries = self.worker_context.client.notaries(block_hash)?;
+		let active_ids = notaries.iter().map(|notary| notary.notary_id).collect::<BTreeSet<_>>();
+		let existing_workers = self
+			.workers_by_id
+			.read()
+			.await
+			.iter()
+			.map(|(notary_id, worker)| (*notary_id, worker.clone()))
+			.collect::<Vec<_>>();
+
+		for (notary_id, worker) in existing_workers {
+			if active_ids.contains(&notary_id) {
+				continue;
+			}
+			worker.clear_record().await;
+			worker.clear_connection().await;
+		}
+
+		for notary in notaries {
+			let notary_id = notary.notary_id;
+			let worker = self.ensure_worker(notary_id).await;
+			worker.start_background_task(
+				Arc::clone(&self.worker_context),
+				self.spawn_handle.clone(),
+				self.background_idle_delay,
+			);
+			let host_changed = worker.update_record(notary.clone()).await;
+			if host_changed {
+				worker.clear_connection().await;
+			}
+
+			match notary.state {
+				NotaryState::Locked { .. } => {
+					worker.clear_connection().await;
+					continue;
+				},
+				NotaryState::Reactivated { reprocess_notebook_number } => {
+					worker.pending.lock().await.rewind_to(reprocess_notebook_number);
+					self.worker_context
+						.aux_client
+						.reprocess_notebook(notary_id, reprocess_notebook_number)?;
+				},
+				_ => {},
+			}
+
+			if *self.pause_notebook_audits.read().await {
+				worker.clear_subscription().await;
+				continue;
+			}
+
+			let is_connected = worker.has_client().await && worker.has_subscription().await;
+
+			if !is_connected || host_changed {
+				if let Err(e) = worker.ensure_connected_subscription().await {
+					self.disconnect(
+						&notary_id,
+						Some(format!("Notary {notary_id} sync failed. {e:?}")),
+					)
+					.await;
+				}
+			}
+		}
+		Ok(())
+	}
+
+	pub async fn process_background_audits(self: &Arc<Self>) -> Result<bool, Error> {
+		if *self.pause_notebook_audits.read().await {
+			return Ok(false);
+		}
+		let Some((best_hash, finalized_hash)) =
+			self.resolve_processing_hashes(self.worker_context.client.best_hash())?
+		else {
+			return Ok(false);
+		};
+		self.process_audits_at_hash(best_hash, finalized_hash).await
+	}
+
+	pub async fn process_audits_at(self: &Arc<Self>, block_hash: B::Hash) -> Result<bool, Error> {
+		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
+			return Ok(true);
+		};
+		self.process_audits_at_hash(best_hash, finalized_hash).await
+	}
+
+	async fn process_selected_audits_at(
+		self: &Arc<Self>,
+		block_hash: B::Hash,
+		notary_ids: &BTreeSet<NotaryId>,
+	) -> Result<bool, Error> {
+		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
+			return Ok(true);
+		};
+		self.process_selected_audits_at_hash(best_hash, finalized_hash, notary_ids)
+			.await
+	}
+
+	fn resolve_processing_hashes(
+		&self,
+		block_hash: B::Hash,
+	) -> Result<Option<ProcessingHashes<B::Hash>>, Error> {
+		let Some(best_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			self.worker_context.client.as_ref(),
+			block_hash,
+		)?
+		else {
+			return Ok(None);
+		};
+		let Some(finalized_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			self.worker_context.client.as_ref(),
+			self.worker_context.client.finalized_hash(),
+		)?
+		else {
+			return Ok(None);
+		};
+		Ok(Some((best_hash, finalized_hash)))
+	}
+
+	async fn process_audits_at_hash(
+		self: &Arc<Self>,
+		best_hash: B::Hash,
+		finalized_hash: B::Hash,
+	) -> Result<bool, Error> {
+		let notary_ids = self.workers_by_id.read().await.keys().copied().collect::<BTreeSet<_>>();
+		let has_more_work = self
+			.process_selected_audits_at_hash(best_hash, finalized_hash, &notary_ids)
+			.await?;
+		if let Some(metrics) = self.worker_context.metrics.as_ref() {
+			let workers = self.workers_by_id.read().await;
+			for (notary_id, worker) in workers.iter() {
+				metrics.record_queue_depth(*notary_id, worker.pending.lock().await.len() as u64);
+			}
+		}
+		Ok(has_more_work)
+	}
+
+	async fn process_selected_audits_at_hash(
+		self: &Arc<Self>,
+		best_hash: B::Hash,
+		finalized_hash: B::Hash,
+		notary_ids: &BTreeSet<NotaryId>,
+	) -> Result<bool, Error> {
+		let workers = self
+			.workers_by_id
+			.read()
+			.await
+			.iter()
+			.filter(|(notary_id, _)| notary_ids.contains(notary_id))
+			.map(|(_, worker)| worker.clone())
+			.collect::<Vec<_>>();
+		let mut has_more_work = false;
+		let mut processing = Vec::new();
+		for worker in workers {
+			if worker.pending.lock().await.len() == 0 {
+				continue;
+			}
+			let worker_context = Arc::clone(&self.worker_context);
+			processing.push(tokio::spawn(async move {
+				worker
+					.process_for_hashes(worker_context.as_ref(), best_hash, finalized_hash)
+					.await
+			}));
+		}
+		for result in join_all(processing).await {
+			match result {
+				Ok(Ok(x)) => has_more_work = has_more_work || x,
+				Ok(Err(err)) => {
+					has_more_work = true;
+					warn!("Error processing notebooks for a notary {err:?}");
+				},
+				Err(join_error) => {
+					has_more_work = true;
+					warn!("Error while processing tracked notary audits - {join_error:?}");
+				},
+			}
+		}
+		Ok(has_more_work)
+	}
+
+	pub async fn disconnect(&self, notary_id: &NotaryId, reason: Option<String>) {
+		info!(
+			"Notary client disconnected from notary #{notary_id} (or could not connect). Reason? {reason:?}"
+		);
+		let Some(worker) = self.worker(*notary_id).await else {
+			return;
+		};
+		worker.clear_connection().await;
 	}
 
 	pub(crate) async fn verify_notebook_audits(
@@ -1039,14 +1670,50 @@ where
 			NotebookAuditMode::Sync => None,
 			NotebookAuditMode::Import { max_wait } => Some(max_wait),
 		};
-		let mut missing_audits_by_notary = BTreeMap::new();
-		let notary_ids = self.get_notary_ids().await;
-		let mut needs_notary_updates = false;
-		for digest_record in &notebook_audit_results {
-			let notary_audits =
-				self.aux_client.get_notary_audit_history(digest_record.notary_id)?.get();
+		let mut missing_audits = self.collect_missing_audits(&notebook_audit_results).await?;
+		if missing_audits.by_notary.is_empty() {
+			return Ok(());
+		}
+		info!(
+			"Notebook digest has missing audits. Will attempt to catchup now. {:#?}",
+			missing_audits.by_notary
+		);
+		let wait_time = Self::missing_audit_wait_time(max_wait, missing_audits.by_notary.len());
+		let start = Instant::now();
+		let timeout_error = || {
+			Error::UnableToSyncNotary(format!(
+				"Could not process all missing audits in {} seconds",
+				wait_time.as_secs()
+			))
+		};
+		if missing_audits.needs_notary_updates {
+			let Some(remaining) = wait_time.checked_sub(start.elapsed()) else {
+				warn!("Timed out waiting for missing audits. {:#?}", missing_audits.by_notary);
+				return Err(timeout_error());
+			};
+			tokio::time::timeout(remaining, self.update_notaries(parent_hash))
+				.await
+				.map_err(|_| timeout_error())??;
+		}
+		self.wait_for_missing_audits(parent_hash, &mut missing_audits.by_notary, wait_time)
+			.await
+	}
 
+	async fn collect_missing_audits(
+		&self,
+		notebook_audit_results: &[NotebookAuditResult<NotebookVerifyError>],
+	) -> Result<MissingAuditCatchup, Error> {
+		let mut missing_audits =
+			MissingAuditCatchup { by_notary: BTreeMap::new(), needs_notary_updates: false };
+
+		for digest_record in notebook_audit_results {
+			let notary_audits = self
+				.worker_context
+				.aux_client
+				.get_notary_audit_history(digest_record.notary_id)?
+				.get();
 			let audit = notary_audits.get(&digest_record.notebook_number);
+
 			if let Some(audit) = audit {
 				if digest_record.audit_first_failure != audit.audit_first_failure {
 					return Err(Error::InvalidNotebookDigest(format!(
@@ -1057,55 +1724,63 @@ where
 						audit.audit_first_failure
 					)));
 				}
-			} else {
-				if !notary_ids.contains(&digest_record.notary_id) ||
-					!self.has_client(digest_record.notary_id).await
-				{
-					needs_notary_updates = true;
-				}
-				self.enqueue_notebook(
-					digest_record.notary_id,
-					digest_record.notebook_number,
-					None,
-					None,
-				)
-				.await?;
-				missing_audits_by_notary
-					.entry(digest_record.notary_id)
-					.or_insert_with(Vec::new)
-					.push(digest_record.notebook_number);
+				continue;
 			}
-		}
-		if missing_audits_by_notary.is_empty() {
-			return Ok(());
+
+			let has_runtime_record =
+				if let Some(worker) = self.worker(digest_record.notary_id).await {
+					worker.record.read().await.is_some()
+				} else {
+					false
+				};
+			let has_client = if let Some(worker) = self.worker(digest_record.notary_id).await {
+				worker.has_client().await
+			} else {
+				false
+			};
+			if !has_runtime_record || !has_client {
+				missing_audits.needs_notary_updates = true;
+			}
+			let worker = self.ensure_worker(digest_record.notary_id).await;
+			worker
+				.pending
+				.lock()
+				.await
+				.track_notebook(digest_record.notebook_number, None, None);
+			missing_audits
+				.by_notary
+				.entry(digest_record.notary_id)
+				.or_default()
+				.push(digest_record.notebook_number);
 		}
 
-		info!(
-			"Notebook digest has missing audits. Will attempt to catchup now. {missing_audits_by_notary:#?}"
-		);
+		Ok(missing_audits)
+	}
 
+	fn missing_audit_wait_time(
+		max_wait: Option<Duration>,
+		missing_notary_count: usize,
+	) -> Duration {
+		Duration::from_secs(
+			max_wait
+				.map(|duration| duration.as_secs().max(1))
+				.unwrap_or((missing_notary_count * 5).clamp(6, 120) as u64),
+		)
+	}
+
+	async fn wait_for_missing_audits(
+		self: &Arc<Self>,
+		parent_hash: &B::Hash,
+		missing_audits_by_notary: &mut BTreeMap<NotaryId, Vec<NotebookNumber>>,
+		wait_time: Duration,
+	) -> Result<(), Error> {
 		let start = Instant::now();
-		let calculated_wait_secs = (missing_audits_by_notary.len() * 5).clamp(6, 120) as u64;
-		let wait_time_secs = max_wait
-			.map(|duration| duration.as_secs().max(1))
-			.unwrap_or(calculated_wait_secs);
-		let wait_time = Duration::from_secs(wait_time_secs);
 		let timeout_error = || {
 			Error::UnableToSyncNotary(format!(
-				"Could not process all missing audits in {wait_time_secs} seconds"
+				"Could not process all missing audits in {} seconds",
+				wait_time.as_secs()
 			))
 		};
-
-		if needs_notary_updates {
-			let Some(remaining) = wait_time.checked_sub(start.elapsed()) else {
-				warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
-				return Err(timeout_error());
-			};
-			tokio::time::timeout(remaining, self.update_notaries(parent_hash))
-				.await
-				.map_err(|_| timeout_error())??;
-		}
-
 		loop {
 			if start.elapsed() > wait_time {
 				warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
@@ -1120,11 +1795,20 @@ where
 				return Ok(());
 			}
 
-			let has_more_work =
-				self.process_selected_queues_at(*parent_hash, &missing_notary_ids).await?;
+			let Some(remaining) = wait_time.checked_sub(start.elapsed()) else {
+				warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
+				return Err(timeout_error());
+			};
+			let has_more_work = tokio::time::timeout(
+				remaining,
+				self.process_selected_audits_at(*parent_hash, &missing_notary_ids),
+			)
+			.await
+			.map_err(|_| timeout_error())??;
 			let mut has_missing_audits = false;
 			for (notary_id, audits) in missing_audits_by_notary.iter_mut() {
-				let notary_audits = self.aux_client.get_notary_audit_history(*notary_id)?.get();
+				let notary_audits =
+					self.worker_context.aux_client.get_notary_audit_history(*notary_id)?.get();
 				audits.retain(|notebook_number| !notary_audits.contains_key(notebook_number));
 				if !audits.is_empty() {
 					has_missing_audits = true;
@@ -1137,209 +1821,6 @@ where
 			let sleep_ms = if has_more_work { 30 } else { 250 };
 			tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
 		}
-	}
-
-	async fn get_notebook_dependencies(
-		&self,
-		notary_id: NotaryId,
-		notebook_number: NotebookNumber,
-		best_hash: &B::Hash,
-	) -> Result<Vec<NotaryNotebookAuditSummary>, Error> {
-		let mut notebook_dependencies = vec![];
-		let mut missing_notebooks = vec![];
-
-		let latest_block_notebook = self.latest_notebook_in_runtime(*best_hash, notary_id);
-
-		// get any missing notebooks
-		if latest_block_notebook < notebook_number - 1 {
-			let notary_notebooks = self.aux_client.get_audit_summaries(notary_id)?.get();
-			for notebook_number_needed in (latest_block_notebook + 1)..notebook_number {
-				if let Some(summary) =
-					notary_notebooks.iter().find(|s| s.notebook_number == notebook_number_needed)
-				{
-					notebook_dependencies.push(summary.clone());
-				} else {
-					missing_notebooks.push(notebook_number_needed);
-				}
-			}
-		}
-
-		if !missing_notebooks.is_empty() {
-			for missing in &missing_notebooks {
-				self.enqueue_notebook(notary_id, *missing, None, None).await?;
-			}
-			let notebook_range =
-				missing_notebooks[0]..missing_notebooks[missing_notebooks.len() - 1];
-			info!("Missing notebooks for notary {notary_id}. Enqueued: {notebook_range:?}");
-			return Err(Error::MissingNotebooksError(format!(
-				"Missing notebooks #{notebook_range:?} to audit {notebook_number} for notary {notary_id}"
-			)));
-		}
-		Ok(notebook_dependencies)
-	}
-
-	async fn audit_notebook(
-		&self,
-		best_hash: &B::Hash,
-		notebook_details: &NotaryNotebookDetails<B::Hash>,
-	) -> Result<NotebookAuditResult<NotebookVerifyError>, Error> {
-		let tick = notebook_details.tick;
-		let notary_id = notebook_details.notary_id;
-		let notebook_number = notebook_details.notebook_number;
-		let notebook_dependencies =
-			self.get_notebook_dependencies(notary_id, notebook_number, best_hash).await?;
-		tracing::trace!(
-			notary_id,
-			notebook_number,
-			best_hash = ?best_hash,
-			tick,
-			notebook_dependencies = notebook_dependencies.len(),
-			"Attempting to audit notebook",
-		);
-
-		let full_notebook = self.download_notebook(notary_id, notebook_number).await?;
-		tracing::trace!(
-			notary_id,
-			notebook_number,
-			bytes = full_notebook.0.len(),
-			"Notebook downloaded.",
-		);
-
-		// audit on the best block since we're adding dependencies
-		let audit_failure_reason = match self.client.audit_notebook_and_get_votes(
-			*best_hash,
-			notebook_details.version,
-			notary_id,
-			notebook_number,
-			tick,
-			notebook_details.header_hash,
-			&full_notebook.0,
-			notebook_dependencies.clone(),
-			&notebook_details.blocks_with_votes,
-		)? {
-			Ok(votes) => {
-				let vote_count = votes.raw_votes.len();
-				self.aux_client.store_votes(tick, votes)?;
-
-				tracing::info!(
-					notary_id,
-					notebook_number,
-					tick,
-					"Notebook audit successful. {vote_count} block vote(s).",
-				);
-				None
-			},
-			Err(error) => {
-				// if this is a catchup notebook error, then it's our problem
-				if error == NotebookVerifyError::CatchupNotebooksMissing {
-					tracing::warn!(
-						notary_id,
-						notebook_number,
-						?notebook_dependencies,
-						?best_hash,
-						"Notebook audit failed for notary. Incorrect catchup provided",
-					);
-					return Err(Error::MissingNotebooksError(format!(
-						"Possibly missing notebooks? Invalid catchup notebooks provided to audit. Notary {notary_id}, #{notebook_number}, tick {tick}.",
-					)));
-				}
-
-				// if audit fails and the tick is greater than the runtime, then we should just
-				// signal upwards that this should try again. Once the tick has passed, we'll
-				// consider it failed.
-				if tick > self.client.current_tick(*best_hash)? {
-					return Err(Error::NotebookAuditBeforeTick(format!(
-						"Notebook tick is > runtime. Notary={notary_id}, notebook={notebook_number}, tick={tick}"
-					)));
-				}
-
-				tracing::warn!(
-					notary_id,
-					notebook_number,
-					tick,
-					"Notebook audit failed ({})",
-					error
-				);
-				Some(error)
-			},
-		};
-
-		Ok(NotebookAuditResult {
-			notary_id,
-			tick,
-			notebook_number,
-			audit_first_failure: audit_failure_reason,
-		})
-	}
-
-	fn should_connect_to_notary(notary_record: &NotaryRecordT) -> bool {
-		!matches!(notary_record.state, NotaryState::Locked { .. })
-	}
-
-	async fn get_notary_ids(&self) -> Vec<NotaryId> {
-		self.notaries_by_id.read().await.keys().copied().collect()
-	}
-
-	async fn get_notary_host(&self, notary_id: NotaryId) -> Result<String, Error> {
-		let notaries = self.notaries_by_id.read().await;
-		let record = notaries
-			.get(&notary_id)
-			.ok_or_else(|| Error::NotaryError("No rpc endpoints found for notary".to_string()))?;
-		let host =
-			record.meta.hosts.first().ok_or_else(|| {
-				Error::NotaryError("No rpc endpoint found for notary".to_string())
-			})?;
-		host.clone().try_into().map_err(|e| {
-			Error::NotaryError(format!(
-				"Could not convert host to string for notary {notary_id} - {e:?}"
-			))
-		})
-	}
-
-	async fn get_or_connect_to_client(
-		&self,
-		notary_id: NotaryId,
-	) -> Result<Arc<argon_notary_apis::Client>, Error> {
-		if let std::collections::btree_map::Entry::Vacant(e) =
-			self.notary_client_by_id.write().await.entry(notary_id)
-		{
-			let host_str = self.get_notary_host(notary_id).await?;
-			let c = argon_notary_apis::create_client(&host_str).await.map_err(|e| {
-				Error::NotaryError(format!(
-					"Could not connect to notary {notary_id} ({host_str}) for audit - {e:?}"
-				))
-			})?;
-			let c = Arc::new(c);
-			e.insert(c.clone());
-		}
-		self.get_client(notary_id)
-			.await
-			.ok_or_else(|| Error::NotaryError("Could not connect to notary for audit".to_string()))
-	}
-
-	async fn has_client(&self, notary_id: NotaryId) -> bool {
-		self.notary_client_by_id.read().await.contains_key(&notary_id)
-	}
-
-	async fn has_subscription(&self, notary_id: NotaryId) -> bool {
-		self.subscriptions_by_id.read().await.contains_key(&notary_id)
-	}
-
-	async fn get_client(&self, notary_id: NotaryId) -> Option<Arc<argon_notary_apis::Client>> {
-		self.notary_client_by_id.read().await.get(&notary_id).cloned()
-	}
-
-	fn latest_notebook_in_runtime(
-		&self,
-		block_hash: B::Hash,
-		notary_id: NotaryId,
-	) -> NotebookNumber {
-		if let Ok(latest_notebooks_in_runtime) = self.client.latest_notebook_by_notary(block_hash) {
-			if let Some((latest_notebook, _)) = latest_notebooks_in_runtime.get(&notary_id) {
-				return *latest_notebook;
-			}
-		}
-		0
 	}
 }
 
@@ -1568,7 +2049,7 @@ mod test {
 	use crate::mock_notary::setup_logs;
 	use sp_core::{H256, bounded_vec};
 	use sp_keyring::Ed25519Keyring;
-	use std::collections::BTreeMap;
+	use std::collections::{BTreeMap, BTreeSet};
 
 	#[derive(Clone, Default)]
 	struct TestNode {
@@ -1789,10 +2270,99 @@ mod test {
 			notebook_downloader,
 			Arc::new(None),
 			ticker,
+			None,
+			Duration::from_millis(250),
 			true,
 		);
 		let notary_client = Arc::new(notary_client);
 		(test_notary, client, notary_client)
+	}
+
+	async fn worker(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> Option<Arc<NotaryWorker>> {
+		notary_client.worker(notary_id).await
+	}
+
+	async fn worker_tracking_snapshot(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> Vec<(NotebookNumber, bool)> {
+		let Some(worker) = worker(notary_client, notary_id).await else {
+			return Vec::new();
+		};
+		worker.pending.lock().await.snapshot()
+	}
+
+	async fn worker_tracked_notebook_count(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> usize {
+		let Some(worker) = worker(notary_client, notary_id).await else {
+			return 0;
+		};
+		worker.pending.lock().await.len()
+	}
+
+	async fn track_worker_notebook(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+		notebook_number: NotebookNumber,
+		header_bytes: Option<SignedHeaderBytes>,
+		known_since: Option<Instant>,
+	) {
+		let worker = notary_client.ensure_worker(notary_id).await;
+		worker
+			.pending
+			.lock()
+			.await
+			.track_notebook(notebook_number, header_bytes, known_since);
+	}
+
+	async fn has_worker_client(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> bool {
+		let Some(worker) = worker(notary_client, notary_id).await else {
+			return false;
+		};
+		worker.has_client().await
+	}
+
+	async fn has_worker_subscription(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> bool {
+		let Some(worker) = worker(notary_client, notary_id).await else {
+			return false;
+		};
+		worker.has_subscription().await
+	}
+
+	async fn wait_for_subscription(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		wait_duration: Duration,
+	) -> Option<(NotaryId, NotebookNumber)> {
+		let start = Instant::now();
+		loop {
+			let worker_ids =
+				notary_client.workers_by_id.read().await.keys().copied().collect::<Vec<_>>();
+			for notary_id in worker_ids {
+				let Some(worker) = worker(notary_client, notary_id).await else {
+					continue;
+				};
+				if let Some(notebook_number) =
+					worker.poll_subscription(notary_client.worker_context.as_ref()).await
+				{
+					return Some((notary_id, notebook_number));
+				}
+			}
+			if start.elapsed() > wait_duration {
+				return None;
+			}
+			tokio::task::yield_now().await;
+		}
 	}
 
 	#[tokio::test]
@@ -1802,12 +2372,12 @@ mod test {
 			.update_notaries(&client.best_hash())
 			.await
 			.expect("Could not update notaries");
-		assert_eq!(notary_client.notaries_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 1);
+		assert_eq!(notary_client.workers_by_id.read().await.len(), 1);
+		assert!(has_worker_client(&notary_client, 1).await);
+		assert!(has_worker_subscription(&notary_client, 1).await);
 
 		test_notary.create_notebook_header(vec![]).await;
-		let next = notary_client.next_subscription(Duration::from_millis(500)).await.unwrap();
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500)).await.unwrap();
 		assert_eq!(next.0, 1);
 
 		// now mark the notary as audit failed
@@ -1820,114 +2390,50 @@ mod test {
 			.update_notaries(&client.best_hash())
 			.await
 			.expect("Could not update notaries");
-		assert_eq!(notary_client.notaries_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 0);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 0);
+		assert_eq!(notary_client.workers_by_id.read().await.len(), 1);
+		assert!(!has_worker_client(&notary_client, 1).await);
+		assert!(!has_worker_subscription(&notary_client, 1).await);
 		test_notary.create_notebook_header(vec![]).await;
-		let next = notary_client.next_subscription(Duration::from_millis(500)).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500)).await;
 		assert!(next.is_none());
 	}
 
 	#[tokio::test]
-	async fn wont_reconnect_if_queue_depth_exceeded() {
-		setup_logs();
-		let (test_notary, client, notary_client) = system().await;
-		notary_client
-			.update_notaries(&client.best_hash())
-			.await
-			.expect("Could not update notaries");
-		assert_eq!(notary_client.notaries_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 1);
-		for i in 0..MAX_QUEUE_DEPTH {
-			test_notary.create_notebook_header(vec![]).await;
-			notary_client.next_subscription(Duration::from_millis(500)).await;
-			assert_eq!(notary_client.queue_depth(1).await, i + 1);
-		}
-
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.len(), 1);
-
-		assert_eq!(notary_client.queue_depth(1).await, MAX_QUEUE_DEPTH);
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 1);
-
-		test_notary.create_notebook_header(vec![]).await;
-		notary_client.next_subscription(Duration::from_millis(500)).await;
-		assert_eq!(notary_client.queue_depth(1).await, MAX_QUEUE_DEPTH + 1);
-		// should have disconnected subscriptions, but kept notary client
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 0);
-	}
-
-	#[tokio::test]
-	async fn handles_queueing_correctly() {
+	async fn handles_notebook_tracking_correctly() {
 		let (_test_notary, _client, notary_client) = system().await;
-		notary_client
-			.enqueue_notebook(1, 3, None, None)
-			.await
-			.expect("Could not enqueue");
-		notary_client
-			.enqueue_notebook(1, 1, None, None)
-			.await
-			.expect("Could not enqueue");
-		notary_client
-			.enqueue_notebook(1, 2, None, None)
-			.await
-			.expect("Could not enqueue");
+		track_worker_notebook(&notary_client, 1, 3, None, None).await;
+		track_worker_notebook(&notary_client, 1, 1, None, None).await;
+		track_worker_notebook(&notary_client, 1, 2, None, None).await;
 		assert_eq!(
-			notary_client
-				.notebook_queue_by_id
-				.read()
-				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| (*n, a.is_some()))
-				.collect::<Vec<_>>(),
+			worker_tracking_snapshot(&notary_client, 1).await,
 			vec![(1, false), (2, false), (3, false)]
 		);
-		let next = notary_client.get_next(1, 0).await;
+		let next = worker(&notary_client, 1)
+			.await
+			.expect("worker should exist")
+			.next_for_processing(notary_client.worker_context.as_ref(), 0)
+			.await;
 		assert!(next.is_none());
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&1).unwrap().len(), 3);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 3);
 
-		notary_client
-			.enqueue_notebook(1, 2, Some(Default::default()), None)
-			.await
-			.expect("Could not enqueue");
-		notary_client
-			.enqueue_notebook(1, 1, Some(Default::default()), None)
-			.await
-			.expect("Could not enqueue");
+		track_worker_notebook(&notary_client, 1, 2, Some(Default::default()), None).await;
+		track_worker_notebook(&notary_client, 1, 1, Some(Default::default()), None).await;
 
 		assert_eq!(
-			notary_client
-				.notebook_queue_by_id
-				.read()
-				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| (*n, a.is_some()))
-				.collect::<Vec<_>>(),
+			worker_tracking_snapshot(&notary_client, 1).await,
 			vec![(1, true), (2, true), (3, false)]
 		);
 
-		notary_client
-			.enqueue_notebook(1, 1, None, None)
-			.await
-			.expect("Could not enqueue");
+		track_worker_notebook(&notary_client, 1, 1, None, None).await;
 		assert_eq!(
-			notary_client
-				.notebook_queue_by_id
-				.read()
-				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| (*n, a.is_some()))
-				.collect::<Vec<_>>(),
+			worker_tracking_snapshot(&notary_client, 1).await,
 			vec![(1, true), (2, true), (3, false)]
 		);
-		let next = notary_client.get_next(1, 0).await;
+		let next = worker(&notary_client, 1)
+			.await
+			.expect("worker should exist")
+			.next_for_processing(notary_client.worker_context.as_ref(), 0)
+			.await;
 		assert!(next.is_some());
 	}
 
@@ -1998,6 +2504,36 @@ mod test {
 	}
 
 	#[tokio::test]
+	async fn reconnects_on_periodic_refresh_without_new_block() {
+		setup_logs();
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert!(has_worker_client(&notary_client, 1).await);
+		assert!(has_worker_subscription(&notary_client, 1).await);
+
+		notary_client.disconnect(&1, None).await;
+		assert!(!has_worker_client(&notary_client, 1).await);
+		assert!(!has_worker_subscription(&notary_client, 1).await);
+
+		// Periodic notary refreshes reuse the same best hash when no new block has arrived.
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not refresh notaries");
+		assert!(has_worker_client(&notary_client, 1).await);
+		assert!(has_worker_subscription(&notary_client, 1).await);
+
+		test_notary.create_notebook_header(vec![]).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500))
+			.await
+			.expect("worker should resubscribe without a new block");
+		assert_eq!(next, (1, 1));
+	}
+
+	#[tokio::test]
 	async fn supplies_missing_notebooks_on_audit() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
@@ -2006,20 +2542,19 @@ mod test {
 			.expect("Could not update notaries");
 
 		let result = notary_client
-			.get_notebook_dependencies(test_notary.notary_id, 10, &client.best_hash())
+			.worker(test_notary.notary_id)
+			.await
+			.expect("worker should exist")
+			.get_notebook_dependencies(
+				notary_client.worker_context.as_ref(),
+				10,
+				&client.best_hash(),
+			)
 			.await
 			.expect_err("Should not have all dependencies");
 		assert!(matches!(result, Error::MissingNotebooksError(_)),);
 		assert_eq!(
-			notary_client
-				.notebook_queue_by_id
-				.read()
-				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| (*n, a.is_some()))
-				.collect::<Vec<_>>(),
+			worker_tracking_snapshot(&notary_client, 1).await,
 			vec![
 				(1, false),
 				(2, false),
@@ -2034,7 +2569,14 @@ mod test {
 		);
 		client.latest_notebook_by_notary.lock().insert(1, (8, 1));
 		let result = notary_client
-			.get_notebook_dependencies(test_notary.notary_id, 10, &client.best_hash())
+			.worker(test_notary.notary_id)
+			.await
+			.expect("worker should exist")
+			.get_notebook_dependencies(
+				notary_client.worker_context.as_ref(),
+				10,
+				&client.best_hash(),
+			)
 			.await
 			.expect_err("Should have all dependencies");
 
@@ -2044,34 +2586,62 @@ mod test {
 		assert!(result.to_string().contains("#9..9"));
 
 		for _ in 0..9 {
-			notary_client.process_queues(None).await.expect("Could not process queues");
-		}
-		assert_eq!(
 			notary_client
-				.notebook_queue_by_id
-				.read()
+				.process_background_audits()
 				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| { (*n, a.is_some()) })
-				.collect::<Vec<_>>(),
-			vec![(9, false)]
-		);
+				.expect("Could not process queues");
+		}
+		assert_eq!(worker_tracking_snapshot(&notary_client, 1).await, vec![(9, false)]);
 		for _ in 0..10 {
 			test_notary.create_notebook_header(vec![]).await;
-			notary_client.process_queues(None).await.expect("Could not process queues");
+			notary_client
+				.process_background_audits()
+				.await
+				.expect("Could not process queues");
 		}
 		let mut rx = notary_client.tick_voting_power_receiver.lock().await;
 		let next_rx = rx.next().await.expect("Could not receive");
 		assert_eq!(next_rx.0, 9);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&1).unwrap(), &vec![]);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 		let result = notary_client
-			.get_notebook_dependencies(test_notary.notary_id, 10, &client.best_hash())
+			.worker(test_notary.notary_id)
+			.await
+			.expect("worker should exist")
+			.get_notebook_dependencies(
+				notary_client.worker_context.as_ref(),
+				10,
+				&client.best_hash(),
+			)
 			.await
 			.expect("Could not retrieve missing notebooks");
 		assert_eq!(result.len(), 1);
 		assert_eq!(result[0].notebook_number, 9);
+	}
+
+	#[tokio::test]
+	async fn tracks_full_missing_notebook_dependency_range() {
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		let result = notary_client
+			.worker(test_notary.notary_id)
+			.await
+			.expect("worker should exist")
+			.get_notebook_dependencies(
+				notary_client.worker_context.as_ref(),
+				42,
+				&client.best_hash(),
+			)
+			.await
+			.expect_err("Should not have all dependencies");
+		assert!(matches!(result, Error::MissingNotebooksError(_)));
+		assert_eq!(
+			worker_tracking_snapshot(&notary_client, 1).await,
+			(1..42).map(|number| (number, false)).collect::<Vec<_>>()
+		);
 	}
 
 	#[tokio::test]
@@ -2088,12 +2658,21 @@ mod test {
 		test_notary.create_notebook_header(vec![]).await;
 		test_notary2.create_notebook_header(vec![]).await;
 
-		notary_client.next_subscription(Duration::from_millis(500)).await;
-		assert_eq!(notary_client.queue_depth(1).await, 1);
-		assert!(notary_client.notebook_queue_by_id.read().await.get(&2).is_none());
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		assert_eq!(notary_client.queue_depth(1).await, 0);
-		assert!(notary_client.notebook_queue_by_id.read().await.get(&2).is_none());
+		wait_for_subscription(&notary_client, Duration::from_millis(500)).await;
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
+		assert!(
+			worker(&notary_client, 2).await.is_none() ||
+				worker_tracked_notebook_count(&notary_client, 2).await == 0
+		);
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
+		assert!(
+			worker(&notary_client, 2).await.is_none() ||
+				worker_tracked_notebook_count(&notary_client, 2).await == 0
+		);
 
 		let next_rx = notary_client
 			.tick_voting_power_receiver
@@ -2108,29 +2687,32 @@ mod test {
 			.update_notaries(&client.best_hash())
 			.await
 			.expect("Could not update notaries");
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 2);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 2);
+		assert!(has_worker_client(&notary_client, 1).await);
+		assert!(has_worker_client(&notary_client, 2).await);
+		assert!(has_worker_subscription(&notary_client, 1).await);
+		assert!(has_worker_subscription(&notary_client, 2).await);
 
 		test_notary.create_notebook_header(vec![]).await;
 		test_notary2.create_notebook_header(vec![]).await;
 
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
 
-		assert_eq!(notary_client.queue_depth(1).await, 1);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&1).unwrap()[0].0, 2);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&2).unwrap().len(), 2);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&2).unwrap()[0].0, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
+		assert_eq!(worker_tracking_snapshot(&notary_client, 1).await[0].0, 2);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 2).await, 2);
+		assert_eq!(worker_tracking_snapshot(&notary_client, 2).await[0].0, 1);
 		// should process one from each notary
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		assert_eq!(notary_client.queue_depth(1).await, 0);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&2).unwrap().len(), 1);
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 2).await, 1);
 	}
 
 	#[tokio::test]
@@ -2151,23 +2733,17 @@ mod test {
 
 		let notebook_1 = test_notary.create_notebook_header(vec![]).await;
 		let notebook_2 = test_notary2.create_notebook_header(vec![]).await;
-		notary_client
-			.enqueue_notebook(1, notebook_1.notebook_number, None, None)
-			.await
-			.expect("Could not enqueue notebook for first notary");
-		notary_client
-			.enqueue_notebook(2, notebook_2.notebook_number, None, None)
-			.await
-			.expect("Could not enqueue notebook for second notary");
+		track_worker_notebook(&notary_client, 1, notebook_1.notebook_number, None, None).await;
+		track_worker_notebook(&notary_client, 2, notebook_2.notebook_number, None, None).await;
 
 		let targeted = BTreeSet::from([1]);
 		notary_client
-			.process_selected_queues_at(client.best_hash(), &targeted)
+			.process_selected_audits_at(client.best_hash(), &targeted)
 			.await
 			.expect("Could not process targeted queues");
 
-		assert_eq!(notary_client.queue_depth(1).await, 0);
-		assert_eq!(notary_client.queue_depth(2).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 2).await, 1);
 	}
 
 	#[tokio::test]
@@ -2179,11 +2755,10 @@ mod test {
 			.expect("Could not update notaries");
 
 		test_notary.create_notebook_header(vec![]).await;
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
 		let block_0 = H256::from_slice(&[0; 32]);
 		let block_1 = H256::from_slice(&[1; 32]);
@@ -2206,10 +2781,12 @@ mod test {
 			raw_audit_summary: vec![],
 		});
 
-		let has_more_work =
-			notary_client.process_queues(None).await.expect("Could not process queues");
+		let has_more_work = notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_2));
 	}
 
@@ -2222,11 +2799,10 @@ mod test {
 			.expect("Could not update notaries");
 
 		test_notary.create_notebook_header(vec![]).await;
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
 		let block_0 = H256::from_slice(&[0; 32]);
 		let block_1 = H256::from_slice(&[1; 32]);
@@ -2250,15 +2826,17 @@ mod test {
 			raw_audit_summary: vec![],
 		});
 
-		let has_more_work =
-			notary_client.process_queues(None).await.expect("Could not process queues");
+		let has_more_work = notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_1));
 	}
 
 	#[tokio::test]
-	async fn paused_queue_processing_returns_false_and_keeps_queue() {
+	async fn paused_notebook_audits_return_false_and_keep_tracking() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
 			.update_notaries(&client.best_hash())
@@ -2266,18 +2844,52 @@ mod test {
 			.expect("Could not update notaries");
 
 		test_notary.create_notebook_header(vec![]).await;
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
-		*notary_client.pause_queue_processing.write().await = true;
+		*notary_client.pause_notebook_audits.write().await = true;
 
-		let has_more_work =
-			notary_client.process_queues(None).await.expect("Could not process queues");
+		let has_more_work = notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
+	}
+
+	#[tokio::test]
+	async fn paused_queue_processing_drops_subscription_backlog() {
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert!(has_worker_subscription(&notary_client, 1).await);
+
+		*notary_client.pause_notebook_audits.write().await = true;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert!(!has_worker_subscription(&notary_client, 1).await);
+
+		test_notary.create_notebook_header(vec![]).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(250)).await;
+		assert!(next.is_none());
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
+
+		*notary_client.pause_notebook_audits.write().await = false;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert!(has_worker_subscription(&notary_client, 1).await);
+
+		test_notary.create_notebook_header(vec![]).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500)).await;
+		assert_eq!(next, Some((1, 2)));
 	}
 
 	#[tokio::test]
@@ -2289,11 +2901,10 @@ mod test {
 			.expect("Could not update notaries");
 
 		test_notary.create_notebook_header(vec![]).await;
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
 		let block_0 = H256::from_slice(&[0; 32]);
 		let block_1 = H256::from_slice(&[1; 32]);
@@ -2317,11 +2928,11 @@ mod test {
 		});
 
 		let has_more_work = notary_client
-			.process_queues_at(block_2)
+			.process_audits_at(block_2)
 			.await
 			.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_1));
 	}
 
@@ -2337,32 +2948,94 @@ mod test {
 		test_notary.create_notebook_header(vec![]).await;
 		test_notary.create_notebook_header(vec![]).await;
 
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 2);
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 2);
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 3);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 3);
 
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
 		*client.current_tick.lock() = 2;
 		client
 			.audit_failure
 			.lock()
 			.replace(NotebookVerifyError::InvalidChainTransfersList);
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
+	}
+
+	#[tokio::test]
+	async fn import_wait_timeout_does_not_block_on_slow_audit_work() {
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		let notebook = test_notary.create_notebook_header(vec![]).await;
+		track_worker_notebook(&notary_client, 1, notebook.notebook_number, None, None).await;
+
+		let audit_slots = notary_client
+			.worker_context
+			.audit_slots
+			.acquire_many(MAX_PARALLEL_NOTARY_AUDITS as u32)
+			.await
+			.expect("Could not exhaust audit slots");
+		let mut missing_audits = BTreeMap::from([(1, vec![notebook.notebook_number])]);
+		let start = Instant::now();
+		let result = notary_client
+			.wait_for_missing_audits(
+				&client.best_hash(),
+				&mut missing_audits,
+				Duration::from_millis(50),
+			)
+			.await;
+		assert!(matches!(result, Err(Error::UnableToSyncNotary(_))));
+		assert!(
+			start.elapsed() < Duration::from_millis(250),
+			"import wait should return promptly once its deadline is exceeded",
+		);
+
+		drop(audit_slots);
+
+		let mut audit_completed = false;
+		for _ in 0..25 {
+			if notary_client
+				.worker_context
+				.aux_client
+				.get_notary_audit_history(1)
+				.expect("could not read audit history")
+				.get()
+				.contains_key(&notebook.notebook_number)
+			{
+				audit_completed = true;
+				break;
+			}
+			tokio::time::sleep(Duration::from_millis(20)).await;
+		}
+
+		assert!(
+			audit_completed,
+			"in-flight notary work should continue after the import wait times out",
+		);
 	}
 
 	#[tokio::test]
@@ -2400,9 +3073,11 @@ mod test {
 			blocks_with_votes: vec![],
 			raw_audit_summary: vec![],
 		});
-		let _ = notary_client
+		let _ = worker(&notary_client, 1)
+			.await
+			.expect("worker should exist")
 			.process_notebook(
-				1,
+				notary_client.worker_context.as_ref(),
 				3,
 				2,
 				&H256::from_slice(&[4; 32]),

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -2,10 +2,7 @@ use crate::{
 	aux_client::ArgonAux,
 	error::Error,
 	metrics::ConsensusMetrics,
-	state_anchor::{
-		DEFAULT_STATE_LOOKBACK_DEPTH, ResolveBestOrFinalizedStateHashError, StateAnchorClient,
-		resolve_best_or_finalized_state_hash,
-	},
+	state_anchor::{DEFAULT_STATE_LOOKBACK_DEPTH, StateAnchorClient},
 };
 use argon_notary_apis::{
 	ArchiveHost, Client, DownloadKind, DownloadPolicy, DownloadTrustMode, SystemRpcClient,
@@ -57,6 +54,13 @@ use tokio::{
 use tracing::error;
 
 const MAX_QUEUE_DEPTH: usize = 1440 * 2; // a notary can be down 2 days before we start dropping history
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum NotebookAuditMode {
+	Sync,
+	Import { max_wait: Duration },
+}
 
 pub trait NotaryApisExt<B: BlockT, AC> {
 	fn has_block_state(&self, block_hash: B::Hash) -> bool;
@@ -213,19 +217,14 @@ where
 	let notary_sync_task = async move {
 		let idle_delay = if ticker.tick_duration_millis <= 10_000 { 100 } else { 1000 };
 		let idle_delay = Duration::from_millis(idle_delay);
-		let initial_notary_hash = match resolve_best_or_finalized_state_hash(
-			notary_client_poll.as_ref(),
-			best_block,
-			client.finalized_hash(),
-			DEFAULT_STATE_LOOKBACK_DEPTH,
-		) {
-			Ok(hash) => Some(hash),
-			Err(ResolveBestOrFinalizedStateHashError::NoAvailableStateHash) => None,
-			Err(ResolveBestOrFinalizedStateHashError::Client(err)) => {
-				warn!("Could not resolve a stateful hash for initial notary update - {err:?}");
-				None
-			},
-		};
+		let initial_notary_hash =
+			match resolve_client_stateful_hash::<B, _, AC>(client.as_ref(), best_block) {
+				Ok(hash) => hash,
+				Err(err) => {
+					warn!("Could not resolve a stateful hash for initial notary update - {err:?}");
+					None
+				},
+			};
 		if let Some(initial_notary_hash) = initial_notary_hash {
 			notary_client_poll
 				.update_notaries(&initial_notary_hash)
@@ -251,10 +250,17 @@ where
 				Some(ref block) = best_block.next() => {
 					if block.is_new_best {
 						let best_hash = block.hash;
-						if !client.has_block_state(best_hash) {
-							// We don't have the block state yet, so we can't update notaries
+						let Some(best_hash) =
+							resolve_client_stateful_hash::<B, _, AC>(client.as_ref(), best_hash)
+								.unwrap_or_else(|err| {
+									warn!(
+										"Could not resolve a stateful hash for best-block notary update - {err:?}"
+									);
+									None
+								})
+						else {
 							continue;
-						}
+						};
 						if let Err(e) = notary_client_poll.update_notaries(&best_hash).await {
 							warn!(
 
@@ -265,7 +271,15 @@ where
 				},
 				_ = health_tick.tick() => {
 					let best_hash = client.best_hash();
-					if client.has_block_state(best_hash) {
+					if let Some(best_hash) =
+						resolve_client_stateful_hash::<B, _, AC>(client.as_ref(), best_hash)
+							.unwrap_or_else(|err| {
+								warn!(
+									"Could not resolve a stateful hash for periodic notary update - {err:?}"
+								);
+								None
+							})
+					{
 						let _ = notary_client_poll.update_notaries(&best_hash).await;
 					}
 				},
@@ -302,6 +316,7 @@ where
 }
 
 type PendingNotebook = (NotebookNumber, Option<SignedHeaderBytes>, Instant);
+type ProcessingHashes<Hash> = (Hash, Hash);
 
 type NotebookCount = u32;
 pub type VotingPowerInfo = (Tick, BlockVotingPower, NotebookCount);
@@ -384,7 +399,12 @@ where
 	}
 
 	pub async fn update_notaries(&self, block_hash: &B::Hash) -> Result<(), Error> {
-		let notaries = self.client.notaries(*block_hash)?;
+		let Some(block_hash) =
+			resolve_client_stateful_hash::<B, _, AC>(self.client.as_ref(), *block_hash)?
+		else {
+			return Ok(());
+		};
+		let notaries = self.client.notaries(block_hash)?;
 		let mut reconnect_ids = BTreeSet::new();
 
 		{
@@ -549,13 +569,79 @@ where
 			return Ok(true);
 		};
 		let is_import_context = importing_with_parent_hash.is_some();
-		let finalized_hash = self.client.finalized_hash();
-		let best_hash = importing_with_parent_hash.unwrap_or(self.client.best_hash());
-		if !self.client.has_block_state(finalized_hash) || !self.client.has_block_state(best_hash) {
+		let block_hash = importing_with_parent_hash.unwrap_or(self.client.best_hash());
+		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
 			return Ok(is_import_context);
-		}
-		let queued_notaries =
-			self.notebook_queue_by_id.read().await.keys().cloned().collect::<Vec<_>>();
+		};
+		self.process_queues_at_hash(best_hash, finalized_hash).await
+	}
+
+	pub async fn process_queues_at(self: &Arc<Self>, block_hash: B::Hash) -> Result<bool, Error> {
+		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
+			return Ok(true);
+		};
+		self.process_queues_at_hash(best_hash, finalized_hash).await
+	}
+
+	async fn process_selected_queues_at(
+		self: &Arc<Self>,
+		block_hash: B::Hash,
+		notary_ids: &BTreeSet<NotaryId>,
+	) -> Result<bool, Error> {
+		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
+			return Ok(true);
+		};
+		self.process_selected_queues_at_hash(best_hash, finalized_hash, notary_ids)
+			.await
+	}
+
+	fn resolve_processing_hashes(
+		&self,
+		block_hash: B::Hash,
+	) -> Result<Option<ProcessingHashes<B::Hash>>, Error> {
+		let Some(best_hash) =
+			resolve_client_stateful_hash::<B, _, AC>(self.client.as_ref(), block_hash)?
+		else {
+			return Ok(None);
+		};
+		let Some(finalized_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			self.client.as_ref(),
+			self.client.finalized_hash(),
+		)?
+		else {
+			return Ok(None);
+		};
+		Ok(Some((best_hash, finalized_hash)))
+	}
+
+	async fn process_queues_at_hash(
+		self: &Arc<Self>,
+		best_hash: B::Hash,
+		finalized_hash: B::Hash,
+	) -> Result<bool, Error> {
+		let notary_ids =
+			self.notebook_queue_by_id.read().await.keys().copied().collect::<BTreeSet<_>>();
+		let has_more_work = self
+			.process_selected_queues_at_hash(best_hash, finalized_hash, &notary_ids)
+			.await?;
+		self.log_queue_depth().await;
+		Ok(has_more_work)
+	}
+
+	async fn process_selected_queues_at_hash(
+		self: &Arc<Self>,
+		best_hash: B::Hash,
+		finalized_hash: B::Hash,
+		notary_ids: &BTreeSet<NotaryId>,
+	) -> Result<bool, Error> {
+		let queued_notaries = self
+			.notebook_queue_by_id
+			.read()
+			.await
+			.keys()
+			.copied()
+			.filter(|notary_id| notary_ids.contains(notary_id))
+			.collect::<Vec<_>>();
 
 		let handles = queued_notaries.into_iter().map(|notary_id| {
 			let finalized_notebook_number =
@@ -591,7 +677,7 @@ where
 							e,
 							Error::MissingNotebooksError(_) |
 								Error::NotebookAuditBeforeTick(_) |
-								Error::StateUnavailableError
+								Error::NotaryAuditDeferred(_)
 						) {
 							trace!("In queue, re-queuing notebook for notary {notary_id} - {e:?}");
 							self_clone
@@ -625,7 +711,6 @@ where
 				},
 			}
 		}
-		self.log_queue_depth().await;
 		Ok(has_more_work)
 	}
 
@@ -875,11 +960,15 @@ where
 				);
 				let parent_hash = self.client.parent_hash(&best_hash)?;
 				if parent_hash == best_hash {
-					return Err(Error::StateUnavailableError);
+					return Err(Error::NotaryAuditDeferred(format!(
+						"Missing state while locating audit parent. Notary={notary_id}, notebook={notebook_number}, block={best_hash:?}"
+					)));
 				}
 				best_hash = parent_hash;
 				if !self.client.has_block_state(best_hash) {
-					return Err(Error::StateUnavailableError);
+					return Err(Error::NotaryAuditDeferred(format!(
+						"Missing state while locating audit parent. Notary={notary_id}, notebook={notebook_number}, block={best_hash:?}"
+					)));
 				}
 				latest_notebook_in_runtime = self.latest_notebook_in_runtime(best_hash, notary_id);
 			}
@@ -940,93 +1029,114 @@ where
 		Ok(())
 	}
 
-	pub async fn verify_notebook_audits(
+	pub(crate) async fn verify_notebook_audits(
 		self: &Arc<Self>,
 		parent_hash: &B::Hash,
 		notebook_audit_results: Vec<NotebookAuditResult<NotebookVerifyError>>,
+		mode: NotebookAuditMode,
 	) -> Result<(), Error> {
-		for _ in 0..2 {
-			let mut missing_audits_by_notary = BTreeMap::new();
-			let notary_ids = self.get_notary_ids().await;
-			let mut needs_notary_updates = false;
-			for digest_record in &notebook_audit_results {
-				let notary_audits =
-					self.aux_client.get_notary_audit_history(digest_record.notary_id)?.get();
+		let max_wait = match mode {
+			NotebookAuditMode::Sync => None,
+			NotebookAuditMode::Import { max_wait } => Some(max_wait),
+		};
+		let mut missing_audits_by_notary = BTreeMap::new();
+		let notary_ids = self.get_notary_ids().await;
+		let mut needs_notary_updates = false;
+		for digest_record in &notebook_audit_results {
+			let notary_audits =
+				self.aux_client.get_notary_audit_history(digest_record.notary_id)?.get();
 
-				let audit = notary_audits.get(&digest_record.notebook_number);
-
-				if let Some(audit) = audit {
-					if digest_record.audit_first_failure != audit.audit_first_failure {
-						return Err(Error::InvalidNotebookDigest(format!(
-							"Notary {}, notebook #{} has an audit mismatch \"{:?}\" with local result. \"{:?}\"",
-							digest_record.notary_id,
-							digest_record.notebook_number,
-							digest_record.audit_first_failure,
-							audit.audit_first_failure
-						)));
-					}
-				} else {
-					if !notary_ids.contains(&digest_record.notary_id) ||
-						!self.has_client(digest_record.notary_id).await
-					{
-						needs_notary_updates = true;
-					}
-					self.enqueue_notebook(
+			let audit = notary_audits.get(&digest_record.notebook_number);
+			if let Some(audit) = audit {
+				if digest_record.audit_first_failure != audit.audit_first_failure {
+					return Err(Error::InvalidNotebookDigest(format!(
+						"Notary {}, notebook #{} has an audit mismatch \"{:?}\" with local result. \"{:?}\"",
 						digest_record.notary_id,
 						digest_record.notebook_number,
-						None,
-						None,
-					)
-					.await?;
-					missing_audits_by_notary
-						.entry(digest_record.notary_id)
-						.or_insert_with(Vec::new)
-						.push(digest_record.notebook_number);
+						digest_record.audit_first_failure,
+						audit.audit_first_failure
+					)));
 				}
+			} else {
+				if !notary_ids.contains(&digest_record.notary_id) ||
+					!self.has_client(digest_record.notary_id).await
+				{
+					needs_notary_updates = true;
+				}
+				self.enqueue_notebook(
+					digest_record.notary_id,
+					digest_record.notebook_number,
+					None,
+					None,
+				)
+				.await?;
+				missing_audits_by_notary
+					.entry(digest_record.notary_id)
+					.or_insert_with(Vec::new)
+					.push(digest_record.notebook_number);
 			}
-			if missing_audits_by_notary.is_empty() {
+		}
+		if missing_audits_by_notary.is_empty() {
+			return Ok(());
+		}
+
+		info!(
+			"Notebook digest has missing audits. Will attempt to catchup now. {missing_audits_by_notary:#?}"
+		);
+
+		let start = Instant::now();
+		let calculated_wait_secs = (missing_audits_by_notary.len() * 5).clamp(6, 120) as u64;
+		let wait_time_secs = max_wait
+			.map(|duration| duration.as_secs().max(1))
+			.unwrap_or(calculated_wait_secs);
+		let wait_time = Duration::from_secs(wait_time_secs);
+		let timeout_error = || {
+			Error::UnableToSyncNotary(format!(
+				"Could not process all missing audits in {wait_time_secs} seconds"
+			))
+		};
+
+		if needs_notary_updates {
+			let Some(remaining) = wait_time.checked_sub(start.elapsed()) else {
+				warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
+				return Err(timeout_error());
+			};
+			tokio::time::timeout(remaining, self.update_notaries(parent_hash))
+				.await
+				.map_err(|_| timeout_error())??;
+		}
+
+		loop {
+			if start.elapsed() > wait_time {
+				warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
+				return Err(timeout_error());
+			}
+
+			let missing_notary_ids = missing_audits_by_notary
+				.iter()
+				.filter_map(|(notary_id, audits)| (!audits.is_empty()).then_some(*notary_id))
+				.collect::<BTreeSet<_>>();
+			if missing_notary_ids.is_empty() {
 				return Ok(());
 			}
 
-			info!(
-				"Notebook digest has missing audits. Will attempt to catchup now. {missing_audits_by_notary:#?}"
-			);
-
-			if needs_notary_updates {
-				self.update_notaries(parent_hash).await?;
-			}
-
-			// drain queues
-			// NOTE: only do this for 10 seconds
-			let start = Instant::now();
-			// wait a max of 5 seconds per notebook.
-			let wait_time = (missing_audits_by_notary.len() * 5).max(120);
-
-			// if we're importing a specific block, then network syncing should be off
-			while self.process_queues(Some(*parent_hash)).await? {
-				tokio::time::sleep(Duration::from_millis(30)).await;
-				let mut has_more_work = false;
-				for (notary_id, audits) in missing_audits_by_notary.iter_mut() {
-					let notary_audits = self.aux_client.get_notary_audit_history(*notary_id)?.get();
-					audits.retain(|notebook_number| !notary_audits.contains_key(notebook_number));
-					if !audits.is_empty() {
-						has_more_work = true;
-					}
-				}
-				if !has_more_work {
-					break;
-				}
-				if start.elapsed() > Duration::from_secs(wait_time as u64) {
-					warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
-					return Err(Error::UnableToSyncNotary(format!(
-						"Could not process all missing audits in {wait_time} seconds"
-					)));
+			let has_more_work =
+				self.process_selected_queues_at(*parent_hash, &missing_notary_ids).await?;
+			let mut has_missing_audits = false;
+			for (notary_id, audits) in missing_audits_by_notary.iter_mut() {
+				let notary_audits = self.aux_client.get_notary_audit_history(*notary_id)?.get();
+				audits.retain(|notebook_number| !notary_audits.contains_key(notebook_number));
+				if !audits.is_empty() {
+					has_missing_audits = true;
 				}
 			}
+			if !has_missing_audits {
+				return Ok(());
+			}
+
+			let sleep_ms = if has_more_work { 30 } else { 250 };
+			tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
 		}
-		Err(Error::InvalidNotebookDigest(
-			"Notebook digest record could not verify all records in local storage".to_string(),
-		))
 	}
 
 	async fn get_notebook_dependencies(
@@ -1231,6 +1341,31 @@ where
 		}
 		0
 	}
+}
+
+fn resolve_client_stateful_hash<B, C, AC>(
+	client: &C,
+	start_hash: B::Hash,
+) -> Result<Option<B::Hash>, Error>
+where
+	B: BlockT,
+	C: NotaryApisExt<B, AC> + ?Sized,
+	AC: Clone + Codec,
+{
+	let mut cursor = start_hash;
+	for _ in 0..DEFAULT_STATE_LOOKBACK_DEPTH {
+		if client.has_block_state(cursor) {
+			return Ok(Some(cursor));
+		}
+
+		let parent_hash = client.parent_hash(&cursor)?;
+		if parent_hash == cursor {
+			return Ok(None);
+		}
+		cursor = parent_hash;
+	}
+
+	Ok(None)
 }
 
 pub async fn get_notebook_header_data<B: BlockT, C, AccountId: Codec>(
@@ -1825,9 +1960,41 @@ mod test {
 					notebook_number: last.notebook_number,
 					audit_first_failure: None,
 				}],
+				NotebookAuditMode::Sync,
 			)
 			.await
 			.expect("Could not retrieve missing notebooks");
+	}
+
+	#[tokio::test]
+	async fn handles_audit_reconnect_in_import_mode() {
+		setup_logs();
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		let mut last = test_notary.create_notebook_header(vec![]).await;
+		for _ in 0..12 {
+			last = test_notary.create_notebook_header(vec![]).await;
+		}
+
+		notary_client.disconnect(&1, None).await;
+
+		notary_client
+			.verify_notebook_audits(
+				&client.best_hash(),
+				vec![NotebookAuditResult {
+					notary_id: 1,
+					tick: last.tick,
+					notebook_number: last.notebook_number,
+					audit_first_failure: None,
+				}],
+				NotebookAuditMode::Import { max_wait: Duration::from_secs(20) },
+			)
+			.await
+			.expect("Could not retrieve missing notebooks in import mode");
 	}
 
 	#[tokio::test]
@@ -1967,7 +2134,44 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn skips_queue_processing_when_finalized_lacks_state() {
+	async fn targeted_import_catchup_only_processes_missing_notaries() {
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		let mut test_notary2 = MockNotary::new(2);
+		test_notary2.start().await.expect("could not start second notary");
+		client.add_notary(&test_notary2);
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		let notebook_1 = test_notary.create_notebook_header(vec![]).await;
+		let notebook_2 = test_notary2.create_notebook_header(vec![]).await;
+		notary_client
+			.enqueue_notebook(1, notebook_1.notebook_number, None, None)
+			.await
+			.expect("Could not enqueue notebook for first notary");
+		notary_client
+			.enqueue_notebook(2, notebook_2.notebook_number, None, None)
+			.await
+			.expect("Could not enqueue notebook for second notary");
+
+		let targeted = BTreeSet::from([1]);
+		notary_client
+			.process_selected_queues_at(client.best_hash(), &targeted)
+			.await
+			.expect("Could not process targeted queues");
+
+		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(notary_client.queue_depth(2).await, 1);
+	}
+
+	#[tokio::test]
+	async fn uses_stateful_ancestor_when_finalized_lacks_state() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
 			.update_notaries(&client.best_hash())
@@ -1990,15 +2194,27 @@ mod test {
 		client.set_block_state(block_2, true);
 		client.set_block_state(block_1, false);
 		client.set_block_state(block_0, true);
+		client.decode_intercept.lock().replace(NotaryNotebookDetails {
+			notary_id: 1,
+			notebook_number: 1,
+			version: 1,
+			tick: 1,
+			header_hash: H256::from_slice(&[9; 32]),
+			block_votes_count: 0,
+			block_voting_power: 0,
+			blocks_with_votes: vec![],
+			raw_audit_summary: vec![],
+		});
 
 		let has_more_work =
 			notary_client.process_queues(None).await.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_2));
 	}
 
 	#[tokio::test]
-	async fn skips_queue_processing_when_best_lacks_state_even_if_ancestor_has_state() {
+	async fn uses_stateful_ancestor_when_best_lacks_state() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
 			.update_notaries(&client.best_hash())
@@ -2037,8 +2253,8 @@ mod test {
 		let has_more_work =
 			notary_client.process_queues(None).await.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 1);
-		assert_eq!(*client.decode_intercepted_at_block.lock(), None);
+		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_1));
 	}
 
 	#[tokio::test]
@@ -2065,7 +2281,7 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn keeps_import_catchup_active_when_state_is_missing() {
+	async fn import_catchup_uses_stateful_ancestor_when_target_hash_lacks_state() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
 			.update_notaries(&client.best_hash())
@@ -2088,13 +2304,25 @@ mod test {
 		client.set_block_state(block_0, true);
 		client.set_block_state(block_1, true);
 		client.set_block_state(block_2, false);
+		client.decode_intercept.lock().replace(NotaryNotebookDetails {
+			notary_id: 1,
+			notebook_number: 1,
+			version: 1,
+			tick: 1,
+			header_hash: H256::from_slice(&[9; 32]),
+			block_votes_count: 0,
+			block_voting_power: 0,
+			blocks_with_votes: vec![],
+			raw_audit_summary: vec![],
+		});
 
 		let has_more_work = notary_client
-			.process_queues(Some(block_2))
+			.process_queues_at(block_2)
 			.await
 			.expect("Could not process queues");
-		assert!(has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert!(!has_more_work);
+		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_1));
 	}
 
 	#[tokio::test]

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -983,6 +983,9 @@ impl NotaryWorker {
 		if *worker_context.pause_notebook_audits.read().await {
 			return false;
 		}
+		if self.pending.lock().await.len() == 0 {
+			return false;
+		}
 		let Some(best_hash) = resolve_client_stateful_hash::<B, _, AC>(
 			worker_context.client.as_ref(),
 			worker_context.client.best_hash(),
@@ -1356,15 +1359,11 @@ impl NotaryWorker {
 		if !missing_notebooks.is_empty() {
 			let first_missing = missing_notebooks[0];
 			let last_missing = missing_notebooks[missing_notebooks.len() - 1];
+			let notebook_range = first_missing..=last_missing;
 			trace!(
-				"Tracking notebook range {}..{} for notary {}",
-				first_missing, last_missing, self.notary_id,
-			);
-			self.pending.lock().await.track_range(first_missing, last_missing);
-			let notebook_range = first_missing..last_missing;
-			info!(
 				"Missing notebooks for notary {notary_id}. Tracking dependency catchup range: {notebook_range:?}",
 			);
+			self.pending.lock().await.track_range(first_missing, last_missing);
 			return Err(Error::MissingNotebooksError(format!(
 				"Missing notebooks #{notebook_range:?} to audit {notebook_number} for notary {notary_id}"
 			)));
@@ -2583,7 +2582,7 @@ mod test {
 		// still missing number 9
 		assert!(matches!(result, Error::MissingNotebooksError(_)),);
 		println!("result: {result}");
-		assert!(result.to_string().contains("#9..9"));
+		assert!(result.to_string().contains("#9..=9"));
 
 		for _ in 0..9 {
 			notary_client

--- a/node/consensus/src/pending_import_replay.rs
+++ b/node/consensus/src/pending_import_replay.rs
@@ -714,6 +714,8 @@ mod tests {
 			notebook_downloader,
 			Arc::new(None),
 			Ticker::new(2_000, 2),
+			None,
+			Duration::from_millis(250),
 			true,
 		));
 

--- a/node/consensus/src/pending_import_replay.rs
+++ b/node/consensus/src/pending_import_replay.rs
@@ -1,0 +1,766 @@
+use codec::{Decode, Encode};
+use futures::{Future, FutureExt};
+use polkadot_sdk::*;
+use sc_client_api::{BlockBackend, backend::AuxStore};
+use sc_consensus::{BlockImportParams, ForkChoiceStrategy, StateAction};
+use sp_consensus::{BlockOrigin, BlockStatus};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use std::{cmp::Ordering, collections::HashSet, sync::Arc, time::Duration};
+use tracing::{debug, info, warn};
+
+use crate::{
+	error::Error,
+	import_queue::ImportApisExt,
+	notary_client::{NotaryApisExt, NotaryClient, NotebookAuditMode},
+};
+
+pub(crate) const PENDING_IMPORTS_ADVISORY_LIMIT: usize = 1024;
+const PENDING_IMPORTS_AUX_KEY: &[u8] = b"argon/consensus/pending-imports/v1";
+const REPLAY_NOTEBOOK_AUDIT_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const MAX_REPLAY_SCAN_PER_PASS: usize = 64;
+
+pub(crate) struct PendingBlockImport<B: BlockT> {
+	pub(crate) hash: B::Hash,
+	pub(crate) parent_hash: B::Hash,
+	pub(crate) block: BlockImportParams<B>,
+}
+
+pub(crate) struct PendingImportReplayQueue<B: BlockT, C: AuxStore> {
+	client: Arc<C>,
+	pending_imports: Arc<tokio::sync::Mutex<Vec<PendingBlockImport<B>>>>,
+	replay_scan_cursor: Arc<std::sync::Mutex<Option<B::Hash>>>,
+}
+
+pub(crate) enum EnqueueResult {
+	Enqueued,
+	AlreadyQueued,
+}
+
+impl<B, C> Clone for PendingImportReplayQueue<B, C>
+where
+	B: BlockT,
+	C: AuxStore,
+{
+	fn clone(&self) -> Self {
+		Self {
+			client: self.client.clone(),
+			pending_imports: self.pending_imports.clone(),
+			replay_scan_cursor: self.replay_scan_cursor.clone(),
+		}
+	}
+}
+
+impl<B, C> PendingImportReplayQueue<B, C>
+where
+	B: BlockT,
+	C: AuxStore,
+{
+	pub(crate) fn new(client: Arc<C>) -> Self {
+		let pending_imports = load_pending_imports_from_aux::<B, C>(&client);
+		if !pending_imports.is_empty() {
+			info!(
+				count = pending_imports.len(),
+				"Recovered pending full block imports from aux store"
+			);
+		}
+		Self {
+			client,
+			pending_imports: Arc::new(tokio::sync::Mutex::new(pending_imports)),
+			replay_scan_cursor: Arc::new(std::sync::Mutex::new(None)),
+		}
+	}
+
+	pub(crate) async fn len(&self) -> usize {
+		self.pending_imports.lock().await.len()
+	}
+
+	pub(crate) async fn has_hash(&self, hash: B::Hash) -> bool {
+		self.pending_imports.lock().await.iter().any(|entry| entry.hash == hash)
+	}
+
+	pub(crate) async fn enqueue(
+		&self,
+		block: BlockImportParams<B>,
+	) -> Result<EnqueueResult, Error> {
+		let hash = block.post_hash();
+		let number = *block.header.number();
+		let parent_hash = *block.header.parent_hash();
+		let mut pending_imports = self.pending_imports.lock().await;
+		if pending_imports.iter().any(|entry| entry.hash == hash) {
+			return Ok(EnqueueResult::AlreadyQueued);
+		}
+
+		if pending_imports.len() >= PENDING_IMPORTS_ADVISORY_LIMIT {
+			warn!(
+				block_hash = ?hash,
+				number = ?number,
+				queue_len = pending_imports.len(),
+				"Pending import replay queue is above the advisory capacity"
+			);
+		}
+
+		pending_imports.push(PendingBlockImport { hash, parent_hash, block });
+		sort_pending_imports(&mut pending_imports);
+		self.persist_snapshot(&pending_imports);
+		Ok(EnqueueResult::Enqueued)
+	}
+
+	pub(crate) async fn defer_full_import(
+		&self,
+		block: BlockImportParams<B>,
+	) -> Result<BlockImportParams<B>, Error> {
+		if !block.intermediates.is_empty() {
+			warn!(
+				block_hash = ?block.post_hash(),
+				number = ?block.header.number(),
+				intermediates = block.intermediates.len(),
+				"Cannot defer full import with unresolved intermediates"
+			);
+			return Err(Error::PendingImportUnsupported(
+				"cannot defer imports with unresolved intermediates".into(),
+			));
+		}
+		let (header_only, pending_full_import) = split_for_deferred_import(block);
+		match self.enqueue(pending_full_import).await? {
+			EnqueueResult::Enqueued | EnqueueResult::AlreadyQueued => Ok(header_only),
+		}
+	}
+
+	// Replay has two competing requirements:
+	// - keep the queue deterministic and preserve import ordering
+	// - avoid starvation when each replay pass can only inspect a bounded window
+	//
+	// We address that by snapshotting the sorted queue, resuming the bounded scan by block hash,
+	// and letting `pending_import_ready_for_replay` enforce the real ordering constraint via
+	// parent-state and notebook checks. The cursor is a hash rather than an index because the queue
+	// is pruned, resorted, and requeued between passes.
+	async fn replay_scan_snapshot(&self, max_scan: usize) -> Result<ReplayScanSnapshot<B>, Error>
+	where
+		C: BlockBackend<B>,
+	{
+		let scan_cursor =
+			*self.replay_scan_cursor.lock().expect("replay scan cursor lock poisoned");
+		let mut pending_imports = self.pending_imports.lock().await;
+		if pending_imports.is_empty() {
+			drop(pending_imports);
+			*self.replay_scan_cursor.lock().expect("replay scan cursor lock poisoned") = None;
+			return Ok(ReplayScanSnapshot {
+				ordered_candidates: Vec::new(),
+				start_index: 0,
+				scan_len: 0,
+			});
+		}
+
+		let before = pending_imports.len();
+		pending_imports.retain(|entry| {
+			self.client.block_status(entry.hash).unwrap_or(BlockStatus::Unknown) !=
+				BlockStatus::InChainWithState
+		});
+		let pruned = before.saturating_sub(pending_imports.len());
+		if pruned > 0 {
+			debug!(pruned, "Pruned pending imports already in chain with state");
+		}
+
+		sort_pending_imports(&mut pending_imports);
+		self.persist_snapshot(&pending_imports);
+
+		if pending_imports.is_empty() {
+			drop(pending_imports);
+			*self.replay_scan_cursor.lock().expect("replay scan cursor lock poisoned") = None;
+			return Ok(ReplayScanSnapshot {
+				ordered_candidates: Vec::new(),
+				start_index: 0,
+				scan_len: 0,
+			});
+		}
+
+		let ordered_candidates = pending_imports
+			.iter()
+			.map(|pending_import| PendingReplayContext {
+				hash: pending_import.hash,
+				number: *pending_import.block.header.number(),
+				parent_hash: pending_import.parent_hash,
+				origin: pending_import.block.origin,
+				finalized: pending_import.block.finalized,
+				skip_execution_checks: pending_import.block.state_action.skip_execution_checks(),
+				digest: pending_import.block.header.digest().clone(),
+			})
+			.collect::<Vec<_>>();
+		let start_index = ordered_candidates
+			.iter()
+			.position(|candidate| Some(candidate.hash) == scan_cursor)
+			.unwrap_or(0);
+		let scan_len = ordered_candidates.len().min(max_scan);
+		let scan_snapshot = ReplayScanSnapshot { ordered_candidates, start_index, scan_len };
+		drop(pending_imports);
+
+		Ok(scan_snapshot)
+	}
+
+	pub(crate) async fn pending_import_ready_for_replay<AC>(
+		&self,
+		notary_client: &Arc<NotaryClient<B, C, AC>>,
+		ctx: &PendingReplayContext<B>,
+	) -> bool
+	where
+		C: ImportApisExt<B, AC> + NotaryApisExt<B, AC> + BlockBackend<B> + 'static,
+		AC: Clone + codec::Codec + Send + Sync + 'static,
+	{
+		if ctx.skip_execution_checks ||
+			matches!(ctx.origin, BlockOrigin::Own | BlockOrigin::NetworkInitialSync) ||
+			ctx.finalized
+		{
+			return true;
+		}
+
+		let latest_verified_finalized = self.client.info().finalized_number;
+		if ctx.number <= latest_verified_finalized {
+			return true;
+		}
+
+		if !matches!(
+			self.client.block_status(ctx.parent_hash).unwrap_or(BlockStatus::Unknown),
+			BlockStatus::InChainWithState
+		) {
+			return false;
+		}
+
+		let digest_notebooks =
+			match self.client.runtime_digest_notebooks(ctx.parent_hash, &ctx.digest) {
+				Ok(digest_notebooks) => digest_notebooks,
+				Err(err) => {
+					warn!(
+						block_hash = ?ctx.hash,
+						block_number = ?ctx.number,
+						parent_hash = ?ctx.parent_hash,
+						error = ?err,
+						"Skipping pending replay: unable to load digest notebooks"
+					);
+					return false;
+				},
+			};
+		if digest_notebooks.is_empty() {
+			return true;
+		}
+
+		match notary_client
+			.verify_notebook_audits(
+				&ctx.parent_hash,
+				digest_notebooks,
+				NotebookAuditMode::Import { max_wait: REPLAY_NOTEBOOK_AUDIT_TIMEOUT },
+			)
+			.await
+		{
+			Ok(_) => true,
+			Err(Error::InvalidNotebookDigest(_)) => true,
+			Err(err) if err.is_retryable_notebook_audit_error() => false,
+			Err(err) => {
+				warn!(
+					block_hash = ?ctx.hash,
+					block_number = ?ctx.number,
+					parent_hash = ?ctx.parent_hash,
+					error = ?err,
+					"Skipping pending replay due to unexpected notebook audit error"
+				);
+				false
+			},
+		}
+	}
+
+	pub(crate) async fn dequeue_ready_for_replay_excluding<AC>(
+		&self,
+		notary_client: &Arc<NotaryClient<B, C, AC>>,
+		attempted_hashes: &HashSet<B::Hash>,
+	) -> Result<Option<(PendingBlockImport<B>, PendingReplayContext<B>)>, Error>
+	where
+		C: ImportApisExt<B, AC> + NotaryApisExt<B, AC> + BlockBackend<B> + 'static,
+		AC: Clone + codec::Codec + Send + Sync + 'static,
+	{
+		let actual_pending_count = self.len().await;
+		if actual_pending_count > MAX_REPLAY_SCAN_PER_PASS {
+			debug!(
+				pending_count = actual_pending_count,
+				max_scan_per_pass = MAX_REPLAY_SCAN_PER_PASS,
+				"Limiting pending import replay scan due to bounded scan limit"
+			);
+		}
+		let scan_snapshot = self.replay_scan_snapshot(MAX_REPLAY_SCAN_PER_PASS).await?;
+		let scan_order = scan_snapshot.ordered_candidates[scan_snapshot.start_index..]
+			.iter()
+			.enumerate()
+			.map(|(offset, replay_context)| (scan_snapshot.start_index + offset, replay_context))
+			.chain(scan_snapshot.ordered_candidates[..scan_snapshot.start_index].iter().enumerate())
+			.take(scan_snapshot.scan_len);
+		for (current_index, replay_context) in scan_order {
+			*self.replay_scan_cursor.lock().expect("replay scan cursor lock poisoned") =
+				if scan_snapshot.ordered_candidates.len() > 1 {
+					Some(
+						scan_snapshot.ordered_candidates
+							[(current_index + 1) % scan_snapshot.ordered_candidates.len()]
+						.hash,
+					)
+				} else {
+					None
+				};
+			if attempted_hashes.contains(&replay_context.hash) {
+				continue;
+			}
+			if self.pending_import_ready_for_replay(notary_client, replay_context).await {
+				let replay_context = replay_context.clone();
+				let mut pending_imports = self.pending_imports.lock().await;
+				if let Some(index) =
+					pending_imports.iter().position(|entry| entry.hash == replay_context.hash)
+				{
+					let pending_import = pending_imports.remove(index);
+					self.persist_snapshot(&pending_imports);
+					return Ok(Some((pending_import, replay_context)));
+				}
+				continue;
+			}
+			debug!(
+				block_hash = ?replay_context.hash,
+				number = ?replay_context.number,
+				"Pending block replay deferred: prerequisites not ready"
+			);
+		}
+		Ok(None)
+	}
+
+	pub(crate) fn retry_block_from_pending(
+		pending_import: &PendingBlockImport<B>,
+	) -> Option<BlockImportParams<B>> {
+		PersistedPendingBlockImport::try_from_pending(pending_import)
+			.map(PersistedPendingBlockImport::into_pending)
+			.map(|pending| pending.block)
+	}
+
+	pub(crate) async fn requeue_retry_block(
+		&self,
+		block: BlockImportParams<B>,
+	) -> Result<(), Error> {
+		let hash = block.post_hash();
+		let parent_hash = *block.header.parent_hash();
+		self.requeue_pending_import(PendingBlockImport { hash, parent_hash, block })
+			.await
+	}
+
+	async fn requeue_pending_import(
+		&self,
+		pending_import: PendingBlockImport<B>,
+	) -> Result<(), Error> {
+		let mut pending_imports = self.pending_imports.lock().await;
+		if pending_imports.iter().any(|entry| entry.hash == pending_import.hash) {
+			return Ok(());
+		}
+		if pending_imports.len() >= PENDING_IMPORTS_ADVISORY_LIMIT {
+			warn!(
+				block_hash = ?pending_import.hash,
+				number = ?pending_import.block.header.number(),
+				queue_len = pending_imports.len(),
+				"Pending replay queue is above the advisory capacity while requeueing deferred import"
+			);
+		}
+		pending_imports.push(pending_import);
+		sort_pending_imports(&mut pending_imports);
+		self.persist_snapshot(&pending_imports);
+		Ok(())
+	}
+
+	fn persist_snapshot(&self, pending_imports: &[PendingBlockImport<B>]) {
+		persist_pending_imports_to_aux::<B, C>(&self.client, pending_imports).unwrap_or_else(
+			|err| {
+				panic!(
+					"pending import replay queue persistence failed for {} deferred full imports: \
+					 {err}",
+					pending_imports.len()
+				)
+			},
+		);
+	}
+}
+
+pub(crate) fn spawn_pending_import_replay_task<F, Fut>(
+	spawner: &impl sp_core::traits::SpawnEssentialNamed,
+	mut replay_pending_imports: F,
+) where
+	F: FnMut() -> Fut + Send + 'static,
+	Fut: Future<Output = Result<(), Error>> + Send + 'static,
+{
+	spawner.spawn_essential(
+		"pending_block_replay",
+		Some("notary_sync"),
+		async move {
+			let mut replay_tick = tokio::time::interval(std::time::Duration::from_secs(2));
+			replay_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+			loop {
+				replay_tick.tick().await;
+				if let Err(err) = replay_pending_imports().await {
+					warn!(error = ?err, "pending import replay task iteration failed");
+				}
+			}
+		}
+		.boxed(),
+	);
+}
+
+#[derive(Clone, Copy, Decode, Encode)]
+enum PersistedStateAction {
+	Execute,
+	ExecuteIfPossible,
+}
+
+impl PersistedStateAction {
+	fn from_state_action<B: BlockT>(state_action: &StateAction<B>) -> Option<Self> {
+		match state_action {
+			StateAction::Execute => Some(Self::Execute),
+			StateAction::ExecuteIfPossible => Some(Self::ExecuteIfPossible),
+			_ => None,
+		}
+	}
+
+	fn to_state_action<B: BlockT>(self) -> StateAction<B> {
+		match self {
+			Self::Execute => StateAction::Execute,
+			Self::ExecuteIfPossible => StateAction::ExecuteIfPossible,
+		}
+	}
+}
+
+#[derive(Clone, Copy, Decode, Encode)]
+enum PersistedBlockOrigin {
+	Genesis,
+	NetworkInitialSync,
+	NetworkBroadcast,
+	ConsensusBroadcast,
+	Own,
+	File,
+}
+
+impl PersistedBlockOrigin {
+	fn from_block_origin(origin: BlockOrigin) -> Self {
+		match origin {
+			BlockOrigin::Genesis => Self::Genesis,
+			BlockOrigin::NetworkInitialSync => Self::NetworkInitialSync,
+			BlockOrigin::NetworkBroadcast => Self::NetworkBroadcast,
+			BlockOrigin::ConsensusBroadcast => Self::ConsensusBroadcast,
+			BlockOrigin::Own => Self::Own,
+			BlockOrigin::File => Self::File,
+		}
+	}
+
+	fn to_block_origin(self) -> BlockOrigin {
+		match self {
+			Self::Genesis => BlockOrigin::Genesis,
+			Self::NetworkInitialSync => BlockOrigin::NetworkInitialSync,
+			Self::NetworkBroadcast => BlockOrigin::NetworkBroadcast,
+			Self::ConsensusBroadcast => BlockOrigin::ConsensusBroadcast,
+			Self::Own => BlockOrigin::Own,
+			Self::File => BlockOrigin::File,
+		}
+	}
+}
+
+#[derive(Decode, Encode)]
+struct PersistedPendingBlockImport<B: BlockT> {
+	origin: PersistedBlockOrigin,
+	header: B::Header,
+	justifications: Option<sp_runtime::Justifications>,
+	post_digests: Vec<sp_runtime::DigestItem>,
+	body: Option<Vec<B::Extrinsic>>,
+	indexed_body: Option<Vec<Vec<u8>>>,
+	state_action: PersistedStateAction,
+	finalized: bool,
+	auxiliary: Vec<(Vec<u8>, Option<Vec<u8>>)>,
+	import_existing: bool,
+	create_gap: bool,
+	post_hash: Option<B::Hash>,
+}
+
+impl<B: BlockT> PersistedPendingBlockImport<B> {
+	fn try_from_pending(pending: &PendingBlockImport<B>) -> Option<Self> {
+		let state_action = PersistedStateAction::from_state_action(&pending.block.state_action)?;
+		Some(Self {
+			origin: PersistedBlockOrigin::from_block_origin(pending.block.origin),
+			header: pending.block.header.clone(),
+			justifications: pending.block.justifications.clone(),
+			post_digests: pending.block.post_digests.clone(),
+			body: pending.block.body.clone(),
+			indexed_body: pending.block.indexed_body.clone(),
+			state_action,
+			finalized: pending.block.finalized,
+			auxiliary: pending.block.auxiliary.clone(),
+			import_existing: pending.block.import_existing,
+			create_gap: pending.block.create_gap,
+			post_hash: pending.block.post_hash,
+		})
+	}
+
+	fn into_pending(self) -> PendingBlockImport<B> {
+		let mut block = BlockImportParams::<B>::new(self.origin.to_block_origin(), self.header);
+		block.justifications = self.justifications;
+		block.post_digests = self.post_digests;
+		block.body = self.body;
+		block.indexed_body = self.indexed_body;
+		block.state_action = self.state_action.to_state_action();
+		block.finalized = self.finalized;
+		block.auxiliary = self.auxiliary;
+		block.import_existing = self.import_existing;
+		block.create_gap = self.create_gap;
+		block.post_hash = self.post_hash;
+
+		let hash = block.post_hash();
+		let parent_hash = *block.header.parent_hash();
+		PendingBlockImport { hash, parent_hash, block }
+	}
+}
+
+fn sort_pending_imports<B: BlockT>(pending_imports: &mut [PendingBlockImport<B>]) {
+	pending_imports.sort_by(|a, b| {
+		let by_number = a
+			.block
+			.header
+			.number()
+			.partial_cmp(b.block.header.number())
+			.unwrap_or(Ordering::Equal);
+		if by_number != Ordering::Equal {
+			return by_number;
+		}
+		a.hash.cmp(&b.hash)
+	});
+}
+
+fn split_for_deferred_import<B: BlockT>(
+	block: BlockImportParams<B>,
+) -> (BlockImportParams<B>, BlockImportParams<B>) {
+	// `BlockImportParams` is intentionally not `Clone` (notably `intermediates` with `Box<dyn
+	// Any>`), so keep the full block for replay and build a minimal header-only import for now.
+	let mut header_only = BlockImportParams::new(block.origin, block.header.clone());
+	header_only.justifications = block.justifications.clone();
+	header_only.post_digests = block.post_digests.clone();
+	header_only.post_hash = Some(block.post_hash());
+	header_only.import_existing = block.import_existing;
+	header_only.create_gap = block.create_gap;
+	header_only.finalized = block.finalized;
+	header_only.fork_choice = Some(ForkChoiceStrategy::Custom(false));
+	header_only.state_action = StateAction::Skip;
+	(header_only, block)
+}
+
+fn load_pending_imports_from_aux<B: BlockT, C: AuxStore>(
+	client: &Arc<C>,
+) -> Vec<PendingBlockImport<B>> {
+	let Ok(Some(bytes)) = client.get_aux(PENDING_IMPORTS_AUX_KEY) else {
+		return Vec::new();
+	};
+
+	let Ok(persisted) = Vec::<PersistedPendingBlockImport<B>>::decode(&mut &bytes[..]) else {
+		warn!("Failed to decode persisted pending import queue. Starting with an empty queue.");
+		return Vec::new();
+	};
+
+	let mut pending_imports = persisted
+		.into_iter()
+		.map(PersistedPendingBlockImport::into_pending)
+		.collect::<Vec<_>>();
+	sort_pending_imports(&mut pending_imports);
+	pending_imports
+}
+
+fn persist_pending_imports_to_aux<B: BlockT, C: AuxStore>(
+	client: &Arc<C>,
+	pending_imports: &[PendingBlockImport<B>],
+) -> Result<(), sp_blockchain::Error> {
+	let mut persisted = Vec::with_capacity(pending_imports.len());
+	for pending in pending_imports {
+		let Some(entry) = PersistedPendingBlockImport::try_from_pending(pending) else {
+			warn!(
+				block_hash = ?pending.hash,
+				number = ?pending.block.header.number(),
+				"Skipping persistence for pending import with unsupported state action"
+			);
+			continue;
+		};
+		persisted.push(entry);
+	}
+
+	if persisted.is_empty() {
+		return client.insert_aux(&[], &[PENDING_IMPORTS_AUX_KEY]);
+	}
+
+	let encoded = persisted.encode();
+	client.insert_aux(&[(PENDING_IMPORTS_AUX_KEY, encoded.as_slice())], &[])
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PendingReplayContext<B: BlockT> {
+	pub(crate) hash: B::Hash,
+	pub(crate) number: sp_runtime::traits::NumberFor<B>,
+	pub(crate) parent_hash: B::Hash,
+	pub(crate) origin: BlockOrigin,
+	pub(crate) finalized: bool,
+	pub(crate) skip_execution_checks: bool,
+	pub(crate) digest: sp_runtime::Digest,
+}
+
+struct ReplayScanSnapshot<B: BlockT> {
+	ordered_candidates: Vec<PendingReplayContext<B>>,
+	start_index: usize,
+	scan_len: usize,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		NotaryClient, NotebookDownloader,
+		aux_client::ArgonAux,
+		mock_importer::{
+			create_params, has_state, new_importer, new_importer_with_notary, pending_import_count,
+		},
+	};
+	use argon_notary_apis::DownloadTrustMode;
+	use argon_primitives::{NotebookAuditResult, prelude::*, tick::Ticker};
+	use polkadot_sdk::{
+		sc_consensus::{BlockImport, ImportResult},
+		sp_blockchain::HeaderBackend,
+		sp_core::H256,
+	};
+	use std::sync::Arc;
+
+	#[tokio::test]
+	async fn test_replay_scans_past_unready_entry_and_imports_ready_entry() {
+		let (importer, client) = new_importer_with_notary();
+		let genesis_hash = client.info().best_hash;
+
+		let parent = create_params(
+			1,
+			genesis_hash,
+			1,
+			None,
+			BlockOrigin::NetworkInitialSync,
+			StateAction::Skip,
+			None,
+		);
+		let parent_hash = parent.post_hash();
+		let _ = importer.import_block(parent).await.unwrap();
+		assert!(!has_state(&client, parent_hash));
+
+		client.set_runtime_notebooks(
+			parent_hash,
+			vec![NotebookAuditResult {
+				notary_id: 1,
+				notebook_number: 1,
+				tick: 1,
+				audit_first_failure: None,
+			}],
+		);
+
+		let mut blocked = create_params(
+			2,
+			parent_hash,
+			1,
+			None,
+			BlockOrigin::NetworkBroadcast,
+			StateAction::ExecuteIfPossible,
+			Some(AccountId::from([1u8; 32])),
+		);
+		blocked.body = Some(Vec::new());
+		let blocked_hash = blocked.post_hash();
+		let blocked_result = importer.import_block(blocked).await.unwrap();
+		assert!(matches!(blocked_result, ImportResult::Imported(_)));
+
+		let mut ready = create_params(
+			2,
+			parent_hash,
+			1,
+			None,
+			BlockOrigin::NetworkInitialSync,
+			StateAction::ExecuteIfPossible,
+			Some(AccountId::from([2u8; 32])),
+		);
+		ready.body = Some(Vec::new());
+		let ready_hash = ready.post_hash();
+		let ready_result = importer.import_block(ready).await.unwrap();
+		assert!(matches!(ready_result, ImportResult::Imported(_)));
+
+		assert_eq!(pending_import_count(&importer).await, 2);
+		client.set_state(parent_hash, sp_consensus::BlockStatus::InChainWithState);
+
+		importer.replay_pending_full_imports().await.unwrap();
+
+		assert!(!has_state(&client, blocked_hash), "blocked replay should remain queued");
+		assert!(has_state(&client, ready_hash), "ready replay should still import");
+		assert_eq!(
+			pending_import_count(&importer).await,
+			1,
+			"only the blocked replay should remain queued",
+		);
+	}
+
+	#[tokio::test]
+	async fn test_bounded_replay_scan_advances_cursor_after_blocked_batch() {
+		let (_, client) = new_importer();
+		let client = Arc::new(client.clone());
+		let queue = PendingImportReplayQueue::new(client.clone());
+		let parent_hash = client.info().best_hash;
+		let blocked_parent_hash = H256::repeat_byte(9);
+		let notebook_downloader =
+			NotebookDownloader::new(Vec::<String>::new(), DownloadTrustMode::Dev, None, None)
+				.expect("notebook downloader should initialize");
+		let notary_client = Arc::new(NotaryClient::new(
+			client.clone(),
+			ArgonAux::new(client.clone()),
+			notebook_downloader,
+			Arc::new(None),
+			Ticker::new(2_000, 2),
+			true,
+		));
+
+		for offset in 0..MAX_REPLAY_SCAN_PER_PASS as u8 {
+			let mut params = create_params(
+				1,
+				blocked_parent_hash,
+				1,
+				None,
+				BlockOrigin::NetworkBroadcast,
+				StateAction::ExecuteIfPossible,
+				Some(AccountId::from([offset; 32])),
+			);
+			params.body = Some(Vec::new());
+			assert!(matches!(queue.enqueue(params).await.unwrap(), EnqueueResult::Enqueued));
+		}
+
+		let mut ready = create_params(
+			2,
+			parent_hash,
+			1,
+			None,
+			BlockOrigin::NetworkInitialSync,
+			StateAction::ExecuteIfPossible,
+			Some(AccountId::from([MAX_REPLAY_SCAN_PER_PASS as u8; 32])),
+		);
+		ready.body = Some(Vec::new());
+		let ready_hash = ready.post_hash();
+		assert!(matches!(queue.enqueue(ready).await.unwrap(), EnqueueResult::Enqueued));
+
+		assert!(
+			queue
+				.dequeue_ready_for_replay_excluding(&notary_client, &HashSet::new())
+				.await
+				.unwrap()
+				.is_none(),
+			"the first bounded pass should only see blocked entries",
+		);
+
+		let second_batch = queue
+			.dequeue_ready_for_replay_excluding(&notary_client, &HashSet::new())
+			.await
+			.unwrap();
+		assert_eq!(
+			second_batch.map(|(_, replay_context)| replay_context.hash),
+			Some(ready_hash),
+			"the next scan should continue after the previously scanned bounded window",
+		);
+	}
+}

--- a/notary/apis/src/lib.rs
+++ b/notary/apis/src/lib.rs
@@ -8,7 +8,7 @@ use argon_primitives::{
 };
 use codec::Decode;
 use jsonrpsee::{
-	async_client::ClientBuilder,
+	async_client::{ClientBuilder, PingConfig},
 	client_transport::ws::{Url, WsTransportClientBuilder},
 };
 use std::{fmt::Debug, sync::OnceLock, time::Duration};
@@ -398,7 +398,9 @@ pub async fn create_client(url: &str) -> anyhow::Result<Client> {
 	let url = Url::parse(url).map_err(|e| anyhow!("Invalid URL: {url:?} -> {e}"))?;
 
 	let (sender, receiver) = transport_builder.build(url).await?;
-	let client = ClientBuilder::default().build_with_tokio(sender, receiver);
+	let client = ClientBuilder::default()
+		.enable_ws_ping(PingConfig::default())
+		.build_with_tokio(sender, receiver);
 	Ok(client)
 }
 

--- a/notary/src/server.rs
+++ b/notary/src/server.rs
@@ -176,7 +176,6 @@ impl NotaryServer {
 			.set_message_buffer_capacity(max_buffer_capacity_per_connection)
 			.set_batch_request_config(batch_config.unwrap_or(BatchRequestConfig::Disabled))
 			.set_rpc_middleware(rpc_middleware)
-			.enable_ws_ping(PingConfig::default())
 			.build(addrs)
 			.await?;
 		Ok(server)


### PR DESCRIPTION
## Why
When notebook audits are temporarily unavailable, import was mixing safety checks with network recovery work in ways that could hurt liveness. In particular, the previous path could hold import on notary connection/update work and could emit `MissingState` under deferred-queue saturation, which can lead to retry churn.

## What changed
- Added an import-safe notebook audit verification mode with bounded wait and no inline notary update/connect side effects.
- Kept background notary update behavior for normal catch-up paths.
- Changed deferred queue saturation to header-only import instead of `MissingState`.
- Preserved justifications on deferred header split and allowed justified/finalized upgrades to reimport.
- Bounded replay scan work per pass to avoid long blocked scans.

## Edge cases handled
- Missing parent state during execution paths.
- Deferred queue saturation under sustained load.
- Replay queues with mixed ready/unready entries.
- Deferred blocks that later arrive with justification/finality upgrades.
- Unsafe defer attempts with unresolved intermediates.

## Impact
- Lower risk of import stalls during transient notary/archive outages.
- Lower risk of retry-thrash behavior from saturation paths.
- Better deterministic replay recovery while preserving existing consensus safety checks.

## Validation
- `cargo test -p argon-node-consensus --lib`
- `cargo make fmt`
- `cargo make lint`