### PR TITLE
fix(bitcoin): clear release requests when a bitcoin lock burns

### DIFF
--- a/pallets/bitcoin_locks/src/lib.rs
+++ b/pallets/bitcoin_locks/src/lib.rs
@@ -1739,6 +1739,24 @@ pub mod pallet {
 
 		fn burn_bitcoin_lock(utxo_id: UtxoId, is_externally_spent: bool) -> DispatchResult {
 			let lock = LocksByUtxoId::<T>::take(utxo_id).ok_or(Error::<T>::LockNotFound)?;
+			if LockReleaseRequestsByUtxoId::<T>::contains_key(utxo_id) {
+				let request = Self::take_release_request(utxo_id)?;
+				// We don't branch on spend status here. A valid release request must be made far
+				// enough ahead of claim height that the overdue-cosign path should always run
+				// before a normal expiration burn. If a burn still happens with a pending
+				// release request, treat it as a terminal failure and burn the held release
+				// funds.
+				if request.redemption_price > T::Balance::zero() {
+					let _ = T::Currency::burn_held(
+						&HoldReason::ReleaseBitcoinLock.into(),
+						&lock.owner_account,
+						request.redemption_price,
+						Precision::Exact,
+						Fortitude::Force,
+					)?;
+					frame_system::Pallet::<T>::dec_providers(&lock.owner_account)?;
+				}
+			}
 			if is_externally_spent {
 				Self::clear_orphans_for_lock(utxo_id, &lock)?;
 			} else {

--- a/pallets/bitcoin_locks/src/tests.rs
+++ b/pallets/bitcoin_locks/src/tests.rs
@@ -965,6 +965,20 @@ fn burns_a_spent_bitcoin() {
 		assert_eq!(DefaultVault::get().securitization_locked, price);
 		// first verify
 		assert_ok!(BitcoinLocks::funding_received(1, SATOSHIS_PER_BITCOIN));
+		assert_ok!(Balances::mint_into(&who, price));
+		let providers_before_request = System::providers(&who);
+		assert_ok!(BitcoinLocks::request_release(
+			RuntimeOrigin::signed(who),
+			1,
+			make_script_pubkey(&[0; 32]),
+			11
+		));
+		let cosign_due_frame = CurrentFrameId::get() + LockReleaseCosignDeadlineFrames::get();
+		assert!(LockReleaseRequestsByUtxoId::<Test>::contains_key(1));
+		assert!(LockCosignDueByFrame::<Test>::get(cosign_due_frame).contains(&1));
+		assert!(VaultViewOfCosignPendingLocks::get().get(&1).unwrap().contains(&1));
+		assert!(Balances::balance_on_hold(&HoldReason::ReleaseBitcoinLock.into(), &who) > 0);
+		assert_eq!(System::providers(&who), providers_before_request + 1);
 		assert_eq!(DefaultVault::get().securitized_satoshis, SATOSHIS_PER_BITCOIN);
 
 		BitcoinPriceInUsd::set(Some(FixedU128::saturating_from_integer(50000)));
@@ -980,6 +994,11 @@ fn burns_a_spent_bitcoin() {
 		assert_eq!(DefaultVault::get().get_relock_capacity(), price - new_price);
 		assert_eq!(DefaultVault::get().securitization, allocated - new_price);
 		assert_eq!(DefaultVault::get().securitized_satoshis, 0);
+		assert!(!LockReleaseRequestsByUtxoId::<Test>::contains_key(1));
+		assert!(LockCosignDueByFrame::<Test>::get(cosign_due_frame).is_empty());
+		assert!(VaultViewOfCosignPendingLocks::get().get(&1).unwrap().is_empty());
+		assert_eq!(Balances::balance_on_hold(&HoldReason::ReleaseBitcoinLock.into(), &who), 0);
+		assert_eq!(System::providers(&who), providers_before_request);
 
 		System::assert_last_event(
 			Event::<Test>::BitcoinLockBurned { vault_id: 1, utxo_id: 1, was_utxo_spent: true }


### PR DESCRIPTION
## What changed
- clear the pending release request when a bitcoin lock burns so the pending cosign state is removed too
- cover the spent and expiration paths in the existing bitcoin lock tests

## Testing
- cargo test -p pallet-bitcoin-locks --lib