### PR TITLE
fix(tests): stabilize end-to-end tx submission

### DIFF
--- a/end-to-end/src/bitcoin.rs
+++ b/end-to-end/src/bitcoin.rs
@@ -105,7 +105,7 @@ async fn test_bitcoin_minting_e2e() {
 		.unwrap();
 
 	let ticker = client.lookup_ticker().await.expect("ticker");
-	let _last_bitcoin_price_tick = submit_price(&ticker, &client, &price_index_operator).await;
+	let mut last_bitcoin_price_tick = submit_price(&ticker, &client, &price_index_operator).await;
 
 	let alice_signer = Sr25519Signer::new(alice_sr25519.clone());
 
@@ -218,6 +218,7 @@ async fn test_bitcoin_minting_e2e() {
 		vout,
 		&ticker,
 		&price_index_operator,
+		&mut last_bitcoin_price_tick,
 	)
 	.await
 	.unwrap();
@@ -227,7 +228,8 @@ async fn test_bitcoin_minting_e2e() {
 		.unwrap();
 
 	println!("Submitting new bitcoin price");
-	submit_price(&ticker, &client, &price_index_operator).await;
+	submit_price_if_needed(&ticker, &client, &price_index_operator, &mut last_bitcoin_price_tick)
+		.await;
 
 	// 5. Ask for the bitcoin to be released
 	println!("\nOwner requests release");
@@ -323,7 +325,7 @@ async fn test_bitcoin_xpriv_lock_e2e() {
 		.unwrap();
 
 	let ticker = client.lookup_ticker().await.expect("ticker");
-	let _last_bitcoin_price_tick = submit_price(&ticker, &client, &price_index_operator).await;
+	let mut last_bitcoin_price_tick = submit_price(&ticker, &client, &price_index_operator).await;
 
 	let _ = run_bitcoin_cli(&test_node, vec!["vault", "list", "--btc", &utxo_btc.to_string()])
 		.await
@@ -391,7 +393,8 @@ async fn test_bitcoin_xpriv_lock_e2e() {
 	}
 
 	println!("Submitting new bitcoin price");
-	submit_price(&ticker, &client, &price_index_operator).await;
+	submit_price_if_needed(&ticker, &client, &price_index_operator, &mut last_bitcoin_price_tick)
+		.await;
 
 	// 5. Ask for the bitcoin to be releaseed
 	println!("\nOwner requests release");
@@ -471,11 +474,15 @@ async fn submit_price(
 	client: &MainchainClient,
 	price_index_operator: &sr25519::Pair,
 ) -> Tick {
-	let tick = ticker.current();
-	client
+	let signer = Sr25519Signer::new(price_index_operator.clone());
+	let account_id = signer.account_id();
+	let tick = current_chain_tick(client, ticker).await;
+	let nonce = client.get_account_nonce(&account_id).await.unwrap();
+	let params = MainchainClient::ext_params_builder().nonce(nonce.into()).mortal(5).build();
+	let progress = client
 		.live
 		.tx()
-		.sign_and_submit_then_watch_default(
+		.sign_and_submit_then_watch(
 			&tx().price_index().submit(Index {
 				btc_usd_price: FixedU128Ext(FixedU128::from_float(62_000.0).into_inner()),
 				argon_usd_target_price: FixedU128Ext(FixedU128::from_float(1.0).into_inner()),
@@ -484,15 +491,36 @@ async fn submit_price(
 				argonot_usd_price: FixedU128Ext(FixedU128::from_float(1.0).into_inner()),
 				tick,
 			}),
-			&Sr25519Signer::new(price_index_operator.clone()),
+			&signer,
+			params,
 		)
 		.await
-		.unwrap()
-		.wait_for_finalized_success()
-		.await
 		.unwrap();
+	MainchainClient::wait_for_ext_in_block(progress, true).await.unwrap();
 	println!("bitcoin prices submitted at tick {tick}",);
 	tick
+}
+
+async fn submit_price_if_needed(
+	ticker: &Ticker,
+	client: &MainchainClient,
+	price_index_operator: &sr25519::Pair,
+	last_submitted_tick: &mut Tick,
+) {
+	let current_tick = current_chain_tick(client, ticker).await;
+	if current_tick <= *last_submitted_tick {
+		return;
+	}
+
+	*last_submitted_tick = submit_price(ticker, client, price_index_operator).await;
+}
+
+async fn current_chain_tick(client: &MainchainClient, ticker: &Ticker) -> Tick {
+	client
+		.fetch_storage(&storage().ticks().current_tick(), FetchAt::Best)
+		.await
+		.unwrap()
+		.unwrap_or_else(|| ticker.current())
 }
 
 fn get_parent_fingerprint(bitcoind: &BitcoinD, owner_hd_key_path: &DerivationPath) -> Fingerprint {
@@ -836,6 +864,7 @@ async fn wait_for_mint(
 	vout: u32,
 	ticker: &Ticker,
 	price_index_operator: &sr25519::Pair,
+	last_submitted_tick: &mut Tick,
 ) -> anyhow::Result<()> {
 	let mut finalized_sub = client.live.blocks().subscribe_finalized().await?;
 	let pending_utxos = client
@@ -909,7 +938,7 @@ async fn wait_for_mint(
 			}
 			counter += 1;
 
-			submit_price(ticker, client, price_index_operator).await;
+			submit_price_if_needed(ticker, client, price_index_operator, last_submitted_tick).await;
 			if counter >= 30 {
 				let registered_miners = client
 					.fetch_storage(

--- a/end-to-end/src/vote_mining.rs
+++ b/end-to-end/src/vote_mining.rs
@@ -1,7 +1,4 @@
-use crate::utils::{
-	create_active_notary_with_archive_bucket, force_set_ownership_balance,
-	mining_slot_ownership_needed, register_miner_keys, register_miners, wait_for_finalized_catchup,
-};
+use crate::utils::{activate_vote_mining, create_active_notary_with_archive_bucket};
 use argon_client::{
 	FetchAt,
 	api::storage,
@@ -13,7 +10,6 @@ use argon_testing::{ArgonNodeStartArgs, ArgonTestNode, ArgonTestNotary, test_min
 use polkadot_sdk::*;
 use serial_test::serial;
 use sp_core::{DeriveJunction, Pair};
-use tokio::join;
 
 /// Tests default votes submitted by a notebook after nodes register as vote miners
 #[tokio::test(flavor = "multi_thread")]
@@ -33,17 +29,6 @@ async fn test_end_to_end_default_vote_mining() {
 		.await
 		.expect("Notary registered");
 
-	let ownership_needed = mining_slot_ownership_needed(&grandpa_miner).await.unwrap();
-	let seeded_ownership = ownership_needed.saturating_mul(2);
-	force_set_ownership_balance(&grandpa_miner, &miner_1.account_id, seeded_ownership)
-		.await
-		.unwrap();
-	force_set_ownership_balance(&grandpa_miner, &miner_2.account_id, seeded_ownership)
-		.await
-		.unwrap();
-	wait_for_finalized_catchup(&grandpa_miner, &miner_1).await.unwrap();
-	wait_for_finalized_catchup(&grandpa_miner, &miner_2).await.unwrap();
-
 	let miner_1_keyring = miner_1.keyring();
 	let miner_1_second_account = miner_1
 		.keyring()
@@ -57,30 +42,7 @@ async fn test_end_to_end_default_vote_mining() {
 
 	let miner_2_keyring = miner_2.keyring();
 
-	let (keys1, keys_1_2, keys2) = join!(
-		register_miner_keys(&miner_1, miner_1_keyring, 1),
-		register_miner_keys(&miner_1, miner_1_keyring, 2),
-		register_miner_keys(&miner_2, miner_2_keyring, 1)
-	);
-	let (miner2_res, miner1_res) = join!(
-		register_miners(
-			&miner_2,
-			miner_2_keyring.pair().into(),
-			vec![(miner_2.account_id.clone(), keys2.unwrap())],
-			None,
-		),
-		register_miners(
-			&miner_1,
-			miner_1_keyring.pair().into(),
-			vec![
-				(miner_1.account_id.clone(), keys1.unwrap()),
-				(miner_1_second_account.clone(), keys_1_2.unwrap())
-			],
-			None,
-		),
-	);
-	miner2_res.unwrap();
-	miner1_res.unwrap();
+	activate_vote_mining(&grandpa_miner, &miner_1, &miner_2).await.unwrap();
 
 	// Ensure registrations are visible in finalized state before counting vote blocks.
 	let mut finalized_wait =


### PR DESCRIPTION
Use the shared vote mining activation path in the e2e harness and submit bitcoin price updates with an explicit nonce plus per-tick gating to avoid intermittent invalid transactions.