### PR TITLE
ci: split sync tests into dedicated workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -137,11 +137,3 @@ jobs:
           RUST_LOG: info
           CI: true
           SQLX_OFFLINE: ${{ startsWith(matrix.os, 'macos') }}
-
-      - name: Run sync tests
-        if: github.ref == 'refs/heads/main' && startsWith(matrix.os, 'ubuntu')
-        run: "cargo test -p end-to-end sync:: -- --ignored --test-threads=1 --nocapture"
-        env:
-          ARGON_LONG_SYNC_STATE_DIR: ${{ runner.temp }}/argon-long-sync-state
-          CI: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Build Edge Docker Images
   push:
     branches:
       - main
+      - 'fix_sync_*'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,89 @@
+name: Sync
+on:
+  workflow_run:
+    workflows:
+      - Build Edge Docker Images
+    types:
+      - completed
+    branches:
+      - main
+      - 'fix_sync_*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  sync:
+    name: Sync
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Free Disk Space
+        uses: ./.github/templates/clear-space
+
+      - uses: ikalnytskyi/action-setup-postgres@v7
+      - uses: ./.github/templates/minio
+
+      - name: Install linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libssl-dev llvm libclang-dev libudev-dev protobuf-compiler pkg-config
+          echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
+
+      - uses: ./.github/templates/rust-cache
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: cargo-x86_64-unknown-linux-gnu
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: 'false'
+          target: x86_64-unknown-linux-gnu
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: sqlx-cli@0.8.3
+
+      - name: Migrate Notary Db
+        working-directory: notary
+        run: cargo sqlx database setup
+
+      - name: Create and Set Database URL
+        working-directory: localchain
+        run: |
+          touch ${{ runner.temp }}/temp.db
+          chmod 777 ${{ runner.temp }}/temp.db
+          echo "DATABASE_URL=sqlite://${{ runner.temp }}/temp.db" > .env
+          cat .env
+
+      - name: Migrate Localchain Db
+        working-directory: localchain
+        run: cargo sqlx database setup
+
+      - name: Run normal sync tests
+        run: cargo test -p end-to-end sync::test_normal_ -- --ignored --test-threads=1 --nocapture
+        env:
+          ARGON_LONG_SYNC_STATE_DIR: ${{ runner.temp }}/argon-long-sync-state
+          CI: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run soak sync tests
+        run: cargo test -p end-to-end sync::test_soak_ -- --ignored --test-threads=1 --nocapture
+        env:
+          ARGON_LONG_SYNC_STATE_DIR: ${{ runner.temp }}/argon-long-sync-state
+          CI: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/end-to-end/src/sync.rs
+++ b/end-to-end/src/sync.rs
@@ -18,7 +18,7 @@ use std::{
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn test_fast_sync_smoke_catches_up_to_notebook_history() {
+async fn test_normal_fast_sync_smoke_catches_up_to_notebook_history() {
 	let mut source_args = ArgonNodeStartArgs::new("alice", 0, "").unwrap();
 	let archive_bucket = ArgonTestNotary::create_archive_bucket();
 	let archive_host = format!("{}/{}", ArgonTestNotary::get_minio_url(), archive_bucket.clone());
@@ -51,28 +51,28 @@ async fn test_fast_sync_smoke_catches_up_to_notebook_history() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[ignore = "sync recovery scenario runs in the sync action"]
-async fn test_fast_sync_catches_up_to_mixed_history() {
+async fn test_normal_fast_sync_catches_up_to_mixed_history() {
 	assert_basic_sync_mode_catches_up("fast").await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[ignore = "sync recovery scenario runs in the sync action"]
-async fn test_warp_sync_catches_up_to_mixed_history() {
+async fn test_normal_warp_sync_catches_up_to_mixed_history() {
 	assert_basic_sync_mode_catches_up("warp").await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[ignore = "sync recovery scenario runs in the sync action"]
-async fn test_fast_sync_recovers_after_notebook_archive_delay() {
+async fn test_normal_fast_sync_recovers_after_notebook_archive_delay() {
 	assert_sync_mode_recovers_after_notebook_archive_delay("fast").await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[ignore = "sync recovery scenario runs in the sync action"]
-async fn test_warp_sync_recovers_after_notebook_archive_delay() {
+async fn test_normal_warp_sync_recovers_after_notebook_archive_delay() {
 	assert_sync_mode_recovers_after_notebook_archive_delay("warp").await;
 }
 
@@ -86,7 +86,7 @@ async fn test_warp_sync_recovers_after_state_sync_restart() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[ignore = "slow live sync soak"]
-async fn test_long_running_network_late_node_catches_up() {
+async fn test_soak_late_node_catches_up() {
 	let settings = SyncSoakSettings::from_env();
 	let mut harness = SyncHarness::start().await;
 	harness.assert_warmup_history_window(settings.warmup_finalized_blocks).await;
@@ -106,7 +106,7 @@ async fn test_long_running_network_late_node_catches_up() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[ignore = "slow live sync soak"]
-async fn test_long_running_network_recovers_after_notary_outage() {
+async fn test_soak_recovers_after_notary_outage() {
 	let settings = SyncSoakSettings::from_env();
 	let mut harness = SyncHarness::start().await;
 	harness.assert_warmup_history_window(settings.warmup_finalized_blocks).await;
@@ -271,7 +271,8 @@ async fn assert_node_matches_snapshot(
 	context: &str,
 ) {
 	let latest_finalized = node.client.latest_finalized_block_hash().await.unwrap();
-	let latest_finalized_number = node.client.block_number(latest_finalized.hash()).await.unwrap();
+	let latest_finalized_hash = latest_finalized.hash();
+	let latest_finalized_number = node.client.block_number(latest_finalized_hash).await.unwrap();
 	assert!(
 		latest_finalized_number >= snapshot.number,
 		"{context}: expected finalized number >= {}, got {}",
@@ -280,7 +281,7 @@ async fn assert_node_matches_snapshot(
 	);
 
 	let source_finalized_hash = header_hash_at_height(source, latest_finalized_number).await;
-	assert_eq!(source_finalized_hash, Some(latest_finalized.hash()), "{context}",);
+	assert_eq!(source_finalized_hash, Some(latest_finalized_hash), "{context}",);
 
 	let synced_target_hash = header_hash_at_height(node, snapshot.number).await;
 	assert_eq!(
@@ -297,7 +298,7 @@ async fn assert_node_matches_snapshot(
 
 		if best_number >= snapshot.number && source_best_at_height == Some(best_hash) {
 			assert_state_available_at(node, best_hash, best_number, context).await;
-			break;
+			return;
 		}
 
 		assert!(
@@ -400,15 +401,6 @@ async fn assert_sync_mode_recovers_after_notebook_archive_delay(sync_mode: &str)
 		&format!("{sync_mode} sync should recover after notebook archive delay"),
 	)
 	.await;
-	if sync_mode == "warp" {
-		assert_block_history_gap_fill_completes(
-			&sync_node,
-			&harness.source,
-			target,
-			"warp sync should complete block history after notebook archive delay",
-		)
-		.await;
-	}
 }
 
 async fn assert_warp_sync_recovers_after_state_sync_restart() {

--- a/testing/src/argon_node.rs
+++ b/testing/src/argon_node.rs
@@ -158,11 +158,7 @@ impl ArgonTestNode {
 		Ok(())
 	}
 
-	/// Restart the node with the same rpc port. NOTE: does not currently support the p2p address
-	/// too
-	///
-	/// If you want to add that, you need to capture the boot url, and also probably use
-	/// pre-generated libp2p nodeIds.
+	/// Restart the node with the same RPC port and refresh the local bootnode address.
 	pub async fn restart(&mut self, wait_duration: Duration) -> anyhow::Result<()> {
 		self.stop()?;
 		tokio::time::sleep(wait_duration).await;
@@ -170,6 +166,15 @@ impl ArgonTestNode {
 		self.proc = Some(proc);
 		self.log_watcher = log_watcher;
 		self.client = MainchainClient::from_url(self.client.url.as_str()).await?;
+		let listen_urls = self
+			.client
+			.rpc
+			.request::<Vec<String>>("system_localListenAddresses", RpcParams::new())
+			.await?;
+		self.boot_url = listen_urls
+			.into_iter()
+			.find(|address| address.contains("127.0.0.1"))
+			.expect("should have a localhost ip");
 		Ok(())
 	}
 


### PR DESCRIPTION
Move ignored sync recovery and soak tests out of the regular check workflow so they can run after the Docker image build path. Keep the fast sync smoke coverage in normal tests and refresh restarted test nodes' boot address so forked sync nodes do not use stale peer addresses.