### PR TITLE
Reduce transaction fee scaling to sub-cent levels

### DIFF
--- a/runtime/common/src/config.rs
+++ b/runtime/common/src/config.rs
@@ -184,7 +184,7 @@ parameter_types! {
 
 	// Fees
 	pub FeeMultiplier: Multiplier = Multiplier::one();
-	pub const TransactionByteFee: Balance = 10;
+	pub const TransactionByteFee: Balance = 1;
 
 
 	// ## pallet_hyperbridge
@@ -251,7 +251,7 @@ impl WeightToFeePolynomial for ArgonWeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
 		let p = ARGON; // microgons
-		let q = 100 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
+		let q = 10_000 * Balance::from(ExtrinsicBaseWeight::get().ref_time());
 		// BAB - disabling wage protector for fees. Makes it hard to keep system stable
 		// let cpi = PriceIndex::get_argon_cpi().unwrap_or(ArgonCPI::zero());
 		// if cpi.is_positive() {


### PR DESCRIPTION
## Summary
- Increase weight-to-fee divisor from 100 to 10,000 and reduce `TransactionByteFee` from 10 to 1 microgon
- Brings per-extrinsic fees to sub-cent levels now that benchmarked weights are in place

### Fee estimates at new rate

| Extrinsic | Fee (microgons) | Fee (cents) |
|---|---|---|
| `transfer_keep_alive` | ~350 | 0.035 |
| `transfer_allow_death` | ~360 | 0.036 |
| `send_to_localchain` | ~760 | 0.08 |
| `bitcoin_locks::initialize` | ~800 | 0.08 |
| `vaults::create` | ~1,080 | 0.11 |
| `bitcoin_locks::cosign_release` | ~1,290 | 0.13 |
| `operational::register` | ~1,380 | 0.14 |
| `mining_slot::bid` | ~1,550 | 0.16 |
| **Batch of 3 bids** | ~4,430 | 0.44 |