### PR TITLE
Guard tx-pool keys for announced proxies

### DIFF
--- a/pallets/fee_control/src/check_fee_wrapper.rs
+++ b/pallets/fee_control/src/check_fee_wrapper.rs
@@ -86,25 +86,70 @@ where
 			return (call, None);
 		};
 
-		if let Some(pallet_proxy::Call::proxy { real, force_proxy_type, call: inner_call }) =
+		if let Some(proxy_call) =
 			<RuntimeCallOf<T> as IsSubType<pallet_proxy::Call<T>>>::is_sub_type(call)
 		{
-			let Ok(real) = T::Lookup::lookup(real.clone()) else {
-				return (call, Some(signer));
-			};
-			let Ok(def) =
-				pallet_proxy::Pallet::<T>::find_proxy(&real, &signer, force_proxy_type.clone())
-			else {
-				return (call, Some(signer));
-			};
-			if !def.delay.is_zero() || !Self::proxy_call_is_allowed(&def, inner_call.as_ref()) {
-				return (call, Some(signer));
-			}
+			match proxy_call {
+				pallet_proxy::Call::proxy { real, force_proxy_type, call: inner_call } => {
+					let Ok(real) = T::Lookup::lookup(real.clone()) else {
+						return (call, Some(signer));
+					};
 
-			return Self::validated_pool_key_context(inner_call.as_ref(), Some(real));
+					return Self::validated_proxy_pool_key_context(
+						call,
+						Some(signer.clone()),
+						real,
+						signer,
+						force_proxy_type.clone(),
+						inner_call.as_ref(),
+					);
+				},
+				pallet_proxy::Call::proxy_announced {
+					delegate,
+					real,
+					force_proxy_type,
+					call: inner_call,
+				} => {
+					let Ok(delegate) = T::Lookup::lookup(delegate.clone()) else {
+						return (call, Some(signer));
+					};
+					let Ok(real) = T::Lookup::lookup(real.clone()) else {
+						return (call, Some(signer));
+					};
+
+					return Self::validated_proxy_pool_key_context(
+						call,
+						Some(signer),
+						real,
+						delegate,
+						force_proxy_type.clone(),
+						inner_call.as_ref(),
+					);
+				},
+				_ => {},
+			}
 		}
 
 		(call, Some(signer))
+	}
+
+	fn validated_proxy_pool_key_context<'a>(
+		call: &'a RuntimeCallOf<T>,
+		fallback_signer: Option<T::AccountId>,
+		real: <T as frame_system::Config>::AccountId,
+		delegate: <T as frame_system::Config>::AccountId,
+		force_proxy_type: Option<T::ProxyType>,
+		inner_call: &'a RuntimeCallOf<T>,
+	) -> (&'a RuntimeCallOf<T>, Option<T::AccountId>) {
+		let Ok(def) = pallet_proxy::Pallet::<T>::find_proxy(&real, &delegate, force_proxy_type)
+		else {
+			return (call, fallback_signer);
+		};
+		if !def.delay.is_zero() || !Self::proxy_call_is_allowed(&def, inner_call) {
+			return (call, fallback_signer);
+		}
+
+		Self::validated_pool_key_context(inner_call, Some(real))
 	}
 
 	fn proxy_call_is_allowed(

--- a/pallets/fee_control/src/test.rs
+++ b/pallets/fee_control/src/test.rs
@@ -22,7 +22,10 @@ use crate::mock::{
 use frame_support::dispatch::DispatchInfo;
 use frame_system::RawOrigin;
 use pallet_prelude::frame_support::traits::Currency;
-use sp_runtime::{traits::DispatchTransaction, transaction_validity::TransactionSource};
+use sp_runtime::{
+	traits::{DispatchTransaction, Hash},
+	transaction_validity::TransactionSource,
+};
 
 #[test]
 fn skip_feeless_payment_works() {
@@ -232,6 +235,42 @@ fn validate_keeps_general_pool_key_for_valid_proxy() {
 			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension)
 				.validate_only(
 					Some(delegate).into(),
+					&call,
+					&DispatchInfo::default(),
+					0,
+					TransactionSource::External,
+					0,
+				)
+				.unwrap();
+
+		assert_eq!(res.provides, vec![(b"general", 7u32).encode()]);
+	});
+}
+
+#[test]
+fn validate_keeps_general_pool_key_for_valid_announced_proxy() {
+	new_test_ext().execute_with(|| {
+		let real = 7u64;
+		let delegate = 1u64;
+		let relayer = 99u64;
+		let inner_call = RuntimeCall::DummyPallet(Call::<Test>::pooled { key: 7 });
+		let call_hash = <Test as pallet_proxy::Config>::CallHasher::hash_of(&inner_call);
+		set_argons(real, 1_000_000u128);
+		set_argons(delegate, 1_000_000u128);
+		set_argons(relayer, 1_000_000u128);
+		assert_ok!(Proxy::add_proxy(Some(real).into(), delegate, ProxyType::Any, 0,));
+		assert_ok!(Proxy::announce(Some(delegate).into(), real, call_hash));
+
+		let call = RuntimeCall::Proxy(pallet_proxy::Call::<Test>::proxy_announced {
+			delegate: delegate.into(),
+			real: real.into(),
+			force_proxy_type: None,
+			call: Box::new(inner_call),
+		});
+		let (res, _, _) =
+			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension)
+				.validate_only(
+					Some(relayer).into(),
 					&call,
 					&DispatchInfo::default(),
 					0,


### PR DESCRIPTION
## Summary
- handle proxy_announced when deriving general tx-pool keys
- keep the shared proxy validation logic in one helper
- add a regression test for the announced proxy path

## Why
The recent initialize_for collision guard depended on a general tx-pool key. Direct proxy calls published that key, but proxy_announced calls did not, which left a bypass for the same logical request through the delayed-proxy path.

## Testing
- cargo test -p pallet-fee-control validate_keeps_general_pool_key_for_valid_proxy -- --nocapture
- cargo test -p pallet-fee-control validate_keeps_general_pool_key_for_valid_announced_proxy -- --nocapture
- cargo make fmt