### PR TITLE
Per notary notebook workers

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -248,7 +248,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 	let consensus_metrics_finder = consensus_metrics.clone();
 
 	let block_finder_task = async move {
-		*notary_client.pause_queue_processing.write().await = true;
+		*notary_client.pause_notebook_audits.write().await = true;
 		let mut import_stream = client.every_import_notification_stream();
 		let mut finalized_stream = client.finality_notification_stream();
 		let idle_delay = if ticker.tick_duration_millis <= 10_000 { 100 } else { 1000 };
@@ -333,7 +333,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 
 			// don't try to check for blocks during a sync
 			if sync_oracle.is_major_syncing() {
-				*notary_client.pause_queue_processing.write().await = true;
+				*notary_client.pause_notebook_audits.write().await = true;
 				continue;
 			}
 
@@ -344,7 +344,7 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 			let state_status =
 				client.block_status(best_hash).unwrap_or(sp_consensus::BlockStatus::Unknown);
 			if state_status != sp_consensus::BlockStatus::InChainWithState {
-				*notary_client.pause_queue_processing.write().await = true;
+				*notary_client.pause_notebook_audits.write().await = true;
 				debug!(
 					?best_hash,
 					?state_status,
@@ -353,13 +353,13 @@ pub fn run_block_builder_task<Block, BI, C, PF, A, SC, SO, JS, B>(
 				continue;
 			}
 
-			if *notary_client.pause_queue_processing.read().await {
+			if *notary_client.pause_notebook_audits.read().await {
 				info!(
 					?best_hash,
 					?best_number,
 					"🏁 Node state is synched. Activating notary sync."
 				);
-				*notary_client.pause_queue_processing.write().await = false;
+				*notary_client.pause_notebook_audits.write().await = false;
 			}
 
 			let mut notebooks_to_check = notebook_ticks_recheck.get_ready();

--- a/node/consensus/src/mock_importer.rs
+++ b/node/consensus/src/mock_importer.rs
@@ -37,6 +37,7 @@ use sp_runtime::{
 use std::{
 	collections::{BTreeMap, HashMap},
 	sync::{Arc, Mutex},
+	time::Duration,
 };
 
 impl<B: BlockT, I, C: AuxStore, AC> ArgonBlockImport<B, I, C, AC> {
@@ -496,6 +497,8 @@ fn new_notary_client_for_tests(client: &Arc<MemChain>) -> Arc<NotaryClient<Block
 		notebook_downloader,
 		Arc::new(None),
 		ticker,
+		None,
+		Duration::from_millis(250),
 		true,
 	))
 }

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -56,6 +56,7 @@ use tracing::error;
 const MAX_PARALLEL_NOTARY_DOWNLOADS: usize = 8;
 const MAX_PARALLEL_NOTARY_AUDITS: usize = 4;
 const HEADER_PREFETCH_WINDOW: usize = MAX_PARALLEL_NOTARY_DOWNLOADS;
+const MAX_NOTEBOOK_SUBSCRIPTION_TICK_LAG: Tick = 2;
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
@@ -605,6 +606,8 @@ struct NotaryWorker {
 	archive_host: RwLock<Option<String>>,
 	subscription: Mutex<Option<Pin<Box<RawHeadersSubscription>>>>,
 	pending: Mutex<NotebookAuditState>,
+	last_notebook_tick: RwLock<Option<Tick>>,
+	last_connection_attempt_tick: RwLock<Option<Tick>>,
 	connection_lock: Arc<Mutex<()>>,
 	processing_lock: Arc<Mutex<()>>,
 	background_task_started: AtomicBool,
@@ -619,6 +622,8 @@ impl NotaryWorker {
 			archive_host: Default::default(),
 			subscription: Default::default(),
 			pending: Default::default(),
+			last_notebook_tick: Default::default(),
+			last_connection_attempt_tick: Default::default(),
 			connection_lock: Arc::new(Mutex::new(())),
 			processing_lock: Arc::new(Mutex::new(())),
 			background_task_started: AtomicBool::new(false),
@@ -688,6 +693,7 @@ impl NotaryWorker {
 		let _connection_guard = self.connection_lock.lock().await;
 		self.client.write().await.take();
 		self.clear_subscription().await;
+		self.last_notebook_tick.write().await.take();
 	}
 
 	async fn has_client(&self) -> bool {
@@ -698,7 +704,7 @@ impl NotaryWorker {
 		self.subscription.lock().await.is_some()
 	}
 
-	async fn ensure_connected_subscription(&self) -> Result<(), Error> {
+	async fn ensure_connected_subscription(&self, current_tick: Tick) -> Result<(), Error> {
 		let _connection_guard = self.connection_lock.lock().await;
 		let can_connect = {
 			let record = self.record.read().await;
@@ -712,16 +718,54 @@ impl NotaryWorker {
 		}
 
 		let notary_id = self.notary_id;
-		if !self.has_client().await {
+		let needs_client = !self.has_client().await;
+		let needs_subscription = !self.has_subscription().await;
+		if !needs_client && !needs_subscription {
+			return Ok(());
+		}
+
+		{
+			let mut last_connection_attempt_tick = self.last_connection_attempt_tick.write().await;
+			if *last_connection_attempt_tick == Some(current_tick) {
+				trace!(
+					"Skipping notary connection attempt. notary_id={notary_id} current_tick={current_tick}"
+				);
+				return Ok(());
+			}
+			*last_connection_attempt_tick = Some(current_tick);
+		}
+
+		if needs_client {
 			info!("Connecting to notary id={notary_id}");
 			self.connect().await?;
 		}
 
-		if !self.has_subscription().await {
+		if needs_subscription {
 			self.subscribe().await?;
 		}
 
 		Ok(())
+	}
+
+	async fn disconnect_if_subscription_stale(&self, current_tick: Tick) {
+		if !self.has_subscription().await {
+			return;
+		}
+
+		let Some(last_notebook_tick) = *self.last_notebook_tick.read().await else {
+			return;
+		};
+
+		let tick_lag = current_tick.saturating_sub(last_notebook_tick);
+		if tick_lag <= MAX_NOTEBOOK_SUBSCRIPTION_TICK_LAG {
+			return;
+		}
+
+		warn!(
+			"Disconnecting stale notary subscription. notary_id={} last_notebook_tick={last_notebook_tick} current_tick={current_tick} tick_lag={tick_lag}",
+			self.notary_id,
+		);
+		self.clear_connection().await;
 	}
 
 	async fn poll_subscription<B, C, AC>(
@@ -741,6 +785,7 @@ impl NotaryWorker {
 
 		match next {
 			Poll::Ready(Some(Ok(download_info))) => {
+				*self.last_notebook_tick.write().await = Some(download_info.tick);
 				if let Some(metrics) = worker_context.metrics.as_ref() {
 					metrics.notebook_notification_received(
 						self.notary_id,
@@ -792,7 +837,20 @@ impl NotaryWorker {
 			self.clear_subscription().await;
 			return Ok(false);
 		}
-		self.ensure_connected_subscription().await?;
+		let current_tick = if let Some(block_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			worker_context.client.as_ref(),
+			worker_context.client.best_hash(),
+		)? {
+			Some(worker_context.client.current_tick(block_hash)?)
+		} else {
+			None
+		};
+		if let Some(current_tick) = current_tick {
+			self.disconnect_if_subscription_stale(current_tick).await;
+			self.ensure_connected_subscription(current_tick).await?;
+		} else if !self.has_client().await || !self.has_subscription().await {
+			return Ok(false);
+		}
 		let saw_subscription = self.poll_subscription(worker_context).await.is_some();
 		let has_more_work = self.process_background_work(worker_context).await;
 		Ok(saw_subscription || has_more_work)
@@ -848,6 +906,7 @@ impl NotaryWorker {
 		})?;
 		*self.archive_host.write().await = Some(archive_host);
 		if notebook_meta.last_closed_notebook_number > 0 {
+			*self.last_notebook_tick.write().await = Some(notebook_meta.last_closed_notebook_tick);
 			trace!(
 				"Tracking latest notebook {} for notary {}",
 				notebook_meta.last_closed_notebook_number, self.notary_id
@@ -1472,6 +1531,7 @@ where
 			return Ok(());
 		};
 		let notaries = self.worker_context.client.notaries(block_hash)?;
+		let current_tick = self.worker_context.client.current_tick(block_hash)?;
 		let active_ids = notaries.iter().map(|notary| notary.notary_id).collect::<BTreeSet<_>>();
 		let existing_workers = self
 			.workers_by_id
@@ -1521,10 +1581,11 @@ where
 				continue;
 			}
 
+			worker.disconnect_if_subscription_stale(current_tick).await;
 			let is_connected = worker.has_client().await && worker.has_subscription().await;
 
 			if !is_connected || host_changed {
-				if let Err(e) = worker.ensure_connected_subscription().await {
+				if let Err(e) = worker.ensure_connected_subscription(current_tick).await {
 					self.disconnect(
 						&notary_id,
 						Some(format!("Notary {notary_id} sync failed. {e:?}")),
@@ -2517,7 +2578,16 @@ mod test {
 		assert!(!has_worker_client(&notary_client, 1).await);
 		assert!(!has_worker_subscription(&notary_client, 1).await);
 
-		// Periodic notary refreshes reuse the same best hash when no new block has arrived.
+		// Periodic notary refreshes reuse the same best hash when no new block has arrived,
+		// but connection attempts are limited to once per tick.
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not refresh notaries");
+		assert!(!has_worker_client(&notary_client, 1).await);
+		assert!(!has_worker_subscription(&notary_client, 1).await);
+
+		*client.current_tick.lock() = 1;
 		notary_client
 			.update_notaries(&client.best_hash())
 			.await
@@ -2530,6 +2600,63 @@ mod test {
 			.await
 			.expect("worker should resubscribe without a new block");
 		assert_eq!(next, (1, 1));
+	}
+
+	#[tokio::test]
+	async fn disconnects_stale_worker_subscription_after_missing_ticks() {
+		let (mut test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		test_notary.create_notebook_header(vec![]).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500)).await.unwrap();
+		assert_eq!(next, (1, 1));
+
+		let worker = worker(&notary_client, 1).await.expect("worker should exist");
+		assert_eq!(*worker.last_notebook_tick.read().await, Some(1));
+
+		*client.current_tick.lock() = 3;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert_eq!(*worker.last_notebook_tick.read().await, Some(1));
+		assert!(worker.has_client().await);
+		assert!(worker.has_subscription().await);
+
+		test_notary.stop().await;
+		*client.current_tick.lock() = 4;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		assert_eq!(*worker.last_notebook_tick.read().await, None);
+		assert!(!worker.has_client().await);
+		assert!(!worker.has_subscription().await);
+		assert_eq!(*worker.last_connection_attempt_tick.read().await, Some(4));
+
+		test_notary.start().await.expect("could not restart notary");
+		client.notaries.lock()[0].meta.hosts = bounded_vec![test_notary.addr.clone().into()];
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		assert!(!worker.has_client().await);
+		assert!(!worker.has_subscription().await);
+
+		*client.current_tick.lock() = 5;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		assert_eq!(*worker.last_connection_attempt_tick.read().await, Some(5));
+		assert!(worker.has_client().await);
+		assert!(worker.has_subscription().await);
 	}
 
 	#[tokio::test]
@@ -2880,6 +3007,7 @@ mod test {
 		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 
 		*notary_client.pause_notebook_audits.write().await = false;
+		*client.current_tick.lock() = 1;
 		notary_client
 			.update_notaries(&client.best_hash())
 			.await

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -877,7 +877,7 @@ impl NotaryWorker {
 		let idle_delay = background_idle_delay;
 
 		spawn_handle.spawn("notary_worker_task", "notary_worker", async move {
-			let mut delay = idle_delay;
+			let mut delay = Duration::ZERO;
 			loop {
 				time::sleep(delay).await;
 				delay = match worker.run_background_pass(worker_context.as_ref()).await {
@@ -2708,7 +2708,6 @@ mod test {
 
 		// still missing number 9
 		assert!(matches!(result, Error::MissingNotebooksError(_)),);
-		println!("result: {result}");
 		assert!(result.to_string().contains("#9..=9"));
 
 		for _ in 0..9 {
@@ -2986,7 +2985,7 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn paused_queue_processing_drops_subscription_backlog() {
+	async fn paused_notebook_audits_disable_subscriptions_until_resumed() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
 			.update_notaries(&client.best_hash())

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -1,8 +1,6 @@
 use crate::{
-	aux_client::ArgonAux,
-	error::Error,
-	metrics::ConsensusMetrics,
-	state_anchor::{DEFAULT_STATE_LOOKBACK_DEPTH, StateAnchorClient},
+	aux_client::ArgonAux, error::Error, metrics::ConsensusMetrics,
+	state_anchor::DEFAULT_STATE_LOOKBACK_DEPTH,
 };
 use argon_notary_apis::{
 	ArchiveHost, Client, DownloadKind, DownloadPolicy, DownloadTrustMode, SystemRpcClient,
@@ -25,7 +23,6 @@ use codec::Codec;
 use futures::{Stream, StreamExt, future::join_all, task::noop_waker_ref};
 use log::{info, trace, warn};
 use polkadot_sdk::*;
-use rand::prelude::SliceRandom;
 use sc_client_api::{AuxStore, BlockchainEvents};
 use sc_service::TaskManager;
 use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender, tracing_unbounded};
@@ -42,18 +39,23 @@ use std::{
 	marker::PhantomData,
 	ops::Range,
 	pin::Pin,
-	sync::Arc,
+	sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	},
 	task::{Context, Poll},
 	time::{Duration, Instant},
 };
 use substrate_prometheus_endpoint::Registry;
 use tokio::{
-	sync::{Mutex, RwLock},
+	sync::{Mutex, RwLock, Semaphore},
 	time,
 };
 use tracing::error;
 
-const MAX_QUEUE_DEPTH: usize = 1440 * 2; // a notary can be down 2 days before we start dropping history
+const MAX_PARALLEL_NOTARY_DOWNLOADS: usize = 8;
+const MAX_PARALLEL_NOTARY_AUDITS: usize = 4;
+const HEADER_PREFETCH_WINDOW: usize = MAX_PARALLEL_NOTARY_DOWNLOADS;
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
@@ -208,10 +210,11 @@ where
 		notebook_downloader,
 		metrics,
 		ticker,
+		Some(task_manager.spawn_handle()),
+		Duration::from_millis(no_work_delay_millis),
 		is_solving_blocks,
 	));
 
-	let notary_client_clone = Arc::clone(&notary_client);
 	let notary_client_poll = Arc::clone(&notary_client);
 	let best_block = client.best_hash();
 	let notary_sync_task = async move {
@@ -244,9 +247,6 @@ where
 
 		loop {
 			tokio::select! {
-				Some((notary_id, notebook_number)) =  notary_client_poll.poll_subscriptions() => {
-					trace!( "Next notebook pushed (notary {notary_id}, notebook {notebook_number})");
-				},
 				Some(ref block) = best_block.next() => {
 					if block.is_new_best {
 						let best_hash = block.hash;
@@ -288,645 +288,754 @@ where
 			}
 		}
 	};
-
-	let notary_queue_task = async move {
-		let notary_client = notary_client_clone;
-		loop {
-			let has_more_work = notary_client
-				.process_queues(None)
-				.await
-				.inspect_err(|err| {
-					warn!("Error while processing notary queues: {err:?}");
-				})
-				.unwrap_or(false);
-
-			let mut delay = 20;
-			if !has_more_work {
-				delay = no_work_delay_millis
-			}
-			tokio::time::sleep(Duration::from_millis(delay)).await;
-		}
-	};
 	let handle = task_manager.spawn_essential_handle();
 	handle.spawn("notary_sync_task", "notary_sync", notary_sync_task);
-	// Making this blocking due to the runtime calls and potentially heavy decodes
-	handle.spawn_blocking("notary_queue_task", "notary_queue", notary_queue_task);
 
 	notary_client
 }
 
-type PendingNotebook = (NotebookNumber, Option<SignedHeaderBytes>, Instant);
+type WorkerHandle = Arc<NotaryWorker>;
+type WorkersById = Arc<RwLock<BTreeMap<NotaryId, WorkerHandle>>>;
 type ProcessingHashes<Hash> = (Hash, Hash);
 
 type NotebookCount = u32;
 pub type VotingPowerInfo = (Tick, BlockVotingPower, NotebookCount);
 
-pub struct NotaryClient<B: BlockT, C: AuxStore, AC> {
+struct MissingAuditCatchup {
+	by_notary: BTreeMap<NotaryId, Vec<NotebookNumber>>,
+	needs_notary_updates: bool,
+}
+
+struct NotebookAuditTarget {
+	notebook_number: NotebookNumber,
+	header_bytes: Option<SignedHeaderBytes>,
+	known_since: Instant,
+}
+
+struct NotebookAuditSelection {
+	target: Option<NotebookAuditTarget>,
+	finalized_notebooks_trimmed: u32,
+	tracked_range: Range<NotebookNumber>,
+}
+
+#[derive(Default)]
+struct NotebookAuditState {
+	next_notebook_number: Option<NotebookNumber>,
+	highest_notebook_number: Option<NotebookNumber>,
+	known_since_by_notebook: BTreeMap<NotebookNumber, Instant>,
+	cached_headers: BTreeMap<NotebookNumber, SignedHeaderBytes>,
+}
+
+impl NotebookAuditState {
+	fn track_notebook(
+		&mut self,
+		notebook_number: NotebookNumber,
+		header_bytes: Option<SignedHeaderBytes>,
+		known_since: Option<Instant>,
+	) {
+		let known_since = known_since.unwrap_or_else(Instant::now);
+		match self.bounds() {
+			Some((next_notebook_number, highest_notebook_number)) => {
+				if notebook_number < next_notebook_number {
+					self.record_known_range(notebook_number, next_notebook_number - 1, known_since);
+					self.next_notebook_number = Some(notebook_number);
+				}
+
+				if notebook_number > highest_notebook_number {
+					self.record_known_range(
+						highest_notebook_number + 1,
+						notebook_number,
+						known_since,
+					);
+					self.highest_notebook_number = Some(notebook_number);
+				}
+			},
+			None => self.initialize(notebook_number, notebook_number, known_since),
+		}
+
+		if let Some(header_bytes) = header_bytes {
+			self.cached_headers.entry(notebook_number).or_insert(header_bytes);
+		}
+	}
+
+	fn track_range(
+		&mut self,
+		first_notebook_number: NotebookNumber,
+		last_notebook_number: NotebookNumber,
+	) {
+		let known_since = Instant::now();
+		if first_notebook_number > last_notebook_number {
+			return;
+		}
+
+		match self.bounds() {
+			Some((next_notebook_number, highest_notebook_number)) => {
+				if first_notebook_number < next_notebook_number {
+					self.record_known_range(
+						first_notebook_number,
+						next_notebook_number - 1,
+						known_since,
+					);
+					self.next_notebook_number = Some(first_notebook_number);
+				}
+				if last_notebook_number > highest_notebook_number {
+					self.record_known_range(
+						highest_notebook_number + 1,
+						last_notebook_number,
+						known_since,
+					);
+					self.highest_notebook_number = Some(last_notebook_number);
+				}
+			},
+			None => self.initialize(first_notebook_number, last_notebook_number, known_since),
+		}
+	}
+
+	fn clear(&mut self) {
+		self.next_notebook_number = None;
+		self.highest_notebook_number = None;
+		self.known_since_by_notebook.clear();
+		self.cached_headers.clear();
+	}
+
+	fn len(&self) -> usize {
+		match self.bounds() {
+			Some((next, highest)) if highest >= next => (highest - next + 1) as usize,
+			_ => 0,
+		}
+	}
+
+	fn range(&self) -> Range<NotebookNumber> {
+		match self.bounds() {
+			Some((start, end)) => Range { start, end },
+			_ => 0..0,
+		}
+	}
+
+	#[cfg(test)]
+	fn snapshot(&self) -> Vec<(NotebookNumber, bool)> {
+		let Some((next, highest)) = self.bounds() else {
+			return Vec::new();
+		};
+
+		(next..=highest)
+			.map(|number| {
+				let has_header = self.cached_headers.contains_key(&number);
+				(number, has_header)
+			})
+			.collect()
+	}
+
+	fn rewind_to(&mut self, notebook_number: NotebookNumber) {
+		let known_since = Instant::now();
+		match self.bounds() {
+			Some((next_notebook_number, highest_notebook_number)) => {
+				if notebook_number < next_notebook_number {
+					self.record_known_range(notebook_number, next_notebook_number - 1, known_since);
+					self.next_notebook_number = Some(notebook_number);
+				} else if notebook_number > highest_notebook_number {
+					self.record_known_range(
+						highest_notebook_number + 1,
+						notebook_number,
+						known_since,
+					);
+					self.highest_notebook_number = Some(notebook_number);
+				}
+			},
+			None => self.initialize(notebook_number, notebook_number, known_since),
+		}
+		self.cached_headers.remove(&notebook_number);
+	}
+
+	fn prefetch_targets(&self, window: usize) -> Vec<NotebookNumber> {
+		let Some((next, highest)) = self.bounds() else {
+			return Vec::new();
+		};
+		if highest <= next {
+			return Vec::new();
+		}
+
+		let last = highest.min(next.saturating_add(window as NotebookNumber));
+		((next + 1)..=last)
+			.filter(|number| !self.cached_headers.contains_key(number))
+			.collect()
+	}
+
+	fn cache_header(&mut self, notebook_number: NotebookNumber, header_bytes: SignedHeaderBytes) {
+		let Some((next, highest)) = self.bounds() else {
+			return;
+		};
+		if notebook_number < next || notebook_number > highest {
+			return;
+		}
+
+		self.cached_headers.entry(notebook_number).or_insert(header_bytes);
+	}
+
+	fn select_next_audit(
+		&mut self,
+		finalized_notebook_number: NotebookNumber,
+	) -> NotebookAuditSelection {
+		let tracked_range = self.range();
+		let Some((mut next, highest)) = self.bounds() else {
+			return NotebookAuditSelection {
+				target: None,
+				finalized_notebooks_trimmed: 0,
+				tracked_range,
+			};
+		};
+
+		let mut finalized_notebooks_trimmed = 0;
+		if next <= finalized_notebook_number {
+			let new_next = finalized_notebook_number.saturating_add(1);
+			if new_next > highest {
+				finalized_notebooks_trimmed = highest - next + 1;
+				self.clear();
+				return NotebookAuditSelection {
+					target: None,
+					finalized_notebooks_trimmed,
+					tracked_range,
+				};
+			}
+
+			finalized_notebooks_trimmed = new_next - next;
+			next = new_next;
+			self.advance_to(new_next);
+		}
+
+		NotebookAuditSelection {
+			target: Some(NotebookAuditTarget {
+				notebook_number: next,
+				header_bytes: self.cached_headers.get(&next).cloned(),
+				known_since: self.known_since(next),
+			}),
+			finalized_notebooks_trimmed,
+			tracked_range,
+		}
+	}
+
+	fn bounds(&self) -> Option<(NotebookNumber, NotebookNumber)> {
+		Some((self.next_notebook_number?, self.highest_notebook_number?))
+	}
+
+	fn initialize(
+		&mut self,
+		first_notebook_number: NotebookNumber,
+		last_notebook_number: NotebookNumber,
+		known_since: Instant,
+	) {
+		self.next_notebook_number = Some(first_notebook_number);
+		self.highest_notebook_number = Some(last_notebook_number);
+		self.known_since_by_notebook.clear();
+		self.known_since_by_notebook.insert(first_notebook_number, known_since);
+	}
+
+	fn mark_processed(&mut self, notebook_number: NotebookNumber) {
+		if self.next_notebook_number != Some(notebook_number) {
+			return;
+		}
+
+		let Some(highest_notebook_number) = self.highest_notebook_number else {
+			return;
+		};
+		self.cached_headers.remove(&notebook_number);
+		if notebook_number >= highest_notebook_number {
+			self.clear();
+			return;
+		}
+		self.advance_to(notebook_number + 1);
+	}
+
+	fn advance_to(&mut self, next_notebook_number: NotebookNumber) {
+		let Some(highest_notebook_number) = self.highest_notebook_number else {
+			return;
+		};
+		if next_notebook_number > highest_notebook_number {
+			self.clear();
+			return;
+		}
+
+		let known_since = self.known_since(next_notebook_number);
+		self.next_notebook_number = Some(next_notebook_number);
+		self.cached_headers.retain(|number, _| *number >= next_notebook_number);
+		self.known_since_by_notebook.retain(|number, _| *number >= next_notebook_number);
+		self.known_since_by_notebook.insert(next_notebook_number, known_since);
+	}
+
+	fn record_known_range(
+		&mut self,
+		first_notebook_number: NotebookNumber,
+		last_notebook_number: NotebookNumber,
+		known_since: Instant,
+	) {
+		if first_notebook_number > last_notebook_number {
+			return;
+		}
+		self.known_since_by_notebook.entry(first_notebook_number).or_insert(known_since);
+	}
+
+	fn known_since(&self, notebook_number: NotebookNumber) -> Instant {
+		self.known_since_by_notebook
+			.range(..=notebook_number)
+			.next_back()
+			.map(|(_, known_since)| *known_since)
+			.unwrap_or_else(Instant::now)
+	}
+}
+
+struct WorkerContext<B: BlockT, C: AuxStore, AC> {
 	client: Arc<C>,
-	pub notary_client_by_id: Arc<RwLock<BTreeMap<NotaryId, Arc<Client>>>>,
-	pub notary_archive_host_by_id: Arc<RwLock<BTreeMap<NotaryId, String>>>,
-	pub notaries_by_id: Arc<RwLock<BTreeMap<NotaryId, NotaryRecordT>>>,
-	pub subscriptions_by_id: Arc<RwLock<BTreeMap<NotaryId, Pin<Box<RawHeadersSubscription>>>>>,
-	tick_voting_power_sender: Arc<Mutex<TracingUnboundedSender<VotingPowerInfo>>>,
-	pub tick_voting_power_receiver: Arc<Mutex<TracingUnboundedReceiver<VotingPowerInfo>>>,
-	notebook_queue_by_id: Arc<RwLock<BTreeMap<NotaryId, Vec<PendingNotebook>>>>,
 	aux_client: ArgonAux<B, C>,
 	notebook_downloader: NotebookDownloader,
-	pub(crate) metrics: Arc<Option<ConsensusMetrics<C>>>,
-	pub pause_queue_processing: Arc<RwLock<bool>>,
+	metrics: Arc<Option<ConsensusMetrics<C>>>,
+	pause_notebook_audits: Arc<RwLock<bool>>,
 	ticker: Ticker,
-	queue_lock: Arc<Mutex<()>>,
-	_block: PhantomData<AC>,
+	tick_voting_power_sender: Arc<Mutex<TracingUnboundedSender<VotingPowerInfo>>>,
+	download_slots: Arc<Semaphore>,
+	audit_slots: Arc<Semaphore>,
 	is_solving_blocks: bool,
+	_phantom: PhantomData<AC>,
 }
 
-impl<B, C, AC> StateAnchorClient<B::Hash> for NotaryClient<B, C, AC>
-where
-	B: BlockT,
-	C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
-	AC: Clone + Codec + Send + Sync + 'static,
-{
-	type Error = Error;
-
-	fn has_block_state(&self, hash: B::Hash) -> bool {
-		self.client.has_block_state(hash)
-	}
-
-	fn parent_hash(&self, hash: &B::Hash) -> Result<Option<B::Hash>, Self::Error> {
-		match self.client.parent_hash(hash) {
-			Ok(parent_hash) => Ok(Some(parent_hash)),
-			Err(Error::BlockNotFound(_)) => Ok(None),
-			Err(error) => Err(error),
-		}
-	}
+/// Owns the per-notary connection state and tracked notebook audits so stalls stay local.
+struct NotaryWorker {
+	notary_id: NotaryId,
+	record: RwLock<Option<NotaryRecordT>>,
+	client: RwLock<Option<Arc<Client>>>,
+	archive_host: RwLock<Option<String>>,
+	subscription: Mutex<Option<Pin<Box<RawHeadersSubscription>>>>,
+	pending: Mutex<NotebookAuditState>,
+	connection_lock: Arc<Mutex<()>>,
+	processing_lock: Arc<Mutex<()>>,
+	background_task_started: AtomicBool,
 }
 
-impl<B, C, AC> NotaryClient<B, C, AC>
-where
-	B: BlockT,
-	C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
-	AC: Clone + Codec + Send + Sync + 'static,
-{
-	pub fn new(
-		client: Arc<C>,
-		aux_client: ArgonAux<B, C>,
-		notebook_downloader: NotebookDownloader,
-		metrics: Arc<Option<ConsensusMetrics<C>>>,
-		ticker: Ticker,
-		is_solving_blocks: bool,
-	) -> Self {
-		let (tick_voting_power_sender, tick_voting_power_receiver) =
-			tracing_unbounded("node::consensus::notebook_tick_stream", 100);
-
+impl NotaryWorker {
+	fn new(notary_id: NotaryId) -> Self {
 		Self {
-			client,
-			subscriptions_by_id: Default::default(),
-			notary_client_by_id: Default::default(),
-			notary_archive_host_by_id: Default::default(),
-			notaries_by_id: Default::default(),
-			notebook_queue_by_id: Default::default(),
-			tick_voting_power_sender: Arc::new(Mutex::new(tick_voting_power_sender)),
-			tick_voting_power_receiver: Arc::new(Mutex::new(tick_voting_power_receiver)),
-			pause_queue_processing: Default::default(),
-			aux_client,
-			notebook_downloader,
-			metrics,
-			ticker,
-			queue_lock: Arc::new(Mutex::new(())),
-			is_solving_blocks,
-			_block: PhantomData,
+			notary_id,
+			record: Default::default(),
+			client: Default::default(),
+			archive_host: Default::default(),
+			subscription: Default::default(),
+			pending: Default::default(),
+			connection_lock: Arc::new(Mutex::new(())),
+			processing_lock: Arc::new(Mutex::new(())),
+			background_task_started: AtomicBool::new(false),
 		}
 	}
 
-	pub async fn update_notaries(&self, block_hash: &B::Hash) -> Result<(), Error> {
-		let Some(block_hash) =
-			resolve_client_stateful_hash::<B, _, AC>(self.client.as_ref(), *block_hash)?
-		else {
-			return Ok(());
-		};
-		let notaries = self.client.notaries(block_hash)?;
-		let mut reconnect_ids = BTreeSet::new();
+	async fn update_record(&self, record: NotaryRecordT) -> bool {
+		let mut current = self.record.write().await;
+		let previous_host = current.as_ref().and_then(|record| record.meta.hosts.first()).cloned();
+		let next_host = record.meta.hosts.first().cloned();
+		let host_changed = previous_host.is_some() && previous_host != next_host;
+		*current = Some(record);
+		host_changed
+	}
 
-		{
-			let next_notaries_by_id =
-				notaries.iter().map(|n| (n.notary_id, n.clone())).collect::<BTreeMap<_, _>>();
-			let mut notaries_by_id = self.notaries_by_id.write().await;
-			if next_notaries_by_id != *notaries_by_id {
-				for notary in &notaries {
-					if let Some(existing) = notaries_by_id.get(&notary.notary_id) {
-						if existing.meta.hosts[0] != notary.meta.hosts[0] {
-							reconnect_ids.insert(notary.notary_id);
-						}
-					}
-				}
-				*notaries_by_id = next_notaries_by_id.clone();
+	async fn clear_record(&self) {
+		self.record.write().await.take();
+	}
 
-				let existing_notary_ids =
-					self.notary_client_by_id.read().await.keys().copied().collect::<Vec<_>>();
-				for id in existing_notary_ids {
-					if let Some(entry) = notaries_by_id.get(&id) {
-						if Self::should_connect_to_notary(entry) {
-							continue;
-						}
-					}
-					self.disconnect(&id, None).await;
-				}
+	async fn host(&self) -> Result<String, Error> {
+		let record = self.record.read().await;
+		let record = record
+			.as_ref()
+			.ok_or_else(|| Error::NotaryError("No rpc endpoints found for notary".to_string()))?;
+		let host =
+			record.meta.hosts.first().ok_or_else(|| {
+				Error::NotaryError("No rpc endpoint found for notary".to_string())
+			})?;
+		host.clone().try_into().map_err(|e| {
+			Error::NotaryError(format!(
+				"Could not convert host to string for notary {} - {e:?}",
+				self.notary_id
+			))
+		})
+	}
+
+	async fn prefetch_headers<B, C, AC>(&self, worker_context: &WorkerContext<B, C, AC>) -> bool
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let targets = self.pending.lock().await.prefetch_targets(HEADER_PREFETCH_WINDOW);
+		let mut prefetched = false;
+		for notebook_number in targets {
+			match self.download_header(worker_context, notebook_number, None).await {
+				Ok(header_bytes) => {
+					self.pending.lock().await.cache_header(notebook_number, header_bytes);
+					prefetched = true;
+				},
+				Err(error) => {
+					trace!(
+						"Unable to prefetch notebook header for notary {} notebook {} - {error:?}",
+						self.notary_id, notebook_number,
+					);
+				},
 			}
 		}
+		prefetched
+	}
 
-		for notary in notaries {
-			let notary_id = notary.notary_id;
-			match notary.state {
-				NotaryState::Locked { .. } => {
-					// don't reconnect to a locked notary
-					continue;
-				},
-				NotaryState::Reactivated { reprocess_notebook_number } => {
-					if let Some(queue) = self.notebook_queue_by_id.write().await.get_mut(&notary_id)
-					{
-						for (n, body, _) in queue.iter_mut() {
-							if *n == reprocess_notebook_number {
-								body.take();
-								break;
-							}
-						}
-					}
-					self.aux_client.reprocess_notebook(notary_id, reprocess_notebook_number)?;
-				},
-				_ => {},
-			}
+	async fn clear_subscription(&self) {
+		self.subscription.lock().await.take();
+	}
 
-			// don't connect if exceeded queue depth
-			if self.queue_depth(notary_id).await > MAX_QUEUE_DEPTH {
-				continue;
-			}
+	async fn clear_connection(&self) {
+		let _connection_guard = self.connection_lock.lock().await;
+		self.client.write().await.take();
+		self.clear_subscription().await;
+	}
 
-			let is_connected =
-				self.has_client(notary_id).await && self.has_subscription(notary_id).await;
+	async fn has_client(&self) -> bool {
+		self.client.read().await.is_some()
+	}
 
-			if !is_connected || reconnect_ids.contains(&notary_id) {
-				info!("Connecting to notary id={notary_id}");
-				if let Err(e) = self.connect_to_notary(notary_id).await {
-					self.disconnect(
-						&notary_id,
-						Some(format!("Notary {notary_id} sync failed. {e:?}")),
-					)
-					.await;
-					continue;
-				}
+	async fn has_subscription(&self) -> bool {
+		self.subscription.lock().await.is_some()
+	}
 
-				if let Err(e) = self.subscribe_to_notebooks(notary_id).await {
-					self.disconnect(
-						&notary_id,
-						Some(format!("Notary {notary_id} subscription failed. {e:?}")),
-					)
-					.await;
-				}
-			}
+	async fn ensure_connected_subscription(&self) -> Result<(), Error> {
+		let _connection_guard = self.connection_lock.lock().await;
+		let can_connect = {
+			let record = self.record.read().await;
+			let Some(record) = record.as_ref() else {
+				return Ok(());
+			};
+			!matches!(record.state, NotaryState::Locked { .. })
+		};
+		if !can_connect {
+			return Ok(());
+		}
+
+		let notary_id = self.notary_id;
+		if !self.has_client().await {
+			info!("Connecting to notary id={notary_id}");
+			self.connect().await?;
+		}
+
+		if !self.has_subscription().await {
+			self.subscribe().await?;
 		}
 
 		Ok(())
 	}
 
-	pub async fn next_subscription(
+	async fn poll_subscription<B, C, AC>(
 		&self,
-		wait_duration: Duration,
-	) -> Option<(NotaryId, NotebookNumber)> {
-		let now = Instant::now();
-		loop {
-			if let Some((notary_id, notebook_number)) = self.poll_subscriptions().await {
-				return Some((notary_id, notebook_number));
-			}
-			if now.elapsed() > wait_duration {
-				return None;
-			}
-			// yield thread
-			tokio::task::yield_now().await;
+		worker_context: &WorkerContext<B, C, AC>,
+	) -> Option<NotebookNumber>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let next = {
+			let mut subscription = self.subscription.lock().await;
+			let subscription = subscription.as_mut()?;
+			subscription.as_mut().poll_next(&mut Context::from_waker(noop_waker_ref()))
+		};
+
+		match next {
+			Poll::Ready(Some(Ok(download_info))) => {
+				if let Some(metrics) = worker_context.metrics.as_ref() {
+					metrics.notebook_notification_received(
+						self.notary_id,
+						download_info.tick,
+						&worker_context.ticker,
+					);
+				}
+				trace!(
+					"Tracking notebook {} for notary {}",
+					download_info.notebook_number, self.notary_id
+				);
+				self.pending
+					.lock()
+					.await
+					.track_notebook(download_info.notebook_number, None, None);
+				Some(download_info.notebook_number)
+			},
+			Poll::Ready(Some(Err(error))) => {
+				self.clear_connection().await;
+				info!(
+					"Notary client disconnected from notary #{} (or could not connect). Reason? {:?}",
+					self.notary_id,
+					Some(error.to_string())
+				);
+				None
+			},
+			Poll::Ready(None) => {
+				self.clear_connection().await;
+				info!(
+					"Notary client disconnected from notary #{} (or could not connect). Reason? {:?}",
+					self.notary_id, None::<String>
+				);
+				None
+			},
+			Poll::Pending => None,
 		}
 	}
 
-	pub async fn poll_subscriptions(&self) -> Option<(NotaryId, NotebookNumber)> {
-		let mut subscription_ids =
-			self.subscriptions_by_id.read().await.keys().copied().collect::<Vec<_>>();
+	async fn run_background_pass<B, C, AC>(
+		self: &Arc<Self>,
+		worker_context: &WorkerContext<B, C, AC>,
+	) -> Result<bool, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if *worker_context.pause_notebook_audits.read().await {
+			self.clear_subscription().await;
+			return Ok(false);
+		}
+		self.ensure_connected_subscription().await?;
+		let saw_subscription = self.poll_subscription(worker_context).await.is_some();
+		let has_more_work = self.process_background_work(worker_context).await;
+		Ok(saw_subscription || has_more_work)
+	}
 
-		// If there are no subscriptions, return early
-		if subscription_ids.is_empty() {
-			return None;
+	fn start_background_task<B, C, AC>(
+		self: &Arc<Self>,
+		worker_context: Arc<WorkerContext<B, C, AC>>,
+		spawn_handle: Option<sc_service::SpawnTaskHandle>,
+		background_idle_delay: Duration,
+	) where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if self.background_task_started.swap(true, Ordering::AcqRel) {
+			return;
+		}
+		let Some(spawn_handle) = spawn_handle else {
+			self.background_task_started.store(false, Ordering::Release);
+			return;
+		};
+		let worker = Arc::clone(self);
+		let idle_delay = background_idle_delay;
+
+		spawn_handle.spawn("notary_worker_task", "notary_worker", async move {
+			let mut delay = idle_delay;
+			loop {
+				time::sleep(delay).await;
+				delay = match worker.run_background_pass(worker_context.as_ref()).await {
+					Ok(true) => Duration::from_millis(20),
+					Ok(false) => idle_delay,
+					Err(error) => {
+						warn!(
+							"Error driving notary {} in background task: {error:?}",
+							worker.notary_id,
+						);
+						worker.clear_connection().await;
+						idle_delay
+					},
+				};
+			}
+		});
+	}
+
+	async fn connect(&self) -> Result<(), Error> {
+		let client = self.get_or_connect_client().await?;
+		let notebook_meta = client.metadata().await.map_err(|error| {
+			Error::NotaryError(format!("Could not get metadata from notary - {error:?}"))
+		})?;
+		let archive_host = client.get_archive_base_url().await.map_err(|error| {
+			Error::NotaryError(format!("Could not get archive host from notary - {error:?}"))
+		})?;
+		*self.archive_host.write().await = Some(archive_host);
+		if notebook_meta.last_closed_notebook_number > 0 {
+			trace!(
+				"Tracking latest notebook {} for notary {}",
+				notebook_meta.last_closed_notebook_number, self.notary_id
+			);
+			self.pending.lock().await.track_notebook(
+				notebook_meta.last_closed_notebook_number,
+				None,
+				None,
+			);
+		}
+		Ok(())
+	}
+
+	async fn subscribe(&self) -> Result<(), Error> {
+		let client = self.get_or_connect_client().await?;
+		let stream: RawHeadersSubscription = client.subscribe_headers().await.map_err(|error| {
+			Error::NotaryError(format!("Could not subscribe to notebooks from notary - {error:?}"))
+		})?;
+		self.subscription.lock().await.replace(Box::pin(stream));
+		info!("Subscribed to notary id={}", self.notary_id);
+		Ok(())
+	}
+
+	async fn next_for_processing<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		finalized_notebook_number: NotebookNumber,
+	) -> Option<(NotebookNumber, SignedHeaderBytes, Instant)>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let NotebookAuditSelection { target, finalized_notebooks_trimmed, tracked_range } =
+			self.pending.lock().await.select_next_audit(finalized_notebook_number);
+
+		if tracing::enabled!(tracing::Level::TRACE) {
+			tracing::trace!(
+				?finalized_notebooks_trimmed,
+				notary_id = self.notary_id,
+				"Selecting notebook audit target for notary. Range: {:?}",
+				tracked_range,
+			);
 		}
 
-		// Shuffle the subscriptions to randomize the polling order
-		subscription_ids.shuffle(&mut rand::rng());
-
-		// Poll each subscription in the randomized order
-		for notary_id in subscription_ids {
-			let next = {
-				let mut subscriptions = self.subscriptions_by_id.write().await;
-				if let Some(sub) = subscriptions.get_mut(&notary_id) {
-					sub.as_mut().poll_next(&mut Context::from_waker(noop_waker_ref()))
-				} else {
-					continue;
-				}
-			};
-
-			match next {
-				Poll::Ready(Some(Ok(download_info))) => {
-					let notebook_number = download_info.notebook_number;
-					if let Some(metrics) = self.metrics.as_ref() {
-						metrics.notebook_notification_received(
-							notary_id,
-							download_info.tick,
-							&self.ticker,
-						);
-					}
-					if let Ok(did_overflow) =
-						self.enqueue_notebook(notary_id, notebook_number, None, None).await
-					{
-						if did_overflow {
-							info!("Overflowed queue for notary {notary_id}");
-							self.unsubscribe_if_overflowed(notary_id).await;
-						}
-					}
-					return Some((notary_id, notebook_number));
-				},
-				Poll::Ready(Some(Err(e))) => self.disconnect(&notary_id, Some(e.to_string())).await,
-				Poll::Ready(None) => self.disconnect(&notary_id, None).await, // Subscription ended
-				_ => {},
+		let NotebookAuditTarget { notebook_number, mut header_bytes, known_since } = target?;
+		if header_bytes.is_none() {
+			header_bytes = self.download_header(worker_context, notebook_number, None).await.ok();
+			if let Some(header_bytes) = header_bytes.as_ref() {
+				self.pending.lock().await.cache_header(notebook_number, header_bytes.clone());
 			}
+		}
+		if let Some(header_bytes) = header_bytes {
+			return Some((notebook_number, header_bytes, known_since));
 		}
 		None
 	}
 
-	pub async fn process_queues(
+	async fn process_for_hashes<B, C, AC>(
 		self: &Arc<Self>,
-		importing_with_parent_hash: Option<B::Hash>,
-	) -> Result<bool, Error> {
-		// Only respect pause flag when running under normal sync.
-		// When importing a specific block (e.g. during verification), always allow processing.
-		if *self.pause_queue_processing.read().await && importing_with_parent_hash.is_none() {
+		worker_context: &WorkerContext<B, C, AC>,
+		best_hash: B::Hash,
+		finalized_hash: B::Hash,
+	) -> Result<bool, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if self.pending.lock().await.len() == 0 {
 			return Ok(false);
 		}
-		let Some(_lock) = self.queue_lock.try_lock().ok() else {
+		let Some(_processing_guard) = self.processing_lock.clone().try_lock_owned().ok() else {
 			return Ok(true);
 		};
-		let is_import_context = importing_with_parent_hash.is_some();
-		let block_hash = importing_with_parent_hash.unwrap_or(self.client.best_hash());
-		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
-			return Ok(is_import_context);
-		};
-		self.process_queues_at_hash(best_hash, finalized_hash).await
-	}
-
-	pub async fn process_queues_at(self: &Arc<Self>, block_hash: B::Hash) -> Result<bool, Error> {
-		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
-			return Ok(true);
-		};
-		self.process_queues_at_hash(best_hash, finalized_hash).await
-	}
-
-	async fn process_selected_queues_at(
-		self: &Arc<Self>,
-		block_hash: B::Hash,
-		notary_ids: &BTreeSet<NotaryId>,
-	) -> Result<bool, Error> {
-		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
-			return Ok(true);
-		};
-		self.process_selected_queues_at_hash(best_hash, finalized_hash, notary_ids)
-			.await
-	}
-
-	fn resolve_processing_hashes(
-		&self,
-		block_hash: B::Hash,
-	) -> Result<Option<ProcessingHashes<B::Hash>>, Error> {
-		let Some(best_hash) =
-			resolve_client_stateful_hash::<B, _, AC>(self.client.as_ref(), block_hash)?
+		let finalized_notebook_number =
+			Self::latest_notebook_in_runtime(worker_context, finalized_hash, self.notary_id);
+		let Some((notebook_number, raw_header, known_since)) =
+			self.next_for_processing(worker_context, finalized_notebook_number).await
 		else {
-			return Ok(None);
+			return Ok(false);
+		};
+
+		let has_more_work = match self
+			.process_notebook(
+				worker_context,
+				notebook_number,
+				finalized_notebook_number,
+				&best_hash,
+				raw_header.clone(),
+				known_since,
+			)
+			.await
+		{
+			Ok(()) => {
+				self.pending.lock().await.mark_processed(notebook_number);
+				let has_more_work = self.pending.lock().await.len() > 0;
+				trace!(
+					"Processed notebook {notebook_number} for notary {}. More work? {has_more_work}",
+					self.notary_id,
+				);
+				has_more_work
+			},
+			Err(error) => {
+				if matches!(
+					error,
+					Error::MissingNotebooksError(_) |
+						Error::NotebookAuditBeforeTick(_) |
+						Error::NotaryAuditDeferred(_)
+				) {
+					trace!("Will retry notebook audit for notary {} - {error:?}", self.notary_id,);
+					tokio::time::sleep(Duration::from_secs(1)).await;
+					true
+				} else {
+					self.pending.lock().await.mark_processed(notebook_number);
+					return Err(error);
+				}
+			},
+		};
+		let prefetched = self.prefetch_headers(worker_context).await;
+		Ok(has_more_work || prefetched)
+	}
+
+	async fn process_background_work<B, C, AC>(
+		self: &Arc<Self>,
+		worker_context: &WorkerContext<B, C, AC>,
+	) -> bool
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if *worker_context.pause_notebook_audits.read().await {
+			return false;
+		}
+		let Some(best_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			worker_context.client.as_ref(),
+			worker_context.client.best_hash(),
+		)
+		.unwrap_or_else(|error| {
+			warn!(
+				"Could not resolve stateful best hash for notary {} background processing - {error:?}",
+				self.notary_id,
+			);
+			None
+		}) else {
+			return false;
 		};
 		let Some(finalized_hash) = resolve_client_stateful_hash::<B, _, AC>(
-			self.client.as_ref(),
-			self.client.finalized_hash(),
-		)?
-		else {
-			return Ok(None);
-		};
-		Ok(Some((best_hash, finalized_hash)))
-	}
-
-	async fn process_queues_at_hash(
-		self: &Arc<Self>,
-		best_hash: B::Hash,
-		finalized_hash: B::Hash,
-	) -> Result<bool, Error> {
-		let notary_ids =
-			self.notebook_queue_by_id.read().await.keys().copied().collect::<BTreeSet<_>>();
-		let has_more_work = self
-			.process_selected_queues_at_hash(best_hash, finalized_hash, &notary_ids)
-			.await?;
-		self.log_queue_depth().await;
-		Ok(has_more_work)
-	}
-
-	async fn process_selected_queues_at_hash(
-		self: &Arc<Self>,
-		best_hash: B::Hash,
-		finalized_hash: B::Hash,
-		notary_ids: &BTreeSet<NotaryId>,
-	) -> Result<bool, Error> {
-		let queued_notaries = self
-			.notebook_queue_by_id
-			.read()
-			.await
-			.keys()
-			.copied()
-			.filter(|notary_id| notary_ids.contains(notary_id))
-			.collect::<Vec<_>>();
-
-		let handles = queued_notaries.into_iter().map(|notary_id| {
-			let finalized_notebook_number =
-				self.latest_notebook_in_runtime(finalized_hash, notary_id);
-
-			let self_clone: Arc<Self> = Arc::clone(self);
-			tokio::spawn(async move {
-				let Some((notebook_number, raw_header, time)) =
-					self_clone.get_next(notary_id, finalized_notebook_number).await
-				else {
-					return Ok::<_, Error>(false);
-				};
-				match self_clone
-					.process_notebook(
-						notary_id,
-						notebook_number,
-						finalized_notebook_number,
-						&best_hash,
-						raw_header.clone(),
-						time,
-					)
-					.await
-				{
-					Ok(()) => {
-						let has_more_work = self_clone.queue_depth(notary_id).await > 0;
-						trace!(
-							"Processed notebook {notebook_number} for notary {notary_id}. More work? {has_more_work}"
-						);
-						Ok::<_, Error>(has_more_work)
-					},
-					Err(e) => {
-						if matches!(
-							e,
-							Error::MissingNotebooksError(_) |
-								Error::NotebookAuditBeforeTick(_) |
-								Error::NotaryAuditDeferred(_)
-						) {
-							trace!("In queue, re-queuing notebook for notary {notary_id} - {e:?}");
-							self_clone
-								.enqueue_notebook(
-									notary_id,
-									notebook_number,
-									Some(raw_header),
-									Some(time),
-								)
-								.await?;
-							// wait for continue processing
-							tokio::time::sleep(Duration::from_secs(1)).await;
-							return Ok::<_, Error>(true);
-						}
-						Err(e)
-					},
-				}
-			})
-		});
-		let results = join_all(handles).await;
-
-		let mut has_more_work = false;
-		for result in results {
-			match result {
-				Ok(inner_result) => match inner_result {
-					Ok(x) => has_more_work = has_more_work || x,
-					Err(err) => warn!("Error processing notebooks for a notary {err:?}"),
-				},
-				Err(join_error) => {
-					warn!("Error while processing notary queue - {join_error:?}");
-				},
-			}
-		}
-		Ok(has_more_work)
-	}
-
-	async fn log_queue_depth(&self) {
-		if let Some(metrics) = self.metrics.as_ref() {
-			let notary_queue = self.notebook_queue_by_id.read().await;
-			for (notary_id, queue) in notary_queue.iter() {
-				metrics.record_queue_depth(*notary_id, queue.len() as u64);
-			}
-		}
-	}
-
-	async fn queue_depth(&self, notary_id: NotaryId) -> usize {
-		let notary_queue = self.notebook_queue_by_id.read().await;
-		notary_queue.get(&notary_id).map_or(0usize, |q| q.len())
-	}
-
-	async fn get_next(
-		&self,
-		notary_id: NotaryId,
-		finalized_notebook_number: NotebookNumber,
-	) -> Option<(NotebookNumber, SignedHeaderBytes, Instant)> {
-		let (notebook_number, mut bytes, queue_time) = {
-			let mut queues = self.notebook_queue_by_id.write().await;
-			let mut next = None;
-			let mut finalized_notebooks_trimmed = 0u32;
-			let mut queue_range: Range<NotebookNumber> = 0..0;
-			while let Some(queue) = queues.get_mut(&notary_id) {
-				if queue.is_empty() {
-					return None;
-				}
-				queue_range = Range { start: queue[0].0, end: queue[queue.len() - 1].0 };
-
-				let (notebook_number, bytes, queue_time) = queue.remove(0);
-				if notebook_number > finalized_notebook_number {
-					next = Some((notebook_number, bytes, queue_time));
-					break;
-				} else {
-					finalized_notebooks_trimmed += 1;
-				}
-			}
-
-			if tracing::enabled!(tracing::Level::TRACE) {
-				tracing::trace!(
-					?finalized_notebooks_trimmed,
-					notary_id,
-					"Dequeuing notebook for notary. Queue: {:?}",
-					queue_range,
-				);
-			}
-			next?
-		};
-
-		if bytes.is_none() {
-			bytes = self.download_header(notary_id, notebook_number, None).await.ok();
-		}
-		if let Some(bytes) = bytes {
-			Some((notebook_number, bytes, queue_time))
-		} else {
-			self.enqueue_notebook(notary_id, notebook_number, None, Some(queue_time))
-				.await
-				.ok();
-			None
-		}
-	}
-
-	/// Enqueue the notebook and return true if the queue overflowed
-	async fn enqueue_notebook(
-		&self,
-		notary_id: NotaryId,
-		notebook_number: NotebookNumber,
-		header_bytes: Option<SignedHeaderBytes>,
-		enqueue_time: Option<Instant>,
-	) -> Result<bool, Error> {
-		let mut notebook_queue_by_id = self.notebook_queue_by_id.write().await;
-
-		let queue = notebook_queue_by_id.entry(notary_id).or_insert_with(Vec::new);
-		let entry = queue.iter().position(|(n, _, _)| *n == notebook_number);
-		if let Some(index) = entry {
-			// only overwrite if missing
-			if queue[index].1.is_none() {
-				trace!(
-					"Overwriting notebook {} header in queue for notary {} with header? {}",
-					notebook_number,
-					notary_id,
-					header_bytes.is_some()
-				);
-				queue[index].1 = header_bytes;
-			}
-			Ok(false)
-		} else {
-			trace!(
-				"Queuing notebook {} for notary {} with header? {}",
-				notebook_number,
-				notary_id,
-				header_bytes.is_some()
+			worker_context.client.as_ref(),
+			worker_context.client.finalized_hash(),
+		)
+		.unwrap_or_else(|error| {
+			warn!(
+				"Could not resolve stateful finalized hash for notary {} background processing - {error:?}",
+				self.notary_id,
 			);
-			// look from back of list since we're normally appending
-			let pos = queue
-				.iter()
-				.rposition(|(n, _, _)| *n < notebook_number)
-				.map(|p| p + 1)
-				.unwrap_or(0);
-			queue.insert(
-				pos,
-				(notebook_number, header_bytes, enqueue_time.unwrap_or(Instant::now())),
-			);
-
-			Ok(queue.len() > MAX_QUEUE_DEPTH)
-		}
-	}
-
-	async fn unsubscribe_if_overflowed(&self, notary_id: NotaryId) {
-		if self.queue_depth(notary_id).await <= MAX_QUEUE_DEPTH {
-			return;
-		}
-
-		self.subscriptions_by_id.write().await.remove(&notary_id);
-	}
-
-	async fn download_header(
-		&self,
-		notary_id: NotaryId,
-		notebook_number: NotebookNumber,
-		mut download_url: Option<String>,
-	) -> Result<SignedHeaderBytes, Error> {
-		let expected_archive_origin =
-			self.notary_archive_host_by_id.read().await.get(&notary_id).cloned();
-		if download_url.is_none() {
-			if let Some(archive_host) = expected_archive_origin.as_ref() {
-				download_url = Some(get_header_url(archive_host, notary_id, notebook_number));
-			}
-		}
-		self.notebook_downloader
-			.get_header(notary_id, notebook_number, download_url, expected_archive_origin)
-			.await
-			.map_err(|e| {
-				Error::NotaryError(format!(
-					"Could not get notary {notary_id}, notebook {notebook_number} from notebook downloader - {e:?}"
-				))
-			})
-	}
-
-	async fn download_notebook(
-		&self,
-		notary_id: NotaryId,
-		notebook_number: NotebookNumber,
-	) -> Result<NotebookBytes, Error> {
-		let expected_archive_origin =
-			self.notary_archive_host_by_id.read().await.get(&notary_id).cloned();
-		let download_url = if let Some(archive_host) = expected_archive_origin.as_ref() {
-			Some(get_notebook_url(archive_host, notary_id, notebook_number))
-		} else if self.notebook_downloader.is_strict() {
 			None
-		} else {
-			let client = self.get_or_connect_to_client(notary_id).await.ok();
-			if let Some(client) = client {
-				client.get_notebook_download_url(notebook_number).await.ok()
-			} else {
-				None
-			}
+		}) else {
+			return false;
 		};
-		let bytes = self
-			.notebook_downloader
-			.get_body(notary_id, notebook_number, download_url, expected_archive_origin)
-			.await
-			.map_err(|e| {
-				Error::NotaryError(format!(
-					"Could not download notebook {notebook_number} from notary {notary_id} - {e:?}"
-				))
-			})?;
-		Ok(bytes)
-	}
-
-	async fn connect_to_notary(&self, id: NotaryId) -> Result<(), Error> {
-		let client = self.get_or_connect_to_client(id).await?;
-		let notebook_meta = client.metadata().await.map_err(|e| {
-			Error::NotaryError(format!("Could not get metadata from notary - {e:?}"))
-		})?;
-		let archive_host = client.get_archive_base_url().await.map_err(|e| {
-			Error::NotaryError(format!("Could not get archive host from notary - {e:?}"))
-		})?;
-		self.notary_archive_host_by_id.write().await.insert(id, archive_host.clone());
-		if notebook_meta.last_closed_notebook_number > 0 {
-			self.enqueue_notebook(id, notebook_meta.last_closed_notebook_number, None, None)
-				.await?;
+		match self.process_for_hashes(worker_context, best_hash, finalized_hash).await {
+			Ok(has_more_work) => has_more_work,
+			Err(error) => {
+				warn!(
+					"Error processing notebooks for notary {} in background task: {error:?}",
+					self.notary_id,
+				);
+				self.pending.lock().await.len() > 0
+			},
 		}
-		Ok(())
 	}
 
-	pub async fn disconnect(&self, notary_id: &NotaryId, reason: Option<String>) {
-		info!(
-			"Notary client disconnected from notary #{notary_id} (or could not connect). Reason? {reason:?}"
-		);
-		self.notary_client_by_id.write().await.remove(notary_id);
-		self.subscriptions_by_id.write().await.remove(notary_id);
-	}
-
-	async fn subscribe_to_notebooks(&self, id: NotaryId) -> Result<(), Error> {
-		let client = self.get_or_connect_to_client(id).await?;
-		let stream: RawHeadersSubscription = client.subscribe_headers().await.map_err(|e| {
-			Error::NotaryError(format!("Could not subscribe to notebooks from notary - {e:?}"))
-		})?;
-		self.subscriptions_by_id.write().await.insert(id, Box::pin(stream));
-		Ok(())
-	}
-
-	pub async fn process_notebook(
+	async fn process_notebook<B, C, AC>(
 		&self,
-		notary_id: NotaryId,
+		worker_context: &WorkerContext<B, C, AC>,
 		notebook_number: NotebookNumber,
 		finalized_notebook_number: NotebookNumber,
 		best_hash: &B::Hash,
 		raw_header: SignedHeaderBytes,
-		enqueue_time: Instant,
-	) -> Result<(), Error> {
+		known_since: Instant,
+	) -> Result<(), Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
 		let mut best_hash = *best_hash;
 		if notebook_number <= finalized_notebook_number {
 			tracing::info!(
@@ -938,13 +1047,12 @@ where
 			return Ok(());
 		}
 
-		let mut latest_notebook_in_runtime = self.latest_notebook_in_runtime(best_hash, notary_id);
+		let mut latest_notebook_in_runtime =
+			Self::latest_notebook_in_runtime(worker_context, best_hash, notary_id);
 		if latest_notebook_in_runtime >= notebook_number {
 			let mut counter = 0;
 			while latest_notebook_in_runtime >= notebook_number {
 				counter += 1;
-				// NOTE: if this goes past 256 finalized blocks, it will hit the limit that nodes
-				// store by default
 				if counter >= 500 {
 					return Err(Error::NotaryError(format!(
 						"Could not find place to audit this notebook {notebook_number} in runtime"
@@ -958,19 +1066,20 @@ where
 					trying_block_hash = ?best_hash,
 					"Checking if we can audit at parent block",
 				);
-				let parent_hash = self.client.parent_hash(&best_hash)?;
+				let parent_hash = worker_context.client.parent_hash(&best_hash)?;
 				if parent_hash == best_hash {
 					return Err(Error::NotaryAuditDeferred(format!(
 						"Missing state while locating audit parent. Notary={notary_id}, notebook={notebook_number}, block={best_hash:?}"
 					)));
 				}
-				best_hash = parent_hash;
-				if !self.client.has_block_state(best_hash) {
+				if !worker_context.client.has_block_state(parent_hash) {
 					return Err(Error::NotaryAuditDeferred(format!(
-						"Missing state while locating audit parent. Notary={notary_id}, notebook={notebook_number}, block={best_hash:?}"
+						"Missing state while locating audit parent. Notary={notary_id}, notebook={notebook_number}, block={parent_hash:?}"
 					)));
 				}
-				latest_notebook_in_runtime = self.latest_notebook_in_runtime(best_hash, notary_id);
+				best_hash = parent_hash;
+				latest_notebook_in_runtime =
+					Self::latest_notebook_in_runtime(worker_context, best_hash, notary_id);
 			}
 			tracing::info!(
 				notary_id,
@@ -981,17 +1090,22 @@ where
 			);
 		}
 
-		let notebook_details = self
+		let _audit_slot = worker_context.audit_slots.acquire().await.map_err(|error| {
+			Error::NotaryError(format!(
+				"Could not acquire audit processing slot for notary {notary_id} - {error:?}",
+			))
+		})?;
+
+		let notebook_details = worker_context
 			.client
 			.decode_signed_raw_notebook_header(&best_hash, raw_header.0.clone())?
-			.map_err(|e| {
+			.map_err(|error| {
 				Error::NotaryError(format!(
-					"Unable to decode notebook header in runtime. Notary={notary_id}, notebook={notebook_number} -> {e:?}"
+					"Unable to decode notebook header in runtime. Notary={notary_id}, notebook={notebook_number} -> {error:?}",
 				))
 			})?;
 
 		let tick = notebook_details.tick;
-
 		ensure!(
 			notary_id == notebook_details.notary_id,
 			Error::NotaryError("Notary ID mismatch".to_string())
@@ -1001,9 +1115,10 @@ where
 			Error::NotaryError("Notebook number mismatch".to_string())
 		);
 
-		let audit_result = self.audit_notebook(&best_hash, &notebook_details).await?;
-		let runtime_tick = self.client.current_tick(best_hash)?;
-		let voting_power = self.aux_client.store_notebook_result(
+		let audit_result =
+			self.audit_notebook(worker_context, &best_hash, &notebook_details).await?;
+		let runtime_tick = worker_context.client.current_tick(best_hash)?;
+		let voting_power = worker_context.aux_client.store_notebook_result(
 			audit_result,
 			raw_header,
 			notebook_details,
@@ -1011,22 +1126,538 @@ where
 			runtime_tick,
 		)?;
 
-		if let Some(metrics) = self.metrics.as_ref() {
-			metrics.notebook_processed(notary_id, tick, enqueue_time, &self.ticker);
+		if let Some(metrics) = worker_context.metrics.as_ref() {
+			metrics.notebook_processed(notary_id, tick, known_since, &worker_context.ticker);
 		}
 
-		if self.is_solving_blocks {
-			self.tick_voting_power_sender
+		if worker_context.is_solving_blocks {
+			worker_context
+				.tick_voting_power_sender
 				.lock()
 				.await
 				.unbounded_send(voting_power)
-				.map_err(|e| {
+				.map_err(|error| {
 					Error::NotaryError(format!(
-						"Could not send tick state to sender (notary {notary_id}, notebook {notebook_number}) - {e:?}"
+						"Could not send tick state to sender (notary {notary_id}, notebook {notebook_number}) - {error:?}",
 					))
 				})?;
 		}
 		Ok(())
+	}
+
+	async fn audit_notebook<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		best_hash: &B::Hash,
+		notebook_details: &NotaryNotebookDetails<B::Hash>,
+	) -> Result<NotebookAuditResult<NotebookVerifyError>, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
+		let tick = notebook_details.tick;
+		let notebook_number = notebook_details.notebook_number;
+		let notebook_dependencies = self
+			.get_notebook_dependencies(worker_context, notebook_number, best_hash)
+			.await?;
+		tracing::trace!(
+			notary_id,
+			notebook_number,
+			best_hash = ?best_hash,
+			tick,
+			notebook_dependencies = notebook_dependencies.len(),
+			"Attempting to audit notebook",
+		);
+
+		let full_notebook = self.download_notebook(worker_context, notebook_number).await?;
+		tracing::trace!(
+			notary_id,
+			notebook_number,
+			bytes = full_notebook.0.len(),
+			"Notebook downloaded.",
+		);
+
+		let audit_failure_reason = match worker_context.client.audit_notebook_and_get_votes(
+			*best_hash,
+			notebook_details.version,
+			notary_id,
+			notebook_number,
+			tick,
+			notebook_details.header_hash,
+			&full_notebook.0,
+			notebook_dependencies.clone(),
+			&notebook_details.blocks_with_votes,
+		)? {
+			Ok(votes) => {
+				let vote_count = votes.raw_votes.len();
+				worker_context.aux_client.store_votes(tick, votes)?;
+				tracing::info!(
+					notary_id,
+					notebook_number,
+					tick,
+					"Notebook audit successful. {vote_count} block vote(s).",
+				);
+				None
+			},
+			Err(error) => {
+				if error == NotebookVerifyError::CatchupNotebooksMissing {
+					tracing::warn!(
+						notary_id,
+						notebook_number,
+						?notebook_dependencies,
+						?best_hash,
+						"Notebook audit failed for notary. Incorrect catchup provided",
+					);
+					return Err(Error::MissingNotebooksError(format!(
+						"Possibly missing notebooks? Invalid catchup notebooks provided to audit. Notary {notary_id}, #{notebook_number}, tick {tick}.",
+					)));
+				}
+
+				if tick > worker_context.client.current_tick(*best_hash)? {
+					return Err(Error::NotebookAuditBeforeTick(format!(
+						"Notebook tick is > runtime. Notary={notary_id}, notebook={notebook_number}, tick={tick}",
+					)));
+				}
+
+				tracing::warn!(notary_id, notebook_number, tick, "Notebook audit failed ({error})",);
+				Some(error)
+			},
+		};
+
+		Ok(NotebookAuditResult {
+			notary_id,
+			tick,
+			notebook_number,
+			audit_first_failure: audit_failure_reason,
+		})
+	}
+
+	async fn get_or_connect_client(&self) -> Result<Arc<Client>, Error> {
+		if let Some(client) = self.client.read().await.clone() {
+			return Ok(client);
+		}
+		let notary_id = self.notary_id;
+		let host = self.host().await?;
+		let client = Arc::new(argon_notary_apis::create_client(&host).await.map_err(|error| {
+			Error::NotaryError(format!(
+				"Could not connect to notary {notary_id} ({host}) for audit - {error:?}",
+			))
+		})?);
+		*self.client.write().await = Some(client.clone());
+		Ok(client)
+	}
+
+	async fn download_header<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		notebook_number: NotebookNumber,
+		mut download_url: Option<String>,
+	) -> Result<SignedHeaderBytes, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
+		let _download_slot = worker_context.download_slots.acquire().await.map_err(|error| {
+			Error::NotaryError(format!(
+				"Could not acquire header download slot for notary {notary_id} - {error:?}",
+			))
+		})?;
+		let expected_archive_origin = self.archive_host.read().await.clone();
+		if download_url.is_none() {
+			if let Some(archive_host) = expected_archive_origin.as_ref() {
+				download_url = Some(get_header_url(archive_host, notary_id, notebook_number));
+			}
+		}
+		worker_context
+			.notebook_downloader
+			.get_header(notary_id, notebook_number, download_url, expected_archive_origin)
+			.await
+			.map_err(|error| {
+				Error::NotaryError(format!(
+					"Could not get notary {notary_id}, notebook {notebook_number} from notebook downloader - {error:?}",
+				))
+			})
+	}
+
+	async fn download_notebook<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		notebook_number: NotebookNumber,
+	) -> Result<NotebookBytes, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
+		let _download_slot = worker_context.download_slots.acquire().await.map_err(|error| {
+			Error::NotaryError(format!(
+				"Could not acquire notebook download slot for notary {notary_id} - {error:?}",
+			))
+		})?;
+		let expected_archive_origin = self.archive_host.read().await.clone();
+		let download_url = if let Some(archive_host) = expected_archive_origin.as_ref() {
+			Some(get_notebook_url(archive_host, notary_id, notebook_number))
+		} else if worker_context.notebook_downloader.is_strict() {
+			None
+		} else {
+			let client = self.get_or_connect_client().await.ok();
+			if let Some(client) = client {
+				client.get_notebook_download_url(notebook_number).await.ok()
+			} else {
+				None
+			}
+		};
+		worker_context
+			.notebook_downloader
+			.get_body(notary_id, notebook_number, download_url, expected_archive_origin)
+			.await
+			.map_err(|error| {
+				Error::NotaryError(format!(
+					"Could not download notebook {notebook_number} from notary {notary_id} - {error:?}",
+				))
+			})
+	}
+
+	async fn get_notebook_dependencies<B, C, AC>(
+		&self,
+		worker_context: &WorkerContext<B, C, AC>,
+		notebook_number: NotebookNumber,
+		best_hash: &B::Hash,
+	) -> Result<Vec<NotaryNotebookAuditSummary>, Error>
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		let notary_id = self.notary_id;
+		let mut notebook_dependencies = vec![];
+		let mut missing_notebooks = vec![];
+		let latest_block_notebook =
+			Self::latest_notebook_in_runtime(worker_context, *best_hash, notary_id);
+
+		if latest_block_notebook < notebook_number - 1 {
+			let notary_notebooks = worker_context.aux_client.get_audit_summaries(notary_id)?.get();
+			for notebook_number_needed in (latest_block_notebook + 1)..notebook_number {
+				if let Some(summary) =
+					notary_notebooks.iter().find(|s| s.notebook_number == notebook_number_needed)
+				{
+					notebook_dependencies.push(summary.clone());
+				} else {
+					missing_notebooks.push(notebook_number_needed);
+				}
+			}
+		}
+
+		if !missing_notebooks.is_empty() {
+			let first_missing = missing_notebooks[0];
+			let last_missing = missing_notebooks[missing_notebooks.len() - 1];
+			trace!(
+				"Tracking notebook range {}..{} for notary {}",
+				first_missing, last_missing, self.notary_id,
+			);
+			self.pending.lock().await.track_range(first_missing, last_missing);
+			let notebook_range = first_missing..last_missing;
+			info!(
+				"Missing notebooks for notary {notary_id}. Tracking dependency catchup range: {notebook_range:?}",
+			);
+			return Err(Error::MissingNotebooksError(format!(
+				"Missing notebooks #{notebook_range:?} to audit {notebook_number} for notary {notary_id}"
+			)));
+		}
+
+		Ok(notebook_dependencies)
+	}
+
+	fn latest_notebook_in_runtime<B, C, AC>(
+		worker_context: &WorkerContext<B, C, AC>,
+		block_hash: B::Hash,
+		notary_id: NotaryId,
+	) -> NotebookNumber
+	where
+		B: BlockT,
+		C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+		AC: Clone + Codec + Send + Sync + 'static,
+	{
+		if let Ok(latest_notebooks_in_runtime) =
+			worker_context.client.latest_notebook_by_notary(block_hash)
+		{
+			if let Some((latest_notebook, _)) = latest_notebooks_in_runtime.get(&notary_id) {
+				return *latest_notebook;
+			}
+		}
+		0
+	}
+}
+
+pub struct NotaryClient<B: BlockT, C: AuxStore, AC> {
+	worker_context: Arc<WorkerContext<B, C, AC>>,
+	workers_by_id: WorkersById,
+	pub(crate) metrics: Arc<Option<ConsensusMetrics<C>>>,
+	pub tick_voting_power_receiver: Arc<Mutex<TracingUnboundedReceiver<VotingPowerInfo>>>,
+	pub pause_notebook_audits: Arc<RwLock<bool>>,
+	background_idle_delay: Duration,
+	spawn_handle: Option<sc_service::SpawnTaskHandle>,
+}
+
+impl<B, C, AC> NotaryClient<B, C, AC>
+where
+	B: BlockT,
+	C: NotaryApisExt<B, AC> + AuxStore + Send + Sync + 'static,
+	AC: Clone + Codec + Send + Sync + 'static,
+{
+	#[allow(clippy::too_many_arguments)]
+	pub fn new(
+		client: Arc<C>,
+		aux_client: ArgonAux<B, C>,
+		notebook_downloader: NotebookDownloader,
+		metrics: Arc<Option<ConsensusMetrics<C>>>,
+		ticker: Ticker,
+		spawn_handle: Option<sc_service::SpawnTaskHandle>,
+		background_idle_delay: Duration,
+		is_solving_blocks: bool,
+	) -> Self {
+		let (tick_voting_power_sender, tick_voting_power_receiver) =
+			tracing_unbounded("node::consensus::notebook_tick_stream", 100);
+		let pause_notebook_audits = Arc::new(RwLock::new(false));
+		let worker_context = Arc::new(WorkerContext {
+			client,
+			aux_client,
+			notebook_downloader,
+			metrics: metrics.clone(),
+			pause_notebook_audits: pause_notebook_audits.clone(),
+			ticker,
+			tick_voting_power_sender: Arc::new(Mutex::new(tick_voting_power_sender)),
+			download_slots: Arc::new(Semaphore::new(MAX_PARALLEL_NOTARY_DOWNLOADS)),
+			audit_slots: Arc::new(Semaphore::new(MAX_PARALLEL_NOTARY_AUDITS)),
+			is_solving_blocks,
+			_phantom: PhantomData,
+		});
+
+		Self {
+			worker_context,
+			workers_by_id: Default::default(),
+			metrics,
+			tick_voting_power_receiver: Arc::new(Mutex::new(tick_voting_power_receiver)),
+			pause_notebook_audits,
+			background_idle_delay,
+			spawn_handle,
+		}
+	}
+
+	async fn worker(&self, notary_id: NotaryId) -> Option<WorkerHandle> {
+		self.workers_by_id.read().await.get(&notary_id).cloned()
+	}
+
+	async fn ensure_worker(&self, notary_id: NotaryId) -> WorkerHandle {
+		if let Some(worker) = self.worker(notary_id).await {
+			return worker;
+		}
+		let mut workers = self.workers_by_id.write().await;
+		workers
+			.entry(notary_id)
+			.or_insert_with(|| Arc::new(NotaryWorker::new(notary_id)))
+			.clone()
+	}
+
+	pub async fn update_notaries(self: &Arc<Self>, block_hash: &B::Hash) -> Result<(), Error> {
+		let Some(block_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			self.worker_context.client.as_ref(),
+			*block_hash,
+		)?
+		else {
+			return Ok(());
+		};
+		let notaries = self.worker_context.client.notaries(block_hash)?;
+		let active_ids = notaries.iter().map(|notary| notary.notary_id).collect::<BTreeSet<_>>();
+		let existing_workers = self
+			.workers_by_id
+			.read()
+			.await
+			.iter()
+			.map(|(notary_id, worker)| (*notary_id, worker.clone()))
+			.collect::<Vec<_>>();
+
+		for (notary_id, worker) in existing_workers {
+			if active_ids.contains(&notary_id) {
+				continue;
+			}
+			worker.clear_record().await;
+			worker.clear_connection().await;
+		}
+
+		for notary in notaries {
+			let notary_id = notary.notary_id;
+			let worker = self.ensure_worker(notary_id).await;
+			worker.start_background_task(
+				Arc::clone(&self.worker_context),
+				self.spawn_handle.clone(),
+				self.background_idle_delay,
+			);
+			let host_changed = worker.update_record(notary.clone()).await;
+			if host_changed {
+				worker.clear_connection().await;
+			}
+
+			match notary.state {
+				NotaryState::Locked { .. } => {
+					worker.clear_connection().await;
+					continue;
+				},
+				NotaryState::Reactivated { reprocess_notebook_number } => {
+					worker.pending.lock().await.rewind_to(reprocess_notebook_number);
+					self.worker_context
+						.aux_client
+						.reprocess_notebook(notary_id, reprocess_notebook_number)?;
+				},
+				_ => {},
+			}
+
+			if *self.pause_notebook_audits.read().await {
+				worker.clear_subscription().await;
+				continue;
+			}
+
+			let is_connected = worker.has_client().await && worker.has_subscription().await;
+
+			if !is_connected || host_changed {
+				if let Err(e) = worker.ensure_connected_subscription().await {
+					self.disconnect(
+						&notary_id,
+						Some(format!("Notary {notary_id} sync failed. {e:?}")),
+					)
+					.await;
+				}
+			}
+		}
+		Ok(())
+	}
+
+	pub async fn process_background_audits(self: &Arc<Self>) -> Result<bool, Error> {
+		if *self.pause_notebook_audits.read().await {
+			return Ok(false);
+		}
+		let Some((best_hash, finalized_hash)) =
+			self.resolve_processing_hashes(self.worker_context.client.best_hash())?
+		else {
+			return Ok(false);
+		};
+		self.process_audits_at_hash(best_hash, finalized_hash).await
+	}
+
+	pub async fn process_audits_at(self: &Arc<Self>, block_hash: B::Hash) -> Result<bool, Error> {
+		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
+			return Ok(true);
+		};
+		self.process_audits_at_hash(best_hash, finalized_hash).await
+	}
+
+	async fn process_selected_audits_at(
+		self: &Arc<Self>,
+		block_hash: B::Hash,
+		notary_ids: &BTreeSet<NotaryId>,
+	) -> Result<bool, Error> {
+		let Some((best_hash, finalized_hash)) = self.resolve_processing_hashes(block_hash)? else {
+			return Ok(true);
+		};
+		self.process_selected_audits_at_hash(best_hash, finalized_hash, notary_ids)
+			.await
+	}
+
+	fn resolve_processing_hashes(
+		&self,
+		block_hash: B::Hash,
+	) -> Result<Option<ProcessingHashes<B::Hash>>, Error> {
+		let Some(best_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			self.worker_context.client.as_ref(),
+			block_hash,
+		)?
+		else {
+			return Ok(None);
+		};
+		let Some(finalized_hash) = resolve_client_stateful_hash::<B, _, AC>(
+			self.worker_context.client.as_ref(),
+			self.worker_context.client.finalized_hash(),
+		)?
+		else {
+			return Ok(None);
+		};
+		Ok(Some((best_hash, finalized_hash)))
+	}
+
+	async fn process_audits_at_hash(
+		self: &Arc<Self>,
+		best_hash: B::Hash,
+		finalized_hash: B::Hash,
+	) -> Result<bool, Error> {
+		let notary_ids = self.workers_by_id.read().await.keys().copied().collect::<BTreeSet<_>>();
+		let has_more_work = self
+			.process_selected_audits_at_hash(best_hash, finalized_hash, &notary_ids)
+			.await?;
+		if let Some(metrics) = self.worker_context.metrics.as_ref() {
+			let workers = self.workers_by_id.read().await;
+			for (notary_id, worker) in workers.iter() {
+				metrics.record_queue_depth(*notary_id, worker.pending.lock().await.len() as u64);
+			}
+		}
+		Ok(has_more_work)
+	}
+
+	async fn process_selected_audits_at_hash(
+		self: &Arc<Self>,
+		best_hash: B::Hash,
+		finalized_hash: B::Hash,
+		notary_ids: &BTreeSet<NotaryId>,
+	) -> Result<bool, Error> {
+		let workers = self
+			.workers_by_id
+			.read()
+			.await
+			.iter()
+			.filter(|(notary_id, _)| notary_ids.contains(notary_id))
+			.map(|(_, worker)| worker.clone())
+			.collect::<Vec<_>>();
+		let mut has_more_work = false;
+		let mut processing = Vec::new();
+		for worker in workers {
+			if worker.pending.lock().await.len() == 0 {
+				continue;
+			}
+			let worker_context = Arc::clone(&self.worker_context);
+			processing.push(tokio::spawn(async move {
+				worker
+					.process_for_hashes(worker_context.as_ref(), best_hash, finalized_hash)
+					.await
+			}));
+		}
+		for result in join_all(processing).await {
+			match result {
+				Ok(Ok(x)) => has_more_work = has_more_work || x,
+				Ok(Err(err)) => {
+					has_more_work = true;
+					warn!("Error processing notebooks for a notary {err:?}");
+				},
+				Err(join_error) => {
+					has_more_work = true;
+					warn!("Error while processing tracked notary audits - {join_error:?}");
+				},
+			}
+		}
+		Ok(has_more_work)
+	}
+
+	pub async fn disconnect(&self, notary_id: &NotaryId, reason: Option<String>) {
+		info!(
+			"Notary client disconnected from notary #{notary_id} (or could not connect). Reason? {reason:?}"
+		);
+		let Some(worker) = self.worker(*notary_id).await else {
+			return;
+		};
+		worker.clear_connection().await;
 	}
 
 	pub(crate) async fn verify_notebook_audits(
@@ -1039,14 +1670,50 @@ where
 			NotebookAuditMode::Sync => None,
 			NotebookAuditMode::Import { max_wait } => Some(max_wait),
 		};
-		let mut missing_audits_by_notary = BTreeMap::new();
-		let notary_ids = self.get_notary_ids().await;
-		let mut needs_notary_updates = false;
-		for digest_record in &notebook_audit_results {
-			let notary_audits =
-				self.aux_client.get_notary_audit_history(digest_record.notary_id)?.get();
+		let mut missing_audits = self.collect_missing_audits(&notebook_audit_results).await?;
+		if missing_audits.by_notary.is_empty() {
+			return Ok(());
+		}
+		info!(
+			"Notebook digest has missing audits. Will attempt to catchup now. {:#?}",
+			missing_audits.by_notary
+		);
+		let wait_time = Self::missing_audit_wait_time(max_wait, missing_audits.by_notary.len());
+		let start = Instant::now();
+		let timeout_error = || {
+			Error::UnableToSyncNotary(format!(
+				"Could not process all missing audits in {} seconds",
+				wait_time.as_secs()
+			))
+		};
+		if missing_audits.needs_notary_updates {
+			let Some(remaining) = wait_time.checked_sub(start.elapsed()) else {
+				warn!("Timed out waiting for missing audits. {:#?}", missing_audits.by_notary);
+				return Err(timeout_error());
+			};
+			tokio::time::timeout(remaining, self.update_notaries(parent_hash))
+				.await
+				.map_err(|_| timeout_error())??;
+		}
+		self.wait_for_missing_audits(parent_hash, &mut missing_audits.by_notary, wait_time)
+			.await
+	}
 
+	async fn collect_missing_audits(
+		&self,
+		notebook_audit_results: &[NotebookAuditResult<NotebookVerifyError>],
+	) -> Result<MissingAuditCatchup, Error> {
+		let mut missing_audits =
+			MissingAuditCatchup { by_notary: BTreeMap::new(), needs_notary_updates: false };
+
+		for digest_record in notebook_audit_results {
+			let notary_audits = self
+				.worker_context
+				.aux_client
+				.get_notary_audit_history(digest_record.notary_id)?
+				.get();
 			let audit = notary_audits.get(&digest_record.notebook_number);
+
 			if let Some(audit) = audit {
 				if digest_record.audit_first_failure != audit.audit_first_failure {
 					return Err(Error::InvalidNotebookDigest(format!(
@@ -1057,55 +1724,63 @@ where
 						audit.audit_first_failure
 					)));
 				}
-			} else {
-				if !notary_ids.contains(&digest_record.notary_id) ||
-					!self.has_client(digest_record.notary_id).await
-				{
-					needs_notary_updates = true;
-				}
-				self.enqueue_notebook(
-					digest_record.notary_id,
-					digest_record.notebook_number,
-					None,
-					None,
-				)
-				.await?;
-				missing_audits_by_notary
-					.entry(digest_record.notary_id)
-					.or_insert_with(Vec::new)
-					.push(digest_record.notebook_number);
+				continue;
 			}
-		}
-		if missing_audits_by_notary.is_empty() {
-			return Ok(());
+
+			let has_runtime_record =
+				if let Some(worker) = self.worker(digest_record.notary_id).await {
+					worker.record.read().await.is_some()
+				} else {
+					false
+				};
+			let has_client = if let Some(worker) = self.worker(digest_record.notary_id).await {
+				worker.has_client().await
+			} else {
+				false
+			};
+			if !has_runtime_record || !has_client {
+				missing_audits.needs_notary_updates = true;
+			}
+			let worker = self.ensure_worker(digest_record.notary_id).await;
+			worker
+				.pending
+				.lock()
+				.await
+				.track_notebook(digest_record.notebook_number, None, None);
+			missing_audits
+				.by_notary
+				.entry(digest_record.notary_id)
+				.or_default()
+				.push(digest_record.notebook_number);
 		}
 
-		info!(
-			"Notebook digest has missing audits. Will attempt to catchup now. {missing_audits_by_notary:#?}"
-		);
+		Ok(missing_audits)
+	}
 
+	fn missing_audit_wait_time(
+		max_wait: Option<Duration>,
+		missing_notary_count: usize,
+	) -> Duration {
+		Duration::from_secs(
+			max_wait
+				.map(|duration| duration.as_secs().max(1))
+				.unwrap_or((missing_notary_count * 5).clamp(6, 120) as u64),
+		)
+	}
+
+	async fn wait_for_missing_audits(
+		self: &Arc<Self>,
+		parent_hash: &B::Hash,
+		missing_audits_by_notary: &mut BTreeMap<NotaryId, Vec<NotebookNumber>>,
+		wait_time: Duration,
+	) -> Result<(), Error> {
 		let start = Instant::now();
-		let calculated_wait_secs = (missing_audits_by_notary.len() * 5).clamp(6, 120) as u64;
-		let wait_time_secs = max_wait
-			.map(|duration| duration.as_secs().max(1))
-			.unwrap_or(calculated_wait_secs);
-		let wait_time = Duration::from_secs(wait_time_secs);
 		let timeout_error = || {
 			Error::UnableToSyncNotary(format!(
-				"Could not process all missing audits in {wait_time_secs} seconds"
+				"Could not process all missing audits in {} seconds",
+				wait_time.as_secs()
 			))
 		};
-
-		if needs_notary_updates {
-			let Some(remaining) = wait_time.checked_sub(start.elapsed()) else {
-				warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
-				return Err(timeout_error());
-			};
-			tokio::time::timeout(remaining, self.update_notaries(parent_hash))
-				.await
-				.map_err(|_| timeout_error())??;
-		}
-
 		loop {
 			if start.elapsed() > wait_time {
 				warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
@@ -1120,11 +1795,20 @@ where
 				return Ok(());
 			}
 
-			let has_more_work =
-				self.process_selected_queues_at(*parent_hash, &missing_notary_ids).await?;
+			let Some(remaining) = wait_time.checked_sub(start.elapsed()) else {
+				warn!("Timed out waiting for missing audits. {missing_audits_by_notary:#?}");
+				return Err(timeout_error());
+			};
+			let has_more_work = tokio::time::timeout(
+				remaining,
+				self.process_selected_audits_at(*parent_hash, &missing_notary_ids),
+			)
+			.await
+			.map_err(|_| timeout_error())??;
 			let mut has_missing_audits = false;
 			for (notary_id, audits) in missing_audits_by_notary.iter_mut() {
-				let notary_audits = self.aux_client.get_notary_audit_history(*notary_id)?.get();
+				let notary_audits =
+					self.worker_context.aux_client.get_notary_audit_history(*notary_id)?.get();
 				audits.retain(|notebook_number| !notary_audits.contains_key(notebook_number));
 				if !audits.is_empty() {
 					has_missing_audits = true;
@@ -1137,209 +1821,6 @@ where
 			let sleep_ms = if has_more_work { 30 } else { 250 };
 			tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
 		}
-	}
-
-	async fn get_notebook_dependencies(
-		&self,
-		notary_id: NotaryId,
-		notebook_number: NotebookNumber,
-		best_hash: &B::Hash,
-	) -> Result<Vec<NotaryNotebookAuditSummary>, Error> {
-		let mut notebook_dependencies = vec![];
-		let mut missing_notebooks = vec![];
-
-		let latest_block_notebook = self.latest_notebook_in_runtime(*best_hash, notary_id);
-
-		// get any missing notebooks
-		if latest_block_notebook < notebook_number - 1 {
-			let notary_notebooks = self.aux_client.get_audit_summaries(notary_id)?.get();
-			for notebook_number_needed in (latest_block_notebook + 1)..notebook_number {
-				if let Some(summary) =
-					notary_notebooks.iter().find(|s| s.notebook_number == notebook_number_needed)
-				{
-					notebook_dependencies.push(summary.clone());
-				} else {
-					missing_notebooks.push(notebook_number_needed);
-				}
-			}
-		}
-
-		if !missing_notebooks.is_empty() {
-			for missing in &missing_notebooks {
-				self.enqueue_notebook(notary_id, *missing, None, None).await?;
-			}
-			let notebook_range =
-				missing_notebooks[0]..missing_notebooks[missing_notebooks.len() - 1];
-			info!("Missing notebooks for notary {notary_id}. Enqueued: {notebook_range:?}");
-			return Err(Error::MissingNotebooksError(format!(
-				"Missing notebooks #{notebook_range:?} to audit {notebook_number} for notary {notary_id}"
-			)));
-		}
-		Ok(notebook_dependencies)
-	}
-
-	async fn audit_notebook(
-		&self,
-		best_hash: &B::Hash,
-		notebook_details: &NotaryNotebookDetails<B::Hash>,
-	) -> Result<NotebookAuditResult<NotebookVerifyError>, Error> {
-		let tick = notebook_details.tick;
-		let notary_id = notebook_details.notary_id;
-		let notebook_number = notebook_details.notebook_number;
-		let notebook_dependencies =
-			self.get_notebook_dependencies(notary_id, notebook_number, best_hash).await?;
-		tracing::trace!(
-			notary_id,
-			notebook_number,
-			best_hash = ?best_hash,
-			tick,
-			notebook_dependencies = notebook_dependencies.len(),
-			"Attempting to audit notebook",
-		);
-
-		let full_notebook = self.download_notebook(notary_id, notebook_number).await?;
-		tracing::trace!(
-			notary_id,
-			notebook_number,
-			bytes = full_notebook.0.len(),
-			"Notebook downloaded.",
-		);
-
-		// audit on the best block since we're adding dependencies
-		let audit_failure_reason = match self.client.audit_notebook_and_get_votes(
-			*best_hash,
-			notebook_details.version,
-			notary_id,
-			notebook_number,
-			tick,
-			notebook_details.header_hash,
-			&full_notebook.0,
-			notebook_dependencies.clone(),
-			&notebook_details.blocks_with_votes,
-		)? {
-			Ok(votes) => {
-				let vote_count = votes.raw_votes.len();
-				self.aux_client.store_votes(tick, votes)?;
-
-				tracing::info!(
-					notary_id,
-					notebook_number,
-					tick,
-					"Notebook audit successful. {vote_count} block vote(s).",
-				);
-				None
-			},
-			Err(error) => {
-				// if this is a catchup notebook error, then it's our problem
-				if error == NotebookVerifyError::CatchupNotebooksMissing {
-					tracing::warn!(
-						notary_id,
-						notebook_number,
-						?notebook_dependencies,
-						?best_hash,
-						"Notebook audit failed for notary. Incorrect catchup provided",
-					);
-					return Err(Error::MissingNotebooksError(format!(
-						"Possibly missing notebooks? Invalid catchup notebooks provided to audit. Notary {notary_id}, #{notebook_number}, tick {tick}.",
-					)));
-				}
-
-				// if audit fails and the tick is greater than the runtime, then we should just
-				// signal upwards that this should try again. Once the tick has passed, we'll
-				// consider it failed.
-				if tick > self.client.current_tick(*best_hash)? {
-					return Err(Error::NotebookAuditBeforeTick(format!(
-						"Notebook tick is > runtime. Notary={notary_id}, notebook={notebook_number}, tick={tick}"
-					)));
-				}
-
-				tracing::warn!(
-					notary_id,
-					notebook_number,
-					tick,
-					"Notebook audit failed ({})",
-					error
-				);
-				Some(error)
-			},
-		};
-
-		Ok(NotebookAuditResult {
-			notary_id,
-			tick,
-			notebook_number,
-			audit_first_failure: audit_failure_reason,
-		})
-	}
-
-	fn should_connect_to_notary(notary_record: &NotaryRecordT) -> bool {
-		!matches!(notary_record.state, NotaryState::Locked { .. })
-	}
-
-	async fn get_notary_ids(&self) -> Vec<NotaryId> {
-		self.notaries_by_id.read().await.keys().copied().collect()
-	}
-
-	async fn get_notary_host(&self, notary_id: NotaryId) -> Result<String, Error> {
-		let notaries = self.notaries_by_id.read().await;
-		let record = notaries
-			.get(&notary_id)
-			.ok_or_else(|| Error::NotaryError("No rpc endpoints found for notary".to_string()))?;
-		let host =
-			record.meta.hosts.first().ok_or_else(|| {
-				Error::NotaryError("No rpc endpoint found for notary".to_string())
-			})?;
-		host.clone().try_into().map_err(|e| {
-			Error::NotaryError(format!(
-				"Could not convert host to string for notary {notary_id} - {e:?}"
-			))
-		})
-	}
-
-	async fn get_or_connect_to_client(
-		&self,
-		notary_id: NotaryId,
-	) -> Result<Arc<argon_notary_apis::Client>, Error> {
-		if let std::collections::btree_map::Entry::Vacant(e) =
-			self.notary_client_by_id.write().await.entry(notary_id)
-		{
-			let host_str = self.get_notary_host(notary_id).await?;
-			let c = argon_notary_apis::create_client(&host_str).await.map_err(|e| {
-				Error::NotaryError(format!(
-					"Could not connect to notary {notary_id} ({host_str}) for audit - {e:?}"
-				))
-			})?;
-			let c = Arc::new(c);
-			e.insert(c.clone());
-		}
-		self.get_client(notary_id)
-			.await
-			.ok_or_else(|| Error::NotaryError("Could not connect to notary for audit".to_string()))
-	}
-
-	async fn has_client(&self, notary_id: NotaryId) -> bool {
-		self.notary_client_by_id.read().await.contains_key(&notary_id)
-	}
-
-	async fn has_subscription(&self, notary_id: NotaryId) -> bool {
-		self.subscriptions_by_id.read().await.contains_key(&notary_id)
-	}
-
-	async fn get_client(&self, notary_id: NotaryId) -> Option<Arc<argon_notary_apis::Client>> {
-		self.notary_client_by_id.read().await.get(&notary_id).cloned()
-	}
-
-	fn latest_notebook_in_runtime(
-		&self,
-		block_hash: B::Hash,
-		notary_id: NotaryId,
-	) -> NotebookNumber {
-		if let Ok(latest_notebooks_in_runtime) = self.client.latest_notebook_by_notary(block_hash) {
-			if let Some((latest_notebook, _)) = latest_notebooks_in_runtime.get(&notary_id) {
-				return *latest_notebook;
-			}
-		}
-		0
 	}
 }
 
@@ -1568,7 +2049,7 @@ mod test {
 	use crate::mock_notary::setup_logs;
 	use sp_core::{H256, bounded_vec};
 	use sp_keyring::Ed25519Keyring;
-	use std::collections::BTreeMap;
+	use std::collections::{BTreeMap, BTreeSet};
 
 	#[derive(Clone, Default)]
 	struct TestNode {
@@ -1789,10 +2270,99 @@ mod test {
 			notebook_downloader,
 			Arc::new(None),
 			ticker,
+			None,
+			Duration::from_millis(250),
 			true,
 		);
 		let notary_client = Arc::new(notary_client);
 		(test_notary, client, notary_client)
+	}
+
+	async fn worker(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> Option<Arc<NotaryWorker>> {
+		notary_client.worker(notary_id).await
+	}
+
+	async fn worker_tracking_snapshot(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> Vec<(NotebookNumber, bool)> {
+		let Some(worker) = worker(notary_client, notary_id).await else {
+			return Vec::new();
+		};
+		worker.pending.lock().await.snapshot()
+	}
+
+	async fn worker_tracked_notebook_count(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> usize {
+		let Some(worker) = worker(notary_client, notary_id).await else {
+			return 0;
+		};
+		worker.pending.lock().await.len()
+	}
+
+	async fn track_worker_notebook(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+		notebook_number: NotebookNumber,
+		header_bytes: Option<SignedHeaderBytes>,
+		known_since: Option<Instant>,
+	) {
+		let worker = notary_client.ensure_worker(notary_id).await;
+		worker
+			.pending
+			.lock()
+			.await
+			.track_notebook(notebook_number, header_bytes, known_since);
+	}
+
+	async fn has_worker_client(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> bool {
+		let Some(worker) = worker(notary_client, notary_id).await else {
+			return false;
+		};
+		worker.has_client().await
+	}
+
+	async fn has_worker_subscription(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		notary_id: NotaryId,
+	) -> bool {
+		let Some(worker) = worker(notary_client, notary_id).await else {
+			return false;
+		};
+		worker.has_subscription().await
+	}
+
+	async fn wait_for_subscription(
+		notary_client: &Arc<NotaryClient<Block, TestNode, AccountId>>,
+		wait_duration: Duration,
+	) -> Option<(NotaryId, NotebookNumber)> {
+		let start = Instant::now();
+		loop {
+			let worker_ids =
+				notary_client.workers_by_id.read().await.keys().copied().collect::<Vec<_>>();
+			for notary_id in worker_ids {
+				let Some(worker) = worker(notary_client, notary_id).await else {
+					continue;
+				};
+				if let Some(notebook_number) =
+					worker.poll_subscription(notary_client.worker_context.as_ref()).await
+				{
+					return Some((notary_id, notebook_number));
+				}
+			}
+			if start.elapsed() > wait_duration {
+				return None;
+			}
+			tokio::task::yield_now().await;
+		}
 	}
 
 	#[tokio::test]
@@ -1802,12 +2372,12 @@ mod test {
 			.update_notaries(&client.best_hash())
 			.await
 			.expect("Could not update notaries");
-		assert_eq!(notary_client.notaries_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 1);
+		assert_eq!(notary_client.workers_by_id.read().await.len(), 1);
+		assert!(has_worker_client(&notary_client, 1).await);
+		assert!(has_worker_subscription(&notary_client, 1).await);
 
 		test_notary.create_notebook_header(vec![]).await;
-		let next = notary_client.next_subscription(Duration::from_millis(500)).await.unwrap();
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500)).await.unwrap();
 		assert_eq!(next.0, 1);
 
 		// now mark the notary as audit failed
@@ -1820,114 +2390,50 @@ mod test {
 			.update_notaries(&client.best_hash())
 			.await
 			.expect("Could not update notaries");
-		assert_eq!(notary_client.notaries_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 0);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 0);
+		assert_eq!(notary_client.workers_by_id.read().await.len(), 1);
+		assert!(!has_worker_client(&notary_client, 1).await);
+		assert!(!has_worker_subscription(&notary_client, 1).await);
 		test_notary.create_notebook_header(vec![]).await;
-		let next = notary_client.next_subscription(Duration::from_millis(500)).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500)).await;
 		assert!(next.is_none());
 	}
 
 	#[tokio::test]
-	async fn wont_reconnect_if_queue_depth_exceeded() {
-		setup_logs();
-		let (test_notary, client, notary_client) = system().await;
-		notary_client
-			.update_notaries(&client.best_hash())
-			.await
-			.expect("Could not update notaries");
-		assert_eq!(notary_client.notaries_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 1);
-		for i in 0..MAX_QUEUE_DEPTH {
-			test_notary.create_notebook_header(vec![]).await;
-			notary_client.next_subscription(Duration::from_millis(500)).await;
-			assert_eq!(notary_client.queue_depth(1).await, i + 1);
-		}
-
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.len(), 1);
-
-		assert_eq!(notary_client.queue_depth(1).await, MAX_QUEUE_DEPTH);
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 1);
-
-		test_notary.create_notebook_header(vec![]).await;
-		notary_client.next_subscription(Duration::from_millis(500)).await;
-		assert_eq!(notary_client.queue_depth(1).await, MAX_QUEUE_DEPTH + 1);
-		// should have disconnected subscriptions, but kept notary client
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 1);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 0);
-	}
-
-	#[tokio::test]
-	async fn handles_queueing_correctly() {
+	async fn handles_notebook_tracking_correctly() {
 		let (_test_notary, _client, notary_client) = system().await;
-		notary_client
-			.enqueue_notebook(1, 3, None, None)
-			.await
-			.expect("Could not enqueue");
-		notary_client
-			.enqueue_notebook(1, 1, None, None)
-			.await
-			.expect("Could not enqueue");
-		notary_client
-			.enqueue_notebook(1, 2, None, None)
-			.await
-			.expect("Could not enqueue");
+		track_worker_notebook(&notary_client, 1, 3, None, None).await;
+		track_worker_notebook(&notary_client, 1, 1, None, None).await;
+		track_worker_notebook(&notary_client, 1, 2, None, None).await;
 		assert_eq!(
-			notary_client
-				.notebook_queue_by_id
-				.read()
-				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| (*n, a.is_some()))
-				.collect::<Vec<_>>(),
+			worker_tracking_snapshot(&notary_client, 1).await,
 			vec![(1, false), (2, false), (3, false)]
 		);
-		let next = notary_client.get_next(1, 0).await;
+		let next = worker(&notary_client, 1)
+			.await
+			.expect("worker should exist")
+			.next_for_processing(notary_client.worker_context.as_ref(), 0)
+			.await;
 		assert!(next.is_none());
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&1).unwrap().len(), 3);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 3);
 
-		notary_client
-			.enqueue_notebook(1, 2, Some(Default::default()), None)
-			.await
-			.expect("Could not enqueue");
-		notary_client
-			.enqueue_notebook(1, 1, Some(Default::default()), None)
-			.await
-			.expect("Could not enqueue");
+		track_worker_notebook(&notary_client, 1, 2, Some(Default::default()), None).await;
+		track_worker_notebook(&notary_client, 1, 1, Some(Default::default()), None).await;
 
 		assert_eq!(
-			notary_client
-				.notebook_queue_by_id
-				.read()
-				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| (*n, a.is_some()))
-				.collect::<Vec<_>>(),
+			worker_tracking_snapshot(&notary_client, 1).await,
 			vec![(1, true), (2, true), (3, false)]
 		);
 
-		notary_client
-			.enqueue_notebook(1, 1, None, None)
-			.await
-			.expect("Could not enqueue");
+		track_worker_notebook(&notary_client, 1, 1, None, None).await;
 		assert_eq!(
-			notary_client
-				.notebook_queue_by_id
-				.read()
-				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| (*n, a.is_some()))
-				.collect::<Vec<_>>(),
+			worker_tracking_snapshot(&notary_client, 1).await,
 			vec![(1, true), (2, true), (3, false)]
 		);
-		let next = notary_client.get_next(1, 0).await;
+		let next = worker(&notary_client, 1)
+			.await
+			.expect("worker should exist")
+			.next_for_processing(notary_client.worker_context.as_ref(), 0)
+			.await;
 		assert!(next.is_some());
 	}
 
@@ -1998,6 +2504,36 @@ mod test {
 	}
 
 	#[tokio::test]
+	async fn reconnects_on_periodic_refresh_without_new_block() {
+		setup_logs();
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert!(has_worker_client(&notary_client, 1).await);
+		assert!(has_worker_subscription(&notary_client, 1).await);
+
+		notary_client.disconnect(&1, None).await;
+		assert!(!has_worker_client(&notary_client, 1).await);
+		assert!(!has_worker_subscription(&notary_client, 1).await);
+
+		// Periodic notary refreshes reuse the same best hash when no new block has arrived.
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not refresh notaries");
+		assert!(has_worker_client(&notary_client, 1).await);
+		assert!(has_worker_subscription(&notary_client, 1).await);
+
+		test_notary.create_notebook_header(vec![]).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500))
+			.await
+			.expect("worker should resubscribe without a new block");
+		assert_eq!(next, (1, 1));
+	}
+
+	#[tokio::test]
 	async fn supplies_missing_notebooks_on_audit() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
@@ -2006,20 +2542,19 @@ mod test {
 			.expect("Could not update notaries");
 
 		let result = notary_client
-			.get_notebook_dependencies(test_notary.notary_id, 10, &client.best_hash())
+			.worker(test_notary.notary_id)
+			.await
+			.expect("worker should exist")
+			.get_notebook_dependencies(
+				notary_client.worker_context.as_ref(),
+				10,
+				&client.best_hash(),
+			)
 			.await
 			.expect_err("Should not have all dependencies");
 		assert!(matches!(result, Error::MissingNotebooksError(_)),);
 		assert_eq!(
-			notary_client
-				.notebook_queue_by_id
-				.read()
-				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| (*n, a.is_some()))
-				.collect::<Vec<_>>(),
+			worker_tracking_snapshot(&notary_client, 1).await,
 			vec![
 				(1, false),
 				(2, false),
@@ -2034,7 +2569,14 @@ mod test {
 		);
 		client.latest_notebook_by_notary.lock().insert(1, (8, 1));
 		let result = notary_client
-			.get_notebook_dependencies(test_notary.notary_id, 10, &client.best_hash())
+			.worker(test_notary.notary_id)
+			.await
+			.expect("worker should exist")
+			.get_notebook_dependencies(
+				notary_client.worker_context.as_ref(),
+				10,
+				&client.best_hash(),
+			)
 			.await
 			.expect_err("Should have all dependencies");
 
@@ -2044,34 +2586,62 @@ mod test {
 		assert!(result.to_string().contains("#9..9"));
 
 		for _ in 0..9 {
-			notary_client.process_queues(None).await.expect("Could not process queues");
-		}
-		assert_eq!(
 			notary_client
-				.notebook_queue_by_id
-				.read()
+				.process_background_audits()
 				.await
-				.get(&1)
-				.unwrap()
-				.iter()
-				.map(|(n, a, _)| { (*n, a.is_some()) })
-				.collect::<Vec<_>>(),
-			vec![(9, false)]
-		);
+				.expect("Could not process queues");
+		}
+		assert_eq!(worker_tracking_snapshot(&notary_client, 1).await, vec![(9, false)]);
 		for _ in 0..10 {
 			test_notary.create_notebook_header(vec![]).await;
-			notary_client.process_queues(None).await.expect("Could not process queues");
+			notary_client
+				.process_background_audits()
+				.await
+				.expect("Could not process queues");
 		}
 		let mut rx = notary_client.tick_voting_power_receiver.lock().await;
 		let next_rx = rx.next().await.expect("Could not receive");
 		assert_eq!(next_rx.0, 9);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&1).unwrap(), &vec![]);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 		let result = notary_client
-			.get_notebook_dependencies(test_notary.notary_id, 10, &client.best_hash())
+			.worker(test_notary.notary_id)
+			.await
+			.expect("worker should exist")
+			.get_notebook_dependencies(
+				notary_client.worker_context.as_ref(),
+				10,
+				&client.best_hash(),
+			)
 			.await
 			.expect("Could not retrieve missing notebooks");
 		assert_eq!(result.len(), 1);
 		assert_eq!(result[0].notebook_number, 9);
+	}
+
+	#[tokio::test]
+	async fn tracks_full_missing_notebook_dependency_range() {
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		let result = notary_client
+			.worker(test_notary.notary_id)
+			.await
+			.expect("worker should exist")
+			.get_notebook_dependencies(
+				notary_client.worker_context.as_ref(),
+				42,
+				&client.best_hash(),
+			)
+			.await
+			.expect_err("Should not have all dependencies");
+		assert!(matches!(result, Error::MissingNotebooksError(_)));
+		assert_eq!(
+			worker_tracking_snapshot(&notary_client, 1).await,
+			(1..42).map(|number| (number, false)).collect::<Vec<_>>()
+		);
 	}
 
 	#[tokio::test]
@@ -2088,12 +2658,21 @@ mod test {
 		test_notary.create_notebook_header(vec![]).await;
 		test_notary2.create_notebook_header(vec![]).await;
 
-		notary_client.next_subscription(Duration::from_millis(500)).await;
-		assert_eq!(notary_client.queue_depth(1).await, 1);
-		assert!(notary_client.notebook_queue_by_id.read().await.get(&2).is_none());
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		assert_eq!(notary_client.queue_depth(1).await, 0);
-		assert!(notary_client.notebook_queue_by_id.read().await.get(&2).is_none());
+		wait_for_subscription(&notary_client, Duration::from_millis(500)).await;
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
+		assert!(
+			worker(&notary_client, 2).await.is_none() ||
+				worker_tracked_notebook_count(&notary_client, 2).await == 0
+		);
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
+		assert!(
+			worker(&notary_client, 2).await.is_none() ||
+				worker_tracked_notebook_count(&notary_client, 2).await == 0
+		);
 
 		let next_rx = notary_client
 			.tick_voting_power_receiver
@@ -2108,29 +2687,32 @@ mod test {
 			.update_notaries(&client.best_hash())
 			.await
 			.expect("Could not update notaries");
-		assert_eq!(notary_client.notary_client_by_id.read().await.len(), 2);
-		assert_eq!(notary_client.subscriptions_by_id.read().await.len(), 2);
+		assert!(has_worker_client(&notary_client, 1).await);
+		assert!(has_worker_client(&notary_client, 2).await);
+		assert!(has_worker_subscription(&notary_client, 1).await);
+		assert!(has_worker_subscription(&notary_client, 2).await);
 
 		test_notary.create_notebook_header(vec![]).await;
 		test_notary2.create_notebook_header(vec![]).await;
 
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
 
-		assert_eq!(notary_client.queue_depth(1).await, 1);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&1).unwrap()[0].0, 2);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&2).unwrap().len(), 2);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&2).unwrap()[0].0, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
+		assert_eq!(worker_tracking_snapshot(&notary_client, 1).await[0].0, 2);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 2).await, 2);
+		assert_eq!(worker_tracking_snapshot(&notary_client, 2).await[0].0, 1);
 		// should process one from each notary
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		assert_eq!(notary_client.queue_depth(1).await, 0);
-		assert_eq!(notary_client.notebook_queue_by_id.read().await.get(&2).unwrap().len(), 1);
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 2).await, 1);
 	}
 
 	#[tokio::test]
@@ -2151,23 +2733,17 @@ mod test {
 
 		let notebook_1 = test_notary.create_notebook_header(vec![]).await;
 		let notebook_2 = test_notary2.create_notebook_header(vec![]).await;
-		notary_client
-			.enqueue_notebook(1, notebook_1.notebook_number, None, None)
-			.await
-			.expect("Could not enqueue notebook for first notary");
-		notary_client
-			.enqueue_notebook(2, notebook_2.notebook_number, None, None)
-			.await
-			.expect("Could not enqueue notebook for second notary");
+		track_worker_notebook(&notary_client, 1, notebook_1.notebook_number, None, None).await;
+		track_worker_notebook(&notary_client, 2, notebook_2.notebook_number, None, None).await;
 
 		let targeted = BTreeSet::from([1]);
 		notary_client
-			.process_selected_queues_at(client.best_hash(), &targeted)
+			.process_selected_audits_at(client.best_hash(), &targeted)
 			.await
 			.expect("Could not process targeted queues");
 
-		assert_eq!(notary_client.queue_depth(1).await, 0);
-		assert_eq!(notary_client.queue_depth(2).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 2).await, 1);
 	}
 
 	#[tokio::test]
@@ -2179,11 +2755,10 @@ mod test {
 			.expect("Could not update notaries");
 
 		test_notary.create_notebook_header(vec![]).await;
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
 		let block_0 = H256::from_slice(&[0; 32]);
 		let block_1 = H256::from_slice(&[1; 32]);
@@ -2206,10 +2781,12 @@ mod test {
 			raw_audit_summary: vec![],
 		});
 
-		let has_more_work =
-			notary_client.process_queues(None).await.expect("Could not process queues");
+		let has_more_work = notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_2));
 	}
 
@@ -2222,11 +2799,10 @@ mod test {
 			.expect("Could not update notaries");
 
 		test_notary.create_notebook_header(vec![]).await;
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
 		let block_0 = H256::from_slice(&[0; 32]);
 		let block_1 = H256::from_slice(&[1; 32]);
@@ -2250,15 +2826,17 @@ mod test {
 			raw_audit_summary: vec![],
 		});
 
-		let has_more_work =
-			notary_client.process_queues(None).await.expect("Could not process queues");
+		let has_more_work = notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_1));
 	}
 
 	#[tokio::test]
-	async fn paused_queue_processing_returns_false_and_keeps_queue() {
+	async fn paused_notebook_audits_return_false_and_keep_tracking() {
 		let (test_notary, client, notary_client) = system().await;
 		notary_client
 			.update_notaries(&client.best_hash())
@@ -2266,18 +2844,52 @@ mod test {
 			.expect("Could not update notaries");
 
 		test_notary.create_notebook_header(vec![]).await;
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
-		*notary_client.pause_queue_processing.write().await = true;
+		*notary_client.pause_notebook_audits.write().await = true;
 
-		let has_more_work =
-			notary_client.process_queues(None).await.expect("Could not process queues");
+		let has_more_work = notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
+	}
+
+	#[tokio::test]
+	async fn paused_queue_processing_drops_subscription_backlog() {
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert!(has_worker_subscription(&notary_client, 1).await);
+
+		*notary_client.pause_notebook_audits.write().await = true;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert!(!has_worker_subscription(&notary_client, 1).await);
+
+		test_notary.create_notebook_header(vec![]).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(250)).await;
+		assert!(next.is_none());
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
+
+		*notary_client.pause_notebook_audits.write().await = false;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+		assert!(has_worker_subscription(&notary_client, 1).await);
+
+		test_notary.create_notebook_header(vec![]).await;
+		let next = wait_for_subscription(&notary_client, Duration::from_millis(500)).await;
+		assert_eq!(next, Some((1, 2)));
 	}
 
 	#[tokio::test]
@@ -2289,11 +2901,10 @@ mod test {
 			.expect("Could not update notaries");
 
 		test_notary.create_notebook_header(vec![]).await;
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
 		let block_0 = H256::from_slice(&[0; 32]);
 		let block_1 = H256::from_slice(&[1; 32]);
@@ -2317,11 +2928,11 @@ mod test {
 		});
 
 		let has_more_work = notary_client
-			.process_queues_at(block_2)
+			.process_audits_at(block_2)
 			.await
 			.expect("Could not process queues");
 		assert!(!has_more_work);
-		assert_eq!(notary_client.queue_depth(1).await, 0);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 0);
 		assert_eq!(*client.decode_intercepted_at_block.lock(), Some(block_1));
 	}
 
@@ -2337,32 +2948,94 @@ mod test {
 		test_notary.create_notebook_header(vec![]).await;
 		test_notary.create_notebook_header(vec![]).await;
 
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 2);
-		notary_client
-			.next_subscription(Duration::from_millis(500))
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 2);
+		wait_for_subscription(&notary_client, Duration::from_millis(500))
 			.await
 			.expect("Could not get next");
-		assert_eq!(notary_client.queue_depth(1).await, 3);
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 3);
 
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
 
 		*client.current_tick.lock() = 2;
 		client
 			.audit_failure
 			.lock()
 			.replace(NotebookVerifyError::InvalidChainTransfersList);
-		notary_client.process_queues(None).await.expect("Could not process queues");
-		assert_eq!(notary_client.queue_depth(1).await, 1);
+		notary_client
+			.process_background_audits()
+			.await
+			.expect("Could not process queues");
+		assert_eq!(worker_tracked_notebook_count(&notary_client, 1).await, 1);
+	}
+
+	#[tokio::test]
+	async fn import_wait_timeout_does_not_block_on_slow_audit_work() {
+		let (test_notary, client, notary_client) = system().await;
+		notary_client
+			.update_notaries(&client.best_hash())
+			.await
+			.expect("Could not update notaries");
+
+		let notebook = test_notary.create_notebook_header(vec![]).await;
+		track_worker_notebook(&notary_client, 1, notebook.notebook_number, None, None).await;
+
+		let audit_slots = notary_client
+			.worker_context
+			.audit_slots
+			.acquire_many(MAX_PARALLEL_NOTARY_AUDITS as u32)
+			.await
+			.expect("Could not exhaust audit slots");
+		let mut missing_audits = BTreeMap::from([(1, vec![notebook.notebook_number])]);
+		let start = Instant::now();
+		let result = notary_client
+			.wait_for_missing_audits(
+				&client.best_hash(),
+				&mut missing_audits,
+				Duration::from_millis(50),
+			)
+			.await;
+		assert!(matches!(result, Err(Error::UnableToSyncNotary(_))));
+		assert!(
+			start.elapsed() < Duration::from_millis(250),
+			"import wait should return promptly once its deadline is exceeded",
+		);
+
+		drop(audit_slots);
+
+		let mut audit_completed = false;
+		for _ in 0..25 {
+			if notary_client
+				.worker_context
+				.aux_client
+				.get_notary_audit_history(1)
+				.expect("could not read audit history")
+				.get()
+				.contains_key(&notebook.notebook_number)
+			{
+				audit_completed = true;
+				break;
+			}
+			tokio::time::sleep(Duration::from_millis(20)).await;
+		}
+
+		assert!(
+			audit_completed,
+			"in-flight notary work should continue after the import wait times out",
+		);
 	}
 
 	#[tokio::test]
@@ -2400,9 +3073,11 @@ mod test {
 			blocks_with_votes: vec![],
 			raw_audit_summary: vec![],
 		});
-		let _ = notary_client
+		let _ = worker(&notary_client, 1)
+			.await
+			.expect("worker should exist")
 			.process_notebook(
-				1,
+				notary_client.worker_context.as_ref(),
 				3,
 				2,
 				&H256::from_slice(&[4; 32]),

--- a/node/consensus/src/notary_client.rs
+++ b/node/consensus/src/notary_client.rs
@@ -983,6 +983,9 @@ impl NotaryWorker {
 		if *worker_context.pause_notebook_audits.read().await {
 			return false;
 		}
+		if self.pending.lock().await.len() == 0 {
+			return false;
+		}
 		let Some(best_hash) = resolve_client_stateful_hash::<B, _, AC>(
 			worker_context.client.as_ref(),
 			worker_context.client.best_hash(),
@@ -1356,15 +1359,11 @@ impl NotaryWorker {
 		if !missing_notebooks.is_empty() {
 			let first_missing = missing_notebooks[0];
 			let last_missing = missing_notebooks[missing_notebooks.len() - 1];
+			let notebook_range = first_missing..=last_missing;
 			trace!(
-				"Tracking notebook range {}..{} for notary {}",
-				first_missing, last_missing, self.notary_id,
-			);
-			self.pending.lock().await.track_range(first_missing, last_missing);
-			let notebook_range = first_missing..last_missing;
-			info!(
 				"Missing notebooks for notary {notary_id}. Tracking dependency catchup range: {notebook_range:?}",
 			);
+			self.pending.lock().await.track_range(first_missing, last_missing);
 			return Err(Error::MissingNotebooksError(format!(
 				"Missing notebooks #{notebook_range:?} to audit {notebook_number} for notary {notary_id}"
 			)));
@@ -2583,7 +2582,7 @@ mod test {
 		// still missing number 9
 		assert!(matches!(result, Error::MissingNotebooksError(_)),);
 		println!("result: {result}");
-		assert!(result.to_string().contains("#9..9"));
+		assert!(result.to_string().contains("#9..=9"));
 
 		for _ in 0..9 {
 			notary_client

--- a/node/consensus/src/pending_import_replay.rs
+++ b/node/consensus/src/pending_import_replay.rs
@@ -714,6 +714,8 @@ mod tests {
 			notebook_downloader,
 			Arc::new(None),
 			Ticker::new(2_000, 2),
+			None,
+			Duration::from_millis(250),
 			true,
 		));
 

--- a/notary/apis/src/lib.rs
+++ b/notary/apis/src/lib.rs
@@ -8,7 +8,7 @@ use argon_primitives::{
 };
 use codec::Decode;
 use jsonrpsee::{
-	async_client::ClientBuilder,
+	async_client::{ClientBuilder, PingConfig},
 	client_transport::ws::{Url, WsTransportClientBuilder},
 };
 use std::{fmt::Debug, sync::OnceLock, time::Duration};
@@ -398,7 +398,9 @@ pub async fn create_client(url: &str) -> anyhow::Result<Client> {
 	let url = Url::parse(url).map_err(|e| anyhow!("Invalid URL: {url:?} -> {e}"))?;
 
 	let (sender, receiver) = transport_builder.build(url).await?;
-	let client = ClientBuilder::default().build_with_tokio(sender, receiver);
+	let client = ClientBuilder::default()
+		.enable_ws_ping(PingConfig::default())
+		.build_with_tokio(sender, receiver);
 	Ok(client)
 }
 

--- a/notary/src/server.rs
+++ b/notary/src/server.rs
@@ -176,7 +176,6 @@ impl NotaryServer {
 			.set_message_buffer_capacity(max_buffer_capacity_per_connection)
 			.set_batch_request_config(batch_config.unwrap_or(BatchRequestConfig::Disabled))
 			.set_rpc_middleware(rpc_middleware)
-			.enable_ws_ping(PingConfig::default())
 			.build(addrs)
 			.await?;
 		Ok(server)


### PR DESCRIPTION
## Summary

This PR moves notebook audit processing into per-notary workers.

Each notary worker now owns its own:
- tracked notebook audit state
- connection and subscription state
- background processing loop
- will reconnect to the notary if stale (no notebook in last 2 ticks)

That keeps stalls local to a single notary instead of serializing progress across all notaries.

## What Changed

- Introduced per-notary worker state in [`node/consensus/src/notary_client.rs`](/Users/blakebyrnes/.codex/worktrees/c7ef/mainchain/node/consensus/src/notary_client.rs)
- Moved notebook tracking to a contiguous range model:
  - `next_notebook_number`
  - `highest_notebook_number`
  - cached headers for upcoming notebooks
- Kept import/replay audit behavior from the deferred replay branch while moving the actual processing ownership into each worker
- Kept shared download throttling in place, so workers can prefetch without exploding concurrency
- Preserved pause/reconnect/targeted catchup behavior under the new worker model

## Why

The old model made notebook progress easier to serialize across notaries. A blocked or slow notary could interfere with unrelated notebook processing.

The new structure isolates that work per notary and makes the flow closer to the real problem shape:
- each notary has a contiguous notebook history
- catchup is range-based
- downloads are still centrally throttled
- retries and reconnects stay scoped to the affected notary

## Testing

- `cargo test -p argon-node-consensus --lib`
- `cargo make lint`

Also validated earlier on the worker branch with the relevant e2e scenarios:
- `test_late_node_catches_up_to_existing_notebook_history`
- `test_late_node_recovers_after_restart_during_notary_outage`
- `test_long_running_network_recovers_after_notary_outage`
