### PR TITLE
Keep price index updates flowing when Uniswap pools have no usable liquidity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,7 @@ dependencies = [
 name = "argon-oracle"
 version = "1.4.3"
 dependencies = [
+ "alloy-contract",
  "alloy-eips",
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,6 +254,7 @@ uniswap-v3-sdk = { version = "5.2.1", default-features = false }
 uniswap-lens = { version = "0.15.0" }
 alloy-primitives = { version = "1.3", default-features = false }
 alloy-sol-types = { version = "1.5", default-features = false }
+alloy-contract = { version = "1.0.42" }
 alloy-provider = { version = "1.0.42" }
 alloy-transport = { version = "1.0.42" }
 alloy-eips = { version = "1.0.42" }

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -38,6 +38,7 @@ dotenv = { workspace = true }
 lazy_static = { workspace = true }
 
 alloy-primitives = { workspace = true }
+alloy-contract = { workspace = true }
 alloy-eips = { workspace = true }
 alloy-transport = { workspace = true }
 alloy-provider = { workspace = true }

--- a/oracle/src/argonot_price.rs
+++ b/oracle/src/argonot_price.rs
@@ -7,17 +7,23 @@ use uniswap_sdk_core::{prelude::*, token};
 
 #[allow(dead_code)]
 pub struct ArgonotPriceLookup {
+	pub last_price: FixedU128,
 	pub uniswap_oracle: UniswapOracle,
 }
 
 impl ArgonotPriceLookup {
-	pub async fn new(project_id: String, usd_token: Token, lookup_token: Token) -> Result<Self> {
+	pub async fn new(
+		project_id: String,
+		usd_token: Token,
+		lookup_token: Token,
+		last_price: FixedU128,
+	) -> Result<Self> {
 		let uniswap_oracle = UniswapOracle::new(project_id, usd_token, lookup_token).await?;
 
-		Ok(Self { uniswap_oracle })
+		Ok(Self { last_price, uniswap_oracle })
 	}
 
-	pub async fn from_env() -> Result<Self> {
+	pub async fn from_env(last_price: FixedU128) -> Result<Self> {
 		let use_sepolia = env::var("USE_SEPOLIA").unwrap_or_default() == "true";
 		let argonot_token_address =
 			env::var("ARGONOT_TOKEN_ADDRESS").expect("ARGONOT_TOKEN_ADDRESS must be set");
@@ -26,12 +32,57 @@ impl ArgonotPriceLookup {
 
 		let usdc_token = get_usdc_token(network);
 		let lookup_token = token!(network as u64, argonot_token_address, 18);
-		Self::new(project_id, usdc_token, lookup_token).await
+		Self::new(project_id, usdc_token, lookup_token, last_price).await
 	}
 
-	pub async fn get_latest_price(&self, usd_token_price: FixedU128) -> Result<FixedU128> {
+	pub async fn get_latest_price(&mut self, usd_token_price: FixedU128) -> Result<FixedU128> {
 		let price = self.uniswap_oracle.get_current_price().await?;
 		// ARGONOT/USDC * USDC/USD = ARGONOT/USD
-		Ok(price.price * usd_token_price)
+		let price = price.price * usd_token_price;
+		self.last_price = price;
+		Ok(price)
+	}
+
+	pub fn hold_last_price(&self) -> FixedU128 {
+		self.last_price
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::uniswap_oracle::{PriceAndLiquidity, use_mock_uniswap_prices};
+	use std::str::FromStr;
+
+	const DAI_ADDRESS_SEPOLIA: &str = "6b175474e89094c44da98b954eedeac495271d0f";
+
+	fn before_each() {
+		dotenv::dotenv().ok();
+		unsafe {
+			env::set_var("USE_SEPOLIA", "true");
+			env::set_var("INFURA_PROJECT_ID", "test");
+			env::set_var("ARGONOT_TOKEN_ADDRESS", DAI_ADDRESS_SEPOLIA);
+		}
+	}
+
+	#[tokio::test]
+	async fn holds_last_price_without_resetting_it() {
+		before_each();
+		let mut argonot_price_lookup =
+			ArgonotPriceLookup::from_env(FixedU128::from_float(0.017)).await.unwrap();
+
+		let argonot_usdc_price = FixedU128::from_float(0.02);
+		let address = Address::from_str(DAI_ADDRESS_SEPOLIA).unwrap();
+		use_mock_uniswap_prices(
+			address,
+			vec![PriceAndLiquidity { price: argonot_usdc_price, liquidity: 100_000_000 }],
+		);
+
+		let latest = argonot_price_lookup
+			.get_latest_price(FixedU128::from_float(0.99))
+			.await
+			.unwrap();
+		assert_eq!(latest, FixedU128::from_float(0.0198));
+		assert_eq!(argonot_price_lookup.hold_last_price(), FixedU128::from_float(0.0198));
 	}
 }

--- a/oracle/src/price_index.rs
+++ b/oracle/src/price_index.rs
@@ -11,8 +11,10 @@ use tokio::{join, time::sleep};
 use tracing::info;
 
 use crate::{
-	argon_price, argonot_price, coin_usd_prices, coin_usd_prices::PriceProviderKind,
-	uniswap_oracle::PriceAndLiquidity, us_cpi::UsCpiRetriever,
+	argon_price, argonot_price, coin_usd_prices,
+	coin_usd_prices::PriceProviderKind,
+	uniswap_oracle::{PriceAndLiquidity, UniswapOracleError},
+	us_cpi::UsCpiRetriever,
 };
 use argon_client::{
 	FetchAt, MainchainClient, ReconnectingClient,
@@ -88,6 +90,10 @@ pub async fn price_index_loop(
 		.as_ref()
 		.map(|a| from_api_fixed_u128(a.argon_usd_target_price.clone()))
 		.unwrap_or(FixedU128::one());
+	let last_argonot_price = last_price
+		.as_ref()
+		.map(|a| from_api_fixed_u128(a.argonot_usd_price.clone()))
+		.unwrap_or(FixedU128::zero());
 
 	let mut min_sleep_duration = Duration::from_millis(ticker.tick_duration_millis)
 		.saturating_sub(Duration::from_secs(10))
@@ -102,7 +108,8 @@ pub async fn price_index_loop(
 
 	let mut argon_price_lookup =
 		argon_price::ArgonPriceLookup::from_env(&ticker, last_price).await?;
-	let argonot_price_lookup = argonot_price::ArgonotPriceLookup::from_env().await?;
+	let mut argonot_price_lookup =
+		argonot_price::ArgonotPriceLookup::from_env(last_argonot_price).await?;
 
 	info!("Oracle Started.");
 	let account_id = signer.account_id();
@@ -140,7 +147,16 @@ pub async fn price_index_loop(
 		let argon_usd_price = match price_result {
 			Ok(x) => x,
 			Err(e) =>
-				if is_test {
+				if should_use_argon_pool_fallback(&e) {
+					let fallback_price =
+						target_price.saturating_sub(FixedU128::from_rational(2, 1000));
+					tracing::warn!(
+						"Couldn't update argon prices because no usable pool liquidity was available. Using target fallback {:?} with zero liquidity: {:?}",
+						fallback_price,
+						e
+					);
+					PriceAndLiquidity { price: fallback_price, liquidity: 0 }
+				} else if is_test {
 					tracing::warn!(
 						"Couldn't update argon prices. Using target {} {:?}",
 						target_price,
@@ -163,8 +179,13 @@ pub async fn price_index_loop(
 					tracing::warn!("Couldn't update argonot prices, using default of 0 {:?}", e);
 					FixedU128::zero()
 				} else {
-					tracing::warn!("Couldn't update argonot prices {:?}", e);
-					continue;
+					let held_price = argonot_price_lookup.hold_last_price();
+					tracing::warn!(
+						"Couldn't update argonot prices, using last price {:?}: {:?}",
+						held_price,
+						e
+					);
+					held_price
 				},
 		};
 
@@ -290,6 +311,15 @@ pub async fn price_index_loop_from_file(
 	}
 }
 
+fn should_use_argon_pool_fallback(error: &anyhow::Error) -> bool {
+	error.chain().any(|cause| {
+		matches!(
+			cause.downcast_ref::<UniswapOracleError>(),
+			Some(UniswapOracleError::NoPoolData | UniswapOracleError::NoActiveLiquidity)
+		)
+	})
+}
+
 /// Truncates a FixedU128 value to the specified number of decimal places.
 /// For example, trunc_fixed_u128(value, 3) will truncate to 3 decimal places.
 fn trunc_fixed_u128(value: FixedU128, decimals: u16) -> FixedU128 {
@@ -318,7 +348,7 @@ mod tests {
 	use crate::{
 		coin_usd_prices::{PriceLookups, use_mock_price_lookups},
 		price_index_loop,
-		uniswap_oracle::{PriceAndLiquidity, use_mock_uniswap_prices},
+		uniswap_oracle::{PriceAndLiquidity, UniswapOracleError, use_mock_uniswap_prices},
 		us_cpi::use_mock_cpi_values,
 	};
 
@@ -397,5 +427,19 @@ mod tests {
 			}
 		}
 		assert!(counter >= 3);
+	}
+
+	#[test]
+	fn only_uses_pool_fallback_for_pool_down_errors() {
+		let no_pool_data = anyhow::Error::new(UniswapOracleError::NoPoolData)
+			.context("wrapped higher in the price pipeline");
+		assert!(super::should_use_argon_pool_fallback(&no_pool_data));
+
+		let no_active_liquidity = anyhow::Error::new(UniswapOracleError::NoActiveLiquidity)
+			.context("wrapped higher in the price pipeline");
+		assert!(super::should_use_argon_pool_fallback(&no_active_liquidity));
+
+		let other_error = anyhow::anyhow!("some other uniswap failure");
+		assert!(!super::should_use_argon_pool_fallback(&other_error));
 	}
 }

--- a/oracle/src/uniswap_oracle.rs
+++ b/oracle/src/uniswap_oracle.rs
@@ -1,3 +1,4 @@
+use alloy_contract::Error as ContractError;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{address, aliases::I56};
 use alloy_provider::{RootProvider, network::Ethereum};
@@ -9,7 +10,7 @@ use argon_primitives::{
 use polkadot_sdk::*;
 use sdk_core::prelude::*;
 use sp_runtime::FixedU128;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 use tokio::sync::Mutex;
 use tracing::{error, trace, warn};
 use uniswap_lens::bindings::iuniswapv3pool::IUniswapV3Pool::IUniswapV3PoolInstance;
@@ -51,6 +52,23 @@ pub struct PriceAndLiquidity {
 	pub price: FixedU128,
 	pub liquidity: Balance,
 }
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum UniswapOracleError {
+	NoPoolData,
+	NoActiveLiquidity,
+}
+
+impl fmt::Display for UniswapOracleError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::NoPoolData => write!(f, "No pool data across available fee tiers"),
+			Self::NoActiveLiquidity => write!(f, "No active liquidity across available fee tiers"),
+		}
+	}
+}
+
+impl std::error::Error for UniswapOracleError {}
 
 impl UniswapOracle {
 	pub async fn new(project_id: String, usd_token: Token, lookup_token: Token) -> Result<Self> {
@@ -105,10 +123,18 @@ impl UniswapOracle {
 
 	async fn get_active_liquidity_reserves(&self, fee: FeeAmount) -> Result<(U256, U256)> {
 		let pool = self.get_cached_pool_contract(fee).await?;
-		let slot0 = pool.slot0().call().await?;
+		let slot0 = match pool.slot0().call().await {
+			Ok(slot0) => slot0,
+			Err(ContractError::ZeroData(..)) => return Err(UniswapOracleError::NoPoolData.into()),
+			Err(e) => return Err(e.into()),
+		};
 
 		let tick = slot0.tick;
-		let liquidity_u128: u128 = pool.liquidity().call().await?;
+		let liquidity_u128: u128 = match pool.liquidity().call().await {
+			Ok(liquidity) => liquidity,
+			Err(ContractError::ZeroData(..)) => return Err(UniswapOracleError::NoPoolData.into()),
+			Err(e) => return Err(e.into()),
+		};
 
 		let spacing = fee.tick_spacing();
 		let tick_lower = tick - (tick % spacing);
@@ -146,11 +172,10 @@ impl UniswapOracle {
 		let result = loop {
 			match pool_contract.observe(vec![time_window_seconds, 0]).block(block_id).call().await {
 				Ok(res) => break res,
+				Err(ContractError::ZeroData(..)) =>
+					return Err(UniswapOracleError::NoPoolData.into()),
 				Err(e) => {
 					let error_msg = format!("{e:?}");
-					if error_msg.contains("ZeroData") {
-						return Err(anyhow!("No data for fee tier {fee:?}: {e:?}"));
-					}
 					if error_msg.contains("execution reverted: OLD") {
 						if backup_second_options.is_empty() {
 							return Err(anyhow!("All time windows exhausted for fee tier {fee:?}"));
@@ -203,14 +228,25 @@ impl UniswapOracle {
 		let mut total_numerator = BigInt::zero();
 		let mut total_denominator = BigInt::zero();
 		let mut total_liquidity = BigInt::zero();
+		let mut no_pool_data_fee_tiers = 0usize;
+		let mut successful_fee_tiers = 0usize;
+		let mut had_other_errors = false;
 
 		for &fee in &self.fee_tiers {
 			match self.get_twap_and_liquidity_basis(fee).await {
 				Err(e) => {
+					let oracle_error =
+						e.chain().find_map(|cause| cause.downcast_ref::<UniswapOracleError>());
+					if matches!(oracle_error, Some(UniswapOracleError::NoPoolData)) {
+						no_pool_data_fee_tiers += 1;
+						continue;
+					}
+					had_other_errors = true;
 					warn!(fee = ?fee, message = e.to_string(), "Could not get TWAP and liquidity basis for fee tier, skipping");
 					continue;
 				},
 				Ok((price, current_liquidity)) => {
+					successful_fee_tiers += 1;
 					trace!(
 						fee = ?fee,
 						price = %price.to_fixed(3, None),
@@ -225,6 +261,12 @@ impl UniswapOracle {
 		}
 
 		if total_denominator == BigInt::zero() {
+			if no_pool_data_fee_tiers == self.fee_tiers.len() {
+				return Err(UniswapOracleError::NoPoolData.into());
+			}
+			if !had_other_errors && successful_fee_tiers > 0 && total_liquidity == BigInt::zero() {
+				return Err(UniswapOracleError::NoActiveLiquidity.into());
+			}
 			return Ok(None);
 		}
 


### PR DESCRIPTION
## Summary

This updates the oracle so the price index can keep submitting when the Uniswap pools stop providing usable liquidity.

For Argon, if the pools have no pool data or no active liquidity, the oracle now submits `target - 0.002` with zero liquidity instead of letting the price index go stale. This means bitcoins will not mint in this scenario, but also aren't given advantage to try to capture price arbitrage.

For Argonot, if any pool lookup fails, the oracle now reuses the last valid price instead of skipping the entire price index update.

## Why

We saw the current production failure mode where Uniswap calls still succeed, but the pools have zero usable liquidity. In that case the oracle was not getting a final price and stopped submitting updates on-chain.

That stale price index then caused downstream issues like vault capital not activating.

## Behavior

- Argon with no pool data: use `target - 0.002` and zero liquidity
- Argon with no active liquidity: use `target - 0.002` and zero liquidity
- Argonot lookup failure: reuse the last submitted Argonot price
- Other Uniswap and RPC errors: keep the existing skip behavior
