### PR TITLE
fix(node): repair warp sync across historical handoffs

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -34,6 +34,7 @@ polkadot-sdk.features = [
     "sp-core",
     "sc-executor",
     "sc-network",
+    "sc-network-sync",
     "sc-consensus-grandpa",
     "sp-consensus-grandpa",
     "sc-service",

--- a/node/src/grandpa_hard_forks.rs
+++ b/node/src/grandpa_hard_forks.rs
@@ -1,0 +1,153 @@
+use crate::runtime_api::opaque::Block;
+use hex_literal::hex;
+use polkadot_sdk::*;
+use sc_consensus_grandpa::AuthoritySetHardFork;
+use sp_consensus_grandpa::{AuthorityList, SetId};
+use sp_core::H256;
+
+pub(crate) fn authority_set_hard_forks(
+	chain_id: &str,
+	genesis_authorities: &AuthorityList,
+) -> Vec<AuthoritySetHardFork<Block>> {
+	match chain_id {
+		"argon" => mainnet_hard_forks(genesis_authorities),
+		"argon-testnet" => testnet_hard_forks(genesis_authorities),
+		_ => Vec::new(),
+	}
+}
+
+fn mainnet_hard_forks(genesis_authorities: &AuthorityList) -> Vec<AuthoritySetHardFork<Block>> {
+	// These historical fixes were set-id bumps without a real authority rotation.
+	vec![hard_fork(
+		hex!("7927b62bef2a417d0affc650f9a3cd2e3ef69a27cbd7ba14691774b0ea2cd712"),
+		17_573,
+		1,
+		genesis_authorities,
+	)]
+}
+
+fn testnet_hard_forks(genesis_authorities: &AuthorityList) -> Vec<AuthoritySetHardFork<Block>> {
+	// The old runtime state patch exposed the new set ids starting on the block *after*
+	// each handoff. GRANDPA hard forks apply on the actual handoff block instead.
+	vec![
+		hard_fork(
+			hex!("36ca332782b5f28798135a6ba266c301b5df1f521caba2be0708cb337295228d"),
+			30_270,
+			1,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("abca5db970894dfc5d7ae04b1575512fdc57f8e5fbb9c3131a1eb64338300a08"),
+			34_561,
+			2,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("664e696211cb8368df3e9313c467bc81d206e2f97f9acb91c93e0b2a42231fa1"),
+			38_880,
+			3,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("34d4b371868027be46cb9437b12b5d125d0b739f422f41c96fcb5a3cf23692e3"),
+			40_320,
+			4,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("06e968f03068bf9c62da2b83279bd4b60f58f95b4b3d8222d260a56cc46b0c85"),
+			41_760,
+			5,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("35400f2b37a85d6fe3e9841e615236ea9306a974549f5b077bf537cb88e9066e"),
+			43_200,
+			6,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("b3239c8d41ce46e1c08bd12c167d0ac6ebef02dd2bd4748c0dc65f57e8515a43"),
+			44_640,
+			7,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("9b677b87ab329807af73f676e702a61c11fa7544a9d81dd6f038d17a89fc9a21"),
+			46_080,
+			8,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("856a44fdd6d656eecfc4d186aeecbf64a9de7f2cbf79f9d57f68c317c718e4a1"),
+			47_520,
+			9,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("c356f29a4b348fb4e6d3211adb32a96094df2433229cf22a92e9f490689205da"),
+			48_960,
+			10,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("14dc783ab6ebb6acad7a318b0424155bec4fd2fc6dd42551246d3003f5adcebb"),
+			50_400,
+			11,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("547e6ad212585c2d3e4057f8e2e0b6a3d28201b2b904aaf1ddaf3be1b33b23eb"),
+			51_840,
+			12,
+			genesis_authorities,
+		),
+		hard_fork(
+			hex!("55f3792183906c2acc201612bafbdfebf8441c1829500a492bd5a0e361f3407c"),
+			53_280,
+			13,
+			genesis_authorities,
+		),
+	]
+}
+
+fn hard_fork(
+	hash: [u8; 32],
+	number: u32,
+	set_id: SetId,
+	authorities: &AuthorityList,
+) -> AuthoritySetHardFork<Block> {
+	AuthoritySetHardFork {
+		block: (H256::from(hash), number),
+		set_id,
+		authorities: authorities.clone(),
+		last_finalized: None,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{AuthorityList, authority_set_hard_forks};
+	use polkadot_sdk::{sp_consensus_grandpa::AuthorityId, sp_core::ed25519};
+
+	fn test_authorities() -> AuthorityList {
+		vec![(AuthorityId::from(ed25519::Public::from_raw([1u8; 32])), 1)]
+	}
+
+	#[test]
+	fn returns_mainnet_hard_fork_at_effective_block() {
+		let hard_forks = authority_set_hard_forks("argon", &test_authorities());
+		assert_eq!(hard_forks.len(), 1);
+		assert_eq!(hard_forks[0].block.1, 17_573);
+		assert_eq!(hard_forks[0].set_id, 1);
+	}
+
+	#[test]
+	fn returns_testnet_hard_forks_for_all_historical_bumps() {
+		let hard_forks = authority_set_hard_forks("argon-testnet", &test_authorities());
+		assert_eq!(hard_forks.len(), 13);
+		assert_eq!(hard_forks.first().unwrap().block.1, 30_270);
+		assert_eq!(hard_forks.last().unwrap().block.1, 53_280);
+		assert_eq!(hard_forks.last().unwrap().set_id, 13);
+	}
+}

--- a/node/src/grandpa_warp_sync.rs
+++ b/node/src/grandpa_warp_sync.rs
@@ -17,6 +17,8 @@ use std::{collections::BTreeMap, error::Error as StdError, sync::Arc};
 
 // This must stay aligned with upstream GRANDPA warp proof generation.
 const MAX_WARP_SYNC_PROOF_SIZE: usize = 8 * 1024 * 1024;
+// This matches upstream's small slack for SCALE-encoding the outer proof wrapper.
+const WARP_SYNC_PROOF_ENCODING_SLACK: usize = 50;
 
 pub struct ArgonWarpSyncProvider<Block: BlockT, Backend: ClientBackend<Block>>
 where
@@ -133,7 +135,9 @@ where
 		};
 		let proof_size = proof.encoded_size();
 
-		if proofs_encoded_len + proof_size >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+		if proofs_encoded_len + proof_size >=
+			MAX_WARP_SYNC_PROOF_SIZE - WARP_SYNC_PROOF_ENCODING_SLACK
+		{
 			proof_limit_reached = true;
 			break
 		}
@@ -160,7 +164,9 @@ where
 				.ok_or(WarpProofError::MissingData)?;
 			let proof = WarpSyncFragment { header, justification: latest_justification };
 
-			if proofs_encoded_len + proof.encoded_size() >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+			if proofs_encoded_len + proof.encoded_size() >=
+				MAX_WARP_SYNC_PROOF_SIZE - WARP_SYNC_PROOF_ENCODING_SLACK
+			{
 				false
 			} else {
 				proofs.push(proof);
@@ -214,9 +220,9 @@ where
 {
 	if let Some(expected_hash) = hard_fork_hash_by_block_number.get(&number) {
 		if *expected_hash != hash {
-			return Err(WarpProofError::InvalidRequest(
-				"Configured GRANDPA hard fork does not match the canonical chain".to_string(),
-			))
+			return Err(WarpProofError::InvalidRequest(format!(
+				"Configured GRANDPA hard fork does not match the canonical chain at block {number:?}: expected hash {expected_hash:?}, canonical hash {hash:?}",
+			)))
 		}
 		return Ok(true)
 	}

--- a/node/src/grandpa_warp_sync.rs
+++ b/node/src/grandpa_warp_sync.rs
@@ -1,0 +1,297 @@
+use codec::{DecodeAll, Encode};
+use polkadot_sdk::*;
+use sc_client_api::Backend as ClientBackend;
+use sc_consensus_grandpa::{
+	AuthoritySetChanges, AuthoritySetHardFork, BlockNumberOps, GrandpaJustification,
+	SharedAuthoritySet, best_justification, find_scheduled_change,
+	warp_proof::{Error as WarpProofError, NetworkProvider, WarpSyncFragment},
+};
+use sc_network_sync::strategy::warp::{EncodedProof, WarpSyncProvider};
+use sp_blockchain::{Backend as BlockchainBackend, HeaderBackend};
+use sp_consensus_grandpa::{AuthorityList, GRANDPA_ENGINE_ID, SetId};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, NumberFor, One},
+};
+use std::{collections::BTreeMap, error::Error as StdError, sync::Arc};
+
+// This must stay aligned with upstream GRANDPA warp proof generation.
+const MAX_WARP_SYNC_PROOF_SIZE: usize = 8 * 1024 * 1024;
+
+pub struct ArgonWarpSyncProvider<Block: BlockT, Backend: ClientBackend<Block>>
+where
+	NumberFor<Block>: BlockNumberOps,
+{
+	backend: Arc<Backend>,
+	authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
+	inner: NetworkProvider<Block, Backend>,
+	hard_fork_hash_by_block_number: BTreeMap<NumberFor<Block>, Block::Hash>,
+}
+
+impl<Block: BlockT, Backend: ClientBackend<Block>> ArgonWarpSyncProvider<Block, Backend>
+where
+	NumberFor<Block>: BlockNumberOps,
+{
+	pub fn new(
+		backend: Arc<Backend>,
+		authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
+		hard_forks: Vec<AuthoritySetHardFork<Block>>,
+	) -> Self {
+		let hard_fork_hash_by_block_number = hard_forks
+			.iter()
+			// `AuthoritySetHardFork::block` is `(hash, number)`, but warp generation
+			// looks hard forks up by the boundary block number.
+			.map(|fork| (fork.block.1, fork.block.0))
+			.collect::<BTreeMap<_, _>>();
+		let inner = NetworkProvider::new(backend.clone(), authority_set.clone(), hard_forks);
+
+		Self { backend, authority_set, inner, hard_fork_hash_by_block_number }
+	}
+}
+
+impl<Block: BlockT, Backend: ClientBackend<Block>> WarpSyncProvider<Block>
+	for ArgonWarpSyncProvider<Block, Backend>
+where
+	NumberFor<Block>: BlockNumberOps,
+{
+	fn generate(
+		&self,
+		start: Block::Hash,
+	) -> Result<EncodedProof, Box<dyn StdError + Send + Sync>> {
+		let proof = generate_warp_sync_proof(
+			&*self.backend,
+			start,
+			&self.authority_set.authority_set_changes(),
+			&self.hard_fork_hash_by_block_number,
+		)
+		.map_err(Box::new)?;
+		Ok(EncodedProof(proof.encode()))
+	}
+
+	fn verify(
+		&self,
+		proof: &EncodedProof,
+		set_id: SetId,
+		authorities: AuthorityList,
+	) -> Result<
+		sc_network_sync::strategy::warp::VerificationResult<Block>,
+		Box<dyn StdError + Send + Sync>,
+	> {
+		self.inner.verify(proof, set_id, authorities)
+	}
+
+	fn current_authorities(&self) -> AuthorityList {
+		self.inner.current_authorities()
+	}
+}
+
+#[derive(Encode)]
+struct ArgonWarpSyncProof<Block: BlockT> {
+	proofs: Vec<WarpSyncFragment<Block>>,
+	is_finished: bool,
+}
+
+fn generate_warp_sync_proof<Backend, Block: BlockT>(
+	backend: &Backend,
+	begin: Block::Hash,
+	set_changes: &AuthoritySetChanges<NumberFor<Block>>,
+	hard_fork_hash_by_block_number: &BTreeMap<NumberFor<Block>, Block::Hash>,
+) -> Result<ArgonWarpSyncProof<Block>, WarpProofError>
+where
+	Backend: ClientBackend<Block>,
+	NumberFor<Block>: BlockNumberOps,
+{
+	let blockchain = backend.blockchain();
+
+	let begin_number = blockchain
+		.block_number_from_id(&BlockId::Hash(begin))?
+		.ok_or_else(|| WarpProofError::InvalidRequest("Missing start block".to_string()))?;
+
+	if begin_number > blockchain.info().finalized_number {
+		return Err(WarpProofError::InvalidRequest("Start block is not finalized".to_string()))
+	}
+
+	let canon_hash = blockchain.hash(begin_number)?.ok_or_else(|| {
+		WarpProofError::InvalidRequest("Missing canonical hash for start block".to_string())
+	})?;
+	if canon_hash != begin {
+		return Err(WarpProofError::InvalidRequest(
+			"Start block is not in the finalized chain".to_string(),
+		))
+	}
+
+	let mut proofs = Vec::new();
+	let mut proofs_encoded_len = 0;
+	let mut proof_limit_reached = false;
+
+	let set_changes = set_changes.iter_from(begin_number).ok_or(WarpProofError::MissingData)?;
+	for (_, last_block) in set_changes {
+		let Some(proof) =
+			find_warp_fragment(blockchain, *last_block, hard_fork_hash_by_block_number)?
+		else {
+			break;
+		};
+		let proof_size = proof.encoded_size();
+
+		if proofs_encoded_len + proof_size >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+			proof_limit_reached = true;
+			break
+		}
+
+		proofs_encoded_len += proof_size;
+		proofs.push(proof);
+	}
+
+	let is_finished = if proof_limit_reached {
+		false
+	} else {
+		let latest_justification = best_justification(backend)?.filter(|justification| {
+			let limit = proofs
+				.last()
+				.map(|proof| proof.justification.target().0 + One::one())
+				.unwrap_or(begin_number);
+
+			justification.target().0 >= limit
+		});
+
+		if let Some(latest_justification) = latest_justification {
+			let header = blockchain
+				.header(latest_justification.target().1)?
+				.ok_or(WarpProofError::MissingData)?;
+			let proof = WarpSyncFragment { header, justification: latest_justification };
+
+			if proofs_encoded_len + proof.encoded_size() >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+				false
+			} else {
+				proofs.push(proof);
+				true
+			}
+		} else {
+			true
+		}
+	};
+
+	let final_outcome = ArgonWarpSyncProof { proofs, is_finished };
+	debug_assert!(final_outcome.encoded_size() <= MAX_WARP_SYNC_PROOF_SIZE);
+	Ok(final_outcome)
+}
+
+fn find_warp_fragment<Backend, Block: BlockT>(
+	blockchain: &Backend,
+	last_block: NumberFor<Block>,
+	hard_fork_hash_by_block_number: &BTreeMap<NumberFor<Block>, Block::Hash>,
+) -> Result<Option<WarpSyncFragment<Block>>, WarpProofError>
+where
+	Backend: BlockchainBackend<Block>,
+	NumberFor<Block>: BlockNumberOps,
+{
+	let hash = blockchain
+		.block_hash_from_id(&BlockId::Number(last_block))?
+		.ok_or(WarpProofError::MissingData)?;
+	let header = blockchain.header(hash)?.ok_or(WarpProofError::MissingData)?;
+
+	if !is_authority_boundary::<Block>(&header, hash, last_block, hard_fork_hash_by_block_number)? {
+		return Ok(None)
+	}
+
+	let justification = blockchain
+		.justifications(hash)?
+		.and_then(|just| just.into_justification(GRANDPA_ENGINE_ID))
+		.ok_or(WarpProofError::MissingData)?;
+	let justification = GrandpaJustification::<Block>::decode_all(&mut &justification[..])?;
+
+	Ok(Some(WarpSyncFragment { header, justification }))
+}
+
+fn is_authority_boundary<Block: BlockT>(
+	header: &Block::Header,
+	hash: Block::Hash,
+	number: NumberFor<Block>,
+	hard_fork_hash_by_block_number: &BTreeMap<NumberFor<Block>, Block::Hash>,
+) -> Result<bool, WarpProofError>
+where
+	NumberFor<Block>: BlockNumberOps,
+{
+	if let Some(expected_hash) = hard_fork_hash_by_block_number.get(&number) {
+		if *expected_hash != hash {
+			return Err(WarpProofError::InvalidRequest(
+				"Configured GRANDPA hard fork does not match the canonical chain".to_string(),
+			))
+		}
+		return Ok(true)
+	}
+
+	Ok(find_scheduled_change::<Block>(header).is_some())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{GRANDPA_ENGINE_ID, is_authority_boundary};
+	use codec::Encode;
+	use polkadot_sdk::*;
+	use sp_consensus_grandpa::{ConsensusLog, ScheduledChange};
+	use sp_core::H256;
+	use sp_keyring::Ed25519Keyring;
+	use sp_runtime::{
+		generic::DigestItem,
+		testing::{Block as TestBlock, Header as TestHeader},
+	};
+	use std::collections::BTreeMap;
+
+	type Block = TestBlock<sp_runtime::OpaqueExtrinsic>;
+	type Number = sp_runtime::traits::NumberFor<Block>;
+
+	#[test]
+	fn boundary_block_uses_scheduled_change_digest() {
+		let header = header(2, H256::default(), true);
+		let hash = header.hash();
+
+		assert!(is_authority_boundary::<Block>(&header, hash, 2, &BTreeMap::new()).unwrap());
+	}
+
+	#[test]
+	fn boundary_block_uses_hard_fork_when_digest_is_missing() {
+		let header = header(17_573, H256::default(), false);
+		let hash = header.hash();
+		let hard_forks = BTreeMap::from([(17_573u64, hash)]);
+
+		assert!(is_authority_boundary::<Block>(&header, hash, 17_573, &hard_forks).unwrap());
+	}
+
+	#[test]
+	fn boundary_block_rejects_mismatched_hard_fork_hash() {
+		let header = header(17_573, H256::default(), false);
+		let hard_forks = BTreeMap::from([(17_573u64, H256::repeat_byte(7))]);
+
+		assert!(
+			is_authority_boundary::<Block>(&header, header.hash(), 17_573, &hard_forks).is_err()
+		);
+	}
+
+	#[test]
+	fn non_boundary_block_without_hard_fork_is_skipped() {
+		let header = header(5, H256::default(), false);
+
+		assert!(
+			!is_authority_boundary::<Block>(&header, header.hash(), 5, &BTreeMap::new()).unwrap()
+		);
+	}
+
+	fn header(number: Number, parent_hash: H256, has_scheduled_change: bool) -> TestHeader {
+		let mut header = TestHeader::new_from_number(number);
+		header.parent_hash = parent_hash;
+		if has_scheduled_change {
+			header.digest.push(scheduled_change_digest());
+		}
+		header
+	}
+
+	fn scheduled_change_digest() -> DigestItem {
+		let next_authorities = vec![(Ed25519Keyring::Alice.public().into(), 1)];
+		DigestItem::Consensus(
+			GRANDPA_ENGINE_ID,
+			ConsensusLog::ScheduledChange(ScheduledChange { next_authorities, delay: 0u64 })
+				.encode(),
+		)
+	}
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -9,6 +9,8 @@ mod service;
 
 mod cli;
 mod command;
+mod grandpa_hard_forks;
+mod grandpa_warp_sync;
 // mod grandpa_set_id_patch;
 mod rpc;
 pub(crate) mod runtime_api;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1,6 +1,8 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 use crate::{
 	command::MiningConfig,
+	grandpa_hard_forks,
+	grandpa_warp_sync::ArgonWarpSyncProvider,
 	rpc,
 	rpc::GrandpaDeps,
 	runtime_api::{BaseHostRuntimeApis, opaque::Block},
@@ -17,8 +19,8 @@ use polkadot_sdk::*;
 use sc_client_api::{BlockBackend, HeaderBackend};
 use sc_consensus::BasicQueue;
 use sc_consensus_grandpa::{
-	BeforeBestBlockBy, FinalityProofProvider as GrandpaFinalityProofProvider, GrandpaBlockImport,
-	ThreeQuartersOfTheUnfinalizedChain,
+	BeforeBestBlockBy, FinalityProofProvider as GrandpaFinalityProofProvider,
+	GenesisAuthoritySetProvider, GrandpaBlockImport, ThreeQuartersOfTheUnfinalizedChain,
 };
 use sc_rpc::SubscriptionTaskExecutor;
 use sc_service::{
@@ -102,6 +104,9 @@ where
 		telemetry
 	});
 	let select_chain = sc_consensus::LongestChain::new(backend.clone());
+	let grandpa_genesis_authorities = client.get().map_err(|error| {
+		ServiceError::Other(format!("Failed to read GRANDPA genesis authorities: {error}"))
+	})?;
 
 	let transaction_pool = Arc::from(
 		sc_transaction_pool::Builder::new(
@@ -113,13 +118,18 @@ where
 		.with_prometheus(config.prometheus_registry())
 		.build(),
 	);
-	let (grandpa_block_import, grandpa_link) = sc_consensus_grandpa::block_import(
-		client.clone(),
-		GRANDPA_JUSTIFICATION_PERIOD,
-		&client,
-		select_chain.clone(),
-		telemetry.as_ref().map(|x| x.handle()),
-	)?;
+	let (grandpa_block_import, grandpa_link) =
+		sc_consensus_grandpa::block_import_with_authority_set_hard_forks(
+			client.clone(),
+			GRANDPA_JUSTIFICATION_PERIOD,
+			&client,
+			select_chain.clone(),
+			grandpa_hard_forks::authority_set_hard_forks(
+				config.chain_spec.id(),
+				&grandpa_genesis_authorities,
+			),
+			telemetry.as_ref().map(|x| x.handle()),
+		)?;
 
 	let (bitcoin_url, bitcoin_auth) = mining_config
 		.bitcoin_rpc_url_with_auth()
@@ -237,11 +247,17 @@ where
 			Arc::clone(&peer_store_handle),
 		);
 	net_config.add_notification_protocol(grandpa_protocol_config);
+	let grandpa_genesis_authorities = client.get().map_err(|error| {
+		ServiceError::Other(format!("Failed to read GRANDPA genesis authorities: {error}"))
+	})?;
 
-	let warp_sync = Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
+	let warp_sync = Arc::new(ArgonWarpSyncProvider::new(
 		backend.clone(),
 		grandpa_link.shared_authority_set().clone(),
-		Vec::default(),
+		grandpa_hard_forks::authority_set_hard_forks(
+			config.chain_spec.id(),
+			&grandpa_genesis_authorities,
+		),
 	));
 	let (network, system_rpc_tx, tx_handler_controller, sync_service) =
 		sc_service::build_network(sc_service::BuildNetworkParams {


### PR DESCRIPTION
## Summary

Fix native node-to-node warp sync across the historical GRANDPA set-id handoffs.

This change:
- uses `block_import_with_authority_set_hard_forks(...)` for the known historical GRANDPA set-id bumps
- serves a hard-fork-aware warp proof so patched nodes generate proofs that fresh native clients can actually accept
- keeps the hard-fork table in the node for both mainnet and testnet

Related issue:
- https://github.com/argonprotocol/mainchain/issues/272

## Testing

- `cargo make fmt`
- `cargo make lint`
- `env CARGO_INCREMENTAL=0 RUSTC_WRAPPER= cargo test -p argon-node --bin argon-node grandpa_ -- --nocapture`

Mainnet validation:
- restored a production archive snapshot
- started a patched serving node from that data
- warp-synced a fresh native client against only that patched peer
- confirmed warp completed and handed off to state sync

Testnet validation:
- restored `https://argon-testnet-backup.nyc3.digitaloceanspaces.com/archive/daily/20250305/`
- started three patched serving nodes from that restored snapshot
- warp-synced a fresh native client against only those patched peers
- confirmed warp completed and handed off to state sync

Historical testnet point validation:
- verified all hard-fork block hashes directly against `wss://rpc.testnet.argonprotocol.org`
- verified the corresponding runtime `specVersion` values were inside the historical broken window
- checked `GrandpaApi_current_set_id` around each boundary to confirm the old historical lookup remained incorrect there

## Remaining Risk

- The hard-fork table currently assumes these historical fixes were set-id bumps without real GRANDPA authority-key rotations. If any listed transition changed the authority list, that entry would need to be corrected.
- The custom warp provider duplicates part of upstream GRANDPA warp-proof generation, so future `polkadot-sdk` upgrades may require keeping that file aligned with upstream behavior.
- Public warp sync will still depend on patched serving peers being deployed. Unpatched peers will continue to serve the old broken proof.
- This fixes native Substrate-to-Substrate warp sync. It does not make stock smoldot support Argon.
