### PR TITLE
Refine prek hook flow

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -7,6 +7,7 @@ hooks = [
     { id = "end-of-file-fixer" },
     { id = "check-yaml" },
     { id = "check-toml" },
+    { id = "check-symlinks" },
     { id = "check-case-conflict" },
     { id = "check-executables-have-shebangs" },
     { id = "check-merge-conflict" },
@@ -17,12 +18,21 @@ hooks = [
 repo = "local"
 hooks = [
     {
-        id = "format",
-        name = "Format code with cargo fmt + zepter",
-        entry = "cargo make format",
+        id = "rust-pre-commit",
+        name = "Format Rust code and restage hook fixes",
+        entry = "bash scripts/prek_rust_pre_commit.sh",
+        language = "system",
+        types = ["rust"],
+        pass_filenames = true,
+        stages = ["pre-commit"],
+    },
+    {
+        id = "rust-clippy-check",
+        name = "Run full workspace clippy before push",
+        entry = "cargo make lint-check",
         language = "system",
         types = ["rust"],
         pass_filenames = false,
-        stages = ["pre-commit", "pre-push"],
+        stages = ["pre-push"],
     },
 ]

--- a/scripts/prek_rust_pre_commit.sh
+++ b/scripts/prek_rust_pre_commit.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+declare -a staged_files=()
+while IFS= read -r -d '' file; do
+    staged_files+=("$file")
+done < <(git diff --cached --name-only -z --diff-filter=ACMR)
+
+declare -a rust_files=()
+if (($# > 0)); then
+    for file in "$@"; do
+        if [[ "$file" == *.rs ]]; then
+            rust_files+=("$file")
+        fi
+    done
+else
+    while IFS= read -r -d '' file; do
+        rust_files+=("$file")
+    done < <(git diff --cached --name-only -z --diff-filter=ACMR -- '*.rs')
+fi
+
+if ((${#rust_files[@]} == 0)); then
+    exit 0
+fi
+
+echo "Running cargo make format"
+cargo make format
+
+declare -a restaged_files=()
+
+for file in "${staged_files[@]}"; do
+    if [[ ! -e "$file" ]]; then
+        continue
+    fi
+
+    if git diff --quiet -- "$file"; then
+        continue
+    fi
+
+    git add -- "$file"
+    restaged_files+=("$file")
+done
+
+if ((${#restaged_files[@]} > 0)); then
+    printf 'Restaged hook updates for:\n'
+    printf '  %s\n' "${restaged_files[@]}"
+fi


### PR DESCRIPTION
## Summary
- run Rust formatting and restaging on pre-commit so formatter changes stay in the same commit
- move full workspace clippy to pre-push instead of pretending to lint changed files only
- keep the low-noise builtin checks in the prek config

## Testing
- validated `prek.toml` with `prek validate-config prek.toml`
- verified the pre-commit hook end-to-end in a disposable worktree by making a formatting-only Rust change and confirming the commit completed with the reformatted file staged