### PR TITLE
fix(consensus): keep pruned sync blocks off best

### DIFF
--- a/node/consensus/src/import_queue.rs
+++ b/node/consensus/src/import_queue.rs
@@ -254,7 +254,15 @@ impl<B: BlockT> ImportContext<B> {
 	}
 
 	fn has_state_or_block(&self) -> bool {
-		!self.skip_execution_checks
+		if self.skip_execution_checks {
+			return false;
+		}
+
+		if self.state_action == ImportStateAction::ExecuteIfPossible {
+			return self.is_parent_state_available();
+		}
+
+		true
 	}
 
 	fn has_state_import(&self) -> bool {

--- a/node/consensus/src/import_queue_test.rs
+++ b/node/consensus/src/import_queue_test.rs
@@ -540,6 +540,11 @@ async fn test_execute_if_possible_initial_sync_block_with_pruned_parent_is_not_d
 	assert_eq!(pending_import_count(&importer).await, 0);
 	assert_eq!(client.status(child_hash).unwrap(), BlockStatus::InChain);
 	assert!(!has_state(&client, child_hash));
+	assert_eq!(
+		client.info().best_hash,
+		genesis_hash,
+		"pruned initial-sync import should not become best before state is available",
+	);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Only treat ExecuteIfPossible imports as best-eligible when the parent state is available. This restores the old guard that prevents initial-sync pruned imports from becoming the best head before state can be imported.