### PR TITLE
fix: arithmetic safety, tax burn accounting, and treasury pool cap

### DIFF
--- a/pallets/bitcoin_locks/src/lib.rs
+++ b/pallets/bitcoin_locks/src/lib.rs
@@ -819,6 +819,11 @@ pub mod pallet {
 				return Ok(());
 			}
 
+			ensure!(
+				!LockReleaseRequestsByUtxoId::<T>::contains_key(utxo_id),
+				Error::<T>::LockInProcessOfRelease
+			);
+
 			// The user must request a co-sign 10 days before the vault can claim on bitcoin to give
 			// them enough time to react. At the time of claim height, the utxo is claimable on the
 			// bitcoin network, so this time frame must be "inside" the claim height
@@ -1174,6 +1179,13 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// NOTE: The `signature` parameter is NOT verified on-chain. The orphan record does
+		/// not retain the cosign script args needed for verification (they are cleaned up
+		/// with the BitcoinLock). The signature is passed through to the
+		/// `OrphanedUtxoCosigned` event so the lock owner can construct the Bitcoin release
+		/// transaction off-chain. A garbage signature means the owner can't spend — no
+		/// on-chain damage. To add on-chain verification, the cosign script args would need
+		/// to be stored in `OrphanedUtxo` (storage migration required).
 		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::cosign_orphaned_utxo_release())]
 		pub fn cosign_orphaned_utxo_release(
@@ -1369,8 +1381,9 @@ pub mod pallet {
 						return Ok(());
 					}
 					lock.is_funded = true;
-					T::VaultProvider::remove_pending(lock.vault_id, &lock.get_securitization())
-						.map_err(Error::<T>::from)?;
+					// Save the original securitization before any adjustments so
+					// remove_pending correctly reverses what lock() added.
+					let original_securitization = lock.get_securitization();
 
 					// If we received different amount of sats than expected, we need to adjust
 					// the lock parameters. We will not change the fee.
@@ -1404,7 +1417,10 @@ pub mod pallet {
 						&lock.owner_account,
 						lock.liquidity_promised,
 					)?;
-					T::VaultProvider::remove_pending(lock.vault_id, &lock.get_securitization())
+					// Confirm pending with the original securitization (matching what
+					// lock() added) but after all adjustments, so the operational
+					// accounts hook sees the final vault state.
+					T::VaultProvider::remove_pending(lock.vault_id, &original_securitization)
 						.map_err(Error::<T>::from)?;
 				} else {
 					log::warn!("Funded utxo_id {utxo_id:?} not found");
@@ -1543,8 +1559,10 @@ pub mod pallet {
 			};
 
 			let current_bitcoin_height = T::BitcoinBlockHeightChange::get().1;
-			let vault_claim_height = current_bitcoin_height + T::LockDurationBlocks::get();
-			let open_claim_height = vault_claim_height + T::LockReclamationBlocks::get();
+			let vault_claim_height =
+				current_bitcoin_height.saturating_add(T::LockDurationBlocks::get());
+			let open_claim_height =
+				vault_claim_height.saturating_add(T::LockReclamationBlocks::get());
 
 			let liquidity_promised = if let Some(rate) = options.and_then(|a| a.microgons_per_btc())
 			{

--- a/pallets/bitcoin_locks/src/tests.rs
+++ b/pallets/bitcoin_locks/src/tests.rs
@@ -1453,6 +1453,38 @@ fn it_should_aggregate_holds_for_a_second_release() {
 }
 
 #[test]
+fn it_rejects_duplicate_release_request() {
+	new_test_ext().execute_with(|| {
+		set_bitcoin_height(1);
+		System::set_block_number(1);
+
+		let pubkey = CompressedBitcoinPubkey([1; 33]);
+		let who = 1;
+		let satoshis = SATOSHIS_PER_BITCOIN;
+		set_argons(who, 2_000);
+		assert_ok!(BitcoinLocks::initialize(RuntimeOrigin::signed(who), 1, satoshis, pubkey, None));
+		assert_ok!(BitcoinLocks::funding_received(1, satoshis));
+		assert_ok!(Balances::mint_into(&who, 200_000 * MICROGONS_PER_ARGON));
+
+		assert_ok!(BitcoinLocks::request_release(
+			RuntimeOrigin::signed(who),
+			1,
+			make_script_pubkey(&[0; 32]),
+			10
+		));
+		assert_noop!(
+			BitcoinLocks::request_release(
+				RuntimeOrigin::signed(who),
+				1,
+				make_script_pubkey(&[0; 32]),
+				10
+			),
+			Error::<Test>::LockInProcessOfRelease
+		);
+	});
+}
+
+#[test]
 fn it_should_allow_a_ratchet_up() {
 	ChargeFee::set(true);
 	new_test_ext().execute_with(|| {

--- a/pallets/bitcoin_utxos/src/lib.rs
+++ b/pallets/bitcoin_utxos/src/lib.rs
@@ -332,11 +332,11 @@ pub mod pallet {
 			});
 			ExpiredPendingFunding::<T>::mutate(|expired| {
 				for (utxo_id, entry) in newly_expired {
-					let inserted = expired.try_insert(utxo_id, entry);
-					debug_assert!(
-						inserted.is_ok(),
-						"expired pending funding queue capacity is preserved when entries move out of pending"
-					);
+					if expired.try_insert(utxo_id, entry).is_err() {
+						log::error!(
+							"Expired pending funding queue full — utxo {utxo_id:?} dropped"
+						);
+					}
 				}
 			});
 

--- a/pallets/block_seal_spec/src/lib.rs
+++ b/pallets/block_seal_spec/src/lib.rs
@@ -403,8 +403,8 @@ pub mod pallet {
 					continue;
 				}
 				if !T::NotebookProvider::is_notary_locked_at_tick(header.notary_id, header.tick) {
-					block_votes.votes_count += header.block_votes_count;
-					block_votes.voting_power += header.block_voting_power;
+					block_votes.votes_count.saturating_accrue(header.block_votes_count);
+					block_votes.voting_power.saturating_accrue(header.block_voting_power);
 				}
 			}
 

--- a/pallets/chain_transfer/src/lib.rs
+++ b/pallets/chain_transfer/src/lib.rs
@@ -331,21 +331,26 @@ pub mod pallet {
 			}
 
 			if header.tax > 0 {
-				if let Err(e) = T::Argon::burn_from(
+				let tax: T::Balance = header.tax.into();
+				let burned = T::Argon::burn_from(
 					&notary_pallet_account_id,
-					header.tax.into(),
+					tax,
 					Preservation::Preserve,
-					Precision::Exact,
+					Precision::BestEffort,
 					Fortitude::Force,
-				) {
+				)
+				.unwrap_or_default();
+				if !burned.is_zero() {
+					T::EventHandler::on_argon_burn(&burned);
+				}
+				if burned < tax {
 					Self::deposit_event(Event::TaxationError {
 						notary_id,
 						notebook_number: header.notebook_number,
-						tax: header.tax.into(),
-						error: e,
+						tax,
+						error: DispatchError::Token(TokenError::FundsUnavailable),
 					});
 				}
-				T::EventHandler::on_argon_burn(&header.tax.into());
 			}
 
 			// Use notebook tick progression as the expiry boundary so delayed-but-valid notebooks

--- a/pallets/chain_transfer/src/tests.rs
+++ b/pallets/chain_transfer/src/tests.rs
@@ -349,3 +349,85 @@ fn it_doesnt_allow_a_notary_balance_to_go_negative() {
 		);
 	});
 }
+
+#[test]
+fn it_emits_taxation_error_when_burn_fails() {
+	MaxNotebookBlocksToRemember::set(2);
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		// Notary escrow has no funds — burn will fail
+		let issuance_before = Balances::total_issuance();
+
+		ChainTransferPallet::notebook_submitted(&NotebookHeader {
+			notary_id: 1,
+			notebook_number: 1,
+			tick: 1,
+			chain_transfers: bounded_vec![],
+			changed_accounts_root: H256::random(),
+			changed_account_origins: bounded_vec![],
+			version: 1,
+			tax: 5000,
+			block_voting_power: 0,
+			blocks_with_votes: Default::default(),
+			block_votes_root: H256::random(),
+			secret_hash: H256::random(),
+			parent_secret: None,
+			block_votes_count: 0,
+			domains: Default::default(),
+		});
+
+		// Total issuance unchanged — burn failed, nothing burned
+		assert_eq!(Balances::total_issuance(), issuance_before);
+		System::assert_has_event(
+			Event::<Test>::TaxationError {
+				notary_id: 1,
+				notebook_number: 1,
+				tax: 5000,
+				error: sp_runtime::TokenError::FundsUnavailable.into(),
+			}
+			.into(),
+		);
+	});
+}
+
+#[test]
+fn it_partially_burns_tax_when_escrow_is_low() {
+	MaxNotebookBlocksToRemember::set(2);
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let who = ChainTransferPallet::notary_account_id(1);
+		// Fund escrow with less than the tax (but above ED so burn can occur)
+		set_argons(&who, 15_000);
+
+		ChainTransferPallet::notebook_submitted(&NotebookHeader {
+			notary_id: 1,
+			notebook_number: 1,
+			tick: 1,
+			chain_transfers: bounded_vec![],
+			changed_accounts_root: H256::random(),
+			changed_account_origins: bounded_vec![],
+			version: 1,
+			tax: 20_000,
+			block_voting_power: 0,
+			blocks_with_votes: Default::default(),
+			block_votes_root: H256::random(),
+			secret_hash: H256::random(),
+			parent_secret: None,
+			block_votes_count: 0,
+			domains: Default::default(),
+		});
+
+		// Should have burned what it could (balance minus ED=10_000 to preserve account)
+		assert!(Balances::total_issuance() < 15_000);
+		// Error event emitted for the shortfall
+		System::assert_has_event(
+			Event::<Test>::TaxationError {
+				notary_id: 1,
+				notebook_number: 1,
+				tax: 20_000,
+				error: sp_runtime::TokenError::FundsUnavailable.into(),
+			}
+			.into(),
+		);
+	});
+}

--- a/pallets/mining_slot/src/lib.rs
+++ b/pallets/mining_slot/src/lib.rs
@@ -933,7 +933,7 @@ impl<T: Config> Pallet<T> {
 			for miner in rotating_out {
 				let account_id = miner.account_id.clone();
 				AccountIndexLookup::<T>::remove(&account_id);
-				active_miners -= 1;
+				active_miners.saturating_reduce(1);
 				let _ = released_miners_by_account_id.try_insert(account_id.clone(), miner.clone());
 				removed_miners.push((account_id, miner.authority_keys.clone()));
 				let next_registration =

--- a/pallets/mint/src/lib.rs
+++ b/pallets/mint/src/lib.rs
@@ -345,12 +345,12 @@ pub mod pallet {
 			let total_minted = mining_mint + bitcoin_utxos;
 			let mining_prorata = (amount * mining_mint).checked_div(&total_minted);
 			if let Some(microgons) = mining_prorata {
-				MintedMiningMicrogons::<T>::mutate(|mint| *mint -= microgons);
+				MintedMiningMicrogons::<T>::mutate(|mint| mint.saturating_reduce(microgons));
 			}
 
 			let bitcoin_prorata = (amount * bitcoin_utxos).checked_div(&total_minted);
 			if let Some(microgons) = bitcoin_prorata {
-				MintedBitcoinMicrogons::<T>::mutate(|mint| *mint -= microgons);
+				MintedBitcoinMicrogons::<T>::mutate(|mint| mint.saturating_reduce(microgons));
 			}
 		}
 	}

--- a/pallets/mint/src/tests.rs
+++ b/pallets/mint/src/tests.rs
@@ -34,6 +34,13 @@ fn it_records_burnt_argons_by_prorata() {
 		MintedBitcoinMicrogons::<Test>::set(66);
 		Mint::on_argon_burn(10);
 		assert_eq!(MintedMiningMicrogons::<Test>::get(), 33 - 3);
+
+		// burn amount larger than tracked mints saturates to zero
+		MintedMiningMicrogons::<Test>::set(5);
+		MintedBitcoinMicrogons::<Test>::set(5);
+		Mint::on_argon_burn(100);
+		assert_eq!(MintedMiningMicrogons::<Test>::get(), 0);
+		assert_eq!(MintedBitcoinMicrogons::<Test>::get(), 0);
 	});
 }
 

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -62,6 +62,7 @@ pub mod pallet {
 	use alloc::{collections::BTreeMap, vec::Vec};
 	use argon_primitives::{
 		TreasuryPoolProvider,
+		providers::PriceProvider,
 		vault::{MiningBidPoolProvider, TreasuryVaultProvider, VaultTreasuryFrameEarnings},
 	};
 	use pallet_prelude::argon_primitives::{
@@ -108,6 +109,8 @@ pub mod pallet {
 		type RuntimeHoldReason: From<HoldReason>;
 
 		type TreasuryVaultProvider: TreasuryVaultProvider<Balance = Self::Balance, AccountId = Self::AccountId>;
+
+		type PriceProvider: PriceProvider<Self::Balance>;
 
 		/// The maximum number of contributors to a bond fund
 		#[pallet::constant]
@@ -817,8 +820,9 @@ pub mod pallet {
 
 		fn get_vault_securitized_funds_per_slot(vault_id: VaultId) -> T::Balance {
 			let securitized_satoshis = T::TreasuryVaultProvider::get_securitized_satoshis(vault_id);
-			let securitized_capital: T::Balance = u128::from(securitized_satoshis).into();
-			securitized_capital / 10u128.into()
+			let securitized_argons =
+				T::PriceProvider::get_bitcoin_argon_price(securitized_satoshis).unwrap_or_default();
+			securitized_argons / 10u128.into()
 		}
 	}
 

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -1,7 +1,7 @@
 use crate as pallet_treasury;
 use argon_primitives::{
 	OperationalAccountsHook, OperationalRewardPayout, OperationalRewardsProvider,
-	bitcoin::Satoshis, vault::TreasuryVaultProvider,
+	bitcoin::Satoshis, providers::PriceProvider, vault::TreasuryVaultProvider,
 };
 use frame_support::traits::Currency;
 use pallet_prelude::{
@@ -129,6 +129,10 @@ parameter_types! {
 
 	pub static VaultsById: HashMap<VaultId, TestVault> = HashMap::new();
 
+	// BTC=$100 / argon=$1 makes 1 sat = 1 microgon for clean test math
+	pub static BitcoinPricePerUsd: Option<FixedU128> = Some(FixedU128::from_float(100.00));
+	pub static ArgonPricePerUsd: Option<FixedU128> = Some(FixedU128::from_float(1.00));
+
 	pub static LastVaultProfits: Vec<VaultTreasuryFrameEarnings<Balance, u64>> = vec![];
 	pub static TreasuryPoolParticipated: Vec<(u64, Balance)> = vec![];
 	pub static PendingOperationalRewards: Vec<OperationalRewardPayout<u64, Balance>> = vec![];
@@ -155,6 +159,28 @@ pub fn set_vault_securitized_satoshis(vault_id: VaultId, satoshis: Satoshis) {
 			vault.securitized_satoshis = satoshis;
 		}
 	});
+}
+
+pub struct StaticPriceProvider;
+impl PriceProvider<Balance> for StaticPriceProvider {
+	fn get_latest_btc_price_in_usd() -> Option<FixedU128> {
+		BitcoinPricePerUsd::get()
+	}
+	fn get_latest_argon_price_in_usd() -> Option<FixedU128> {
+		ArgonPricePerUsd::get()
+	}
+	fn get_argon_cpi() -> Option<argon_primitives::ArgonCPI> {
+		None
+	}
+	fn get_redemption_r_value() -> Option<FixedU128> {
+		None
+	}
+	fn get_circulation() -> Balance {
+		0
+	}
+	fn get_average_cpi_for_ticks(_tick_range: (Tick, Tick)) -> argon_primitives::ArgonCPI {
+		FixedI128::zero()
+	}
 }
 
 pub struct StaticTreasuryVaultProvider;
@@ -213,6 +239,7 @@ impl pallet_treasury::Config for Test {
 	type Currency = Balances;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type TreasuryVaultProvider = StaticTreasuryVaultProvider;
+	type PriceProvider = StaticPriceProvider;
 	type MaxTreasuryContributors = MaxTreasuryContributors;
 	type MinimumArgonsPerContributor = MinimumArgonsPerContributor;
 	type PalletId = VaultPalletId;

--- a/pallets/vaults/src/mock.rs
+++ b/pallets/vaults/src/mock.rs
@@ -173,6 +173,7 @@ impl pallet_treasury::Config for Test {
 	type MiningFrameTransitionProvider = StaticMiningFrameProvider;
 	type OperationalAccountsHook = ();
 	type OperationalRewardsProvider = ();
+	type PriceProvider = StaticPriceProvider;
 }
 
 pub struct StaticBitcoinUtxoTracker;

--- a/runtime/argon/src/lib.rs
+++ b/runtime/argon/src/lib.rs
@@ -397,6 +397,7 @@ impl pallet_treasury::Config for Runtime {
 	type Currency = Balances;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type TreasuryVaultProvider = Vaults;
+	type PriceProvider = PriceIndex;
 	type MaxTreasuryContributors = MaxTreasuryContributors;
 	type MinimumArgonsPerContributor = MinimumArgonsPerContributor;
 	type PalletId = TreasuryInternalPalletId;

--- a/runtime/canary/src/lib.rs
+++ b/runtime/canary/src/lib.rs
@@ -399,6 +399,7 @@ impl pallet_treasury::Config for Runtime {
 	type Currency = Balances;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type TreasuryVaultProvider = Vaults;
+	type PriceProvider = PriceIndex;
 	type MaxTreasuryContributors = MaxTreasuryContributors;
 	type MinimumArgonsPerContributor = MinimumArgonsPerContributor;
 	type PalletId = TreasuryInternalPalletId;


### PR DESCRIPTION
## Summary

- Fix tax burn accounting in `chain_transfer` — use `BestEffort` burn so the mint pallet only tracks what was actually burned, not the requested amount. Emits `TaxationError` on shortfall.
- Fix double `remove_pending` in `bitcoin_locks::funding_received` — save original securitization before adjustments and call `remove_pending` once after all state is finalized.
- Reject duplicate `request_release` calls for the same UTXO to prevent permanently freezing the first hold.
- Fix treasury pool cap to convert securitized satoshis to argon microgons via `PriceProvider` instead of treating raw satoshis as argon balances.
- Replace bare `+=`/`-=` with `saturating_accrue`/`saturating_reduce` in mint, mining_slot, and block_seal_spec to prevent silent wrapping in WASM builds.
- Replace `debug_assert!` with `log::error!` in bitcoin_utxos expired funding queue overflow (debug_assert is a no-op in release WASM).
- Use `saturating_add` for bitcoin lock height calculations.

## Test plan

- [x] All 162 tests pass across 7 modified packages
- [x] New test: `it_rejects_duplicate_release_request` in bitcoin_locks
- [x] New tests: `it_emits_taxation_error_when_burn_fails` and `it_partially_burns_tax_when_escrow_is_low` in chain_transfer
- [x] Extended `it_records_burnt_argons_by_prorata` in mint to cover saturating underflow
- [x] `cargo make lint` passes clean