### PR TITLE
feat: erc20 gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules
 /.port-lock
 /state.raw
 /.claude/worktrees
+chains/ethereum/contracts/artifacts/
+chains/ethereum/contracts/cache/
+chains/ethereum/contracts/deployments/default/

--- a/bitcoin/nodejs/ts/__test__/CosignScript.test.ts
+++ b/bitcoin/nodejs/ts/__test__/CosignScript.test.ts
@@ -295,7 +295,7 @@ describe.skipIf(SKIP_E2E)('Bitcoin Bindings test', { retry: 0, timeout: 60e3 }, 
     expect(tx.blockHash).toBeTruthy();
     console.log('Cosign transaction included in block:', tx.blockHash);
     const blockHeight = await vaulterClient
-      .at(tx.blockHash!)
+      .at(tx.blockHash)
       .then(x => x.query.system.number())
       .then(x => x.toNumber());
     console.log('Cosign transaction block height:', blockHeight);

--- a/bitcoin/nodejs/ts/wasm/bitcoin_bindings.d.ts
+++ b/bitcoin/nodejs/ts/wasm/bitcoin_bindings.d.ts
@@ -2,30 +2,71 @@
 /* eslint-disable */
 
 export enum BitcoinNetwork {
-    /**
-     * Mainnet Bitcoin.
-     */
-    Bitcoin = 0,
-    /**
-     * Bitcoin's testnet network.
-     */
-    Testnet = 1,
-    /**
-     * Bitcoin's signet network
-     */
-    Signet = 2,
-    /**
-     * Bitcoin's regtest network.
-     */
-    Regtest = 3,
+  /**
+   * Mainnet Bitcoin.
+   */
+  Bitcoin = 0,
+  /**
+   * Bitcoin's testnet network.
+   */
+  Testnet = 1,
+  /**
+   * Bitcoin's signet network
+   */
+  Signet = 2,
+  /**
+   * Bitcoin's regtest network.
+   */
+  Regtest = 3,
 }
 
-export function calculateFee(vault_pubkey_hex: string, vault_claim_pubkey_hex: string, owner_pubkey_hex: string, vault_claim_height: bigint, open_claim_height: bigint, created_at_height: bigint, bitcoin_network: BitcoinNetwork, fee_rate_sats_per_vb: bigint, to_script_pubkey: string): bigint;
+export function calculateFee(
+  vault_pubkey_hex: string,
+  vault_claim_pubkey_hex: string,
+  owner_pubkey_hex: string,
+  vault_claim_height: bigint,
+  open_claim_height: bigint,
+  created_at_height: bigint,
+  bitcoin_network: BitcoinNetwork,
+  fee_rate_sats_per_vb: bigint,
+  to_script_pubkey: string,
+): bigint;
 
-export function createCosignPubkey(vault_pubkey_hex: string, vault_claim_pubkey_hex: string, owner_pubkey_hex: string, vault_claim_height: bigint, open_claim_height: bigint, created_at_height: bigint, bitcoin_network: BitcoinNetwork): string;
+export function createCosignPubkey(
+  vault_pubkey_hex: string,
+  vault_claim_pubkey_hex: string,
+  owner_pubkey_hex: string,
+  vault_claim_height: bigint,
+  open_claim_height: bigint,
+  created_at_height: bigint,
+  bitcoin_network: BitcoinNetwork,
+): string;
 
-export function getCosignPsbt(txid: string, vout: number, satoshis: bigint, vault_pubkey_hex: string, vault_claim_pubkey_hex: string, owner_pubkey_hex: string, vault_claim_height: bigint, open_claim_height: bigint, created_at_height: bigint, bitcoin_network: BitcoinNetwork, to_script_pubkey_hex: string, bitcoin_network_fee: bigint): string;
+export function getCosignPsbt(
+  txid: string,
+  vout: number,
+  satoshis: bigint,
+  vault_pubkey_hex: string,
+  vault_claim_pubkey_hex: string,
+  owner_pubkey_hex: string,
+  vault_claim_height: bigint,
+  open_claim_height: bigint,
+  created_at_height: bigint,
+  bitcoin_network: BitcoinNetwork,
+  to_script_pubkey_hex: string,
+  bitcoin_network_fee: bigint,
+): string;
 
-export function signPsbt(psbt_hex: string, bitcoin_network: BitcoinNetwork, private_key_hex: string, finalize: boolean): string;
+export function signPsbt(
+  psbt_hex: string,
+  bitcoin_network: BitcoinNetwork,
+  private_key_hex: string,
+  finalize: boolean,
+): string;
 
-export function signPsbtDerived(psbt_hex: string, xpriv_b58: string, xpriv_hd_path: string, finalize: boolean): string;
+export function signPsbtDerived(
+  psbt_hex: string,
+  xpriv_b58: string,
+  xpriv_hd_path: string,
+  finalize: boolean,
+): string;

--- a/chains/ethereum/README.md
+++ b/chains/ethereum/README.md
@@ -1,0 +1,8 @@
+# Ethereum Chain Integration
+
+Ethereum-specific offchain and EVM integration code lives here.
+
+- `contracts/`: canonical token and Minting Gateway contracts, tests, deployments, and bootstrap
+  setup.
+- recovery research and migration tooling now live in the separate
+  `argonprotocol/hyperbridge-recovery` repository.

--- a/chains/ethereum/contracts/README.md
+++ b/chains/ethereum/contracts/README.md
@@ -1,0 +1,174 @@
+# Ethereum Contracts
+
+This package holds the Ethereum-side contracts for the replacement Argon and Argonot tokens.
+
+At a high level, the shape is:
+
+- the tokens are plain ERC-20s
+- the tokens trust one gateway address forever
+- that gateway address is a proxy, so the gateway logic can change without changing the address the
+  tokens trust
+- the gateway handles the protocol behavior: burns for transfer and the current admin batch mint
+  path
+- a guardian can pause immediately
+- the admin Safe owns gateway actions and upgrades today
+
+## Visual Overview
+
+```text
+Users ----------------------> MintingGateway proxy ----------------------> ArgonToken / ArgonotToken
+Guardian Safe -------------> pause()
+Admin Safe ---------------> proxy upgrade / adminMintBatch / unpause
+Admin Safe ---------------> ProxyAdmin --------> upgrade gateway implementation
+
+The tokens only trust the proxy address.
+The proxy runs MintingGateway implementation code behind that stable address.
+```
+
+At the basic level, that is the whole shape:
+
+- users and admins talk to the gateway
+- the gateway talks to the tokens
+- the tokens trust one gateway address forever
+- the gateway code can still change later because that address is a proxy
+- emergency pause is separated from the normal admin path
+
+## Contracts
+
+- `ArgonToken.sol`
+- `ArgonotToken.sol`
+- `MintingGateway.sol`
+
+The two token contracts are intentionally boring. They expose `mint(...)` and `burnFrom(...)`, but
+only the gateway can call them. They do not have their own role system, and they do not expose a
+public self-burn path.
+
+The gateway is where the actual protocol behavior lives:
+
+- every gateway amount is expressed in 6-decimal Argon runtime base units
+- `burnForTransfer(...)` is the primary user path: the user first grants an exact ERC-20 allowance
+  to the gateway after the app scales the selected 6-decimal amount into 18-decimal ERC-20 units,
+  then signs the gateway transaction that burns that approved balance and emits the event Argon
+  needs for the outbound proof flow
+- `adminMintBatch(...)` is the current admin-only mint path for restoration work, and it accepts
+  the same 6-decimal runtime amounts as the burn path
+- `pause()` can be called by the guardian
+- `unpause()` stays on the admin Safe owner path
+
+In the app, that approval step can be hidden behind one "move" action. The user does not need to
+think about allowance mechanics, but the token still enforces per-user burn authorization even if
+the gateway logic changes later.
+
+## What Can Change
+
+There are only three things to keep in your head:
+
+1. The token contracts are fixed. They are plain ERC-20s, and each one is deployed with one gateway
+   address baked in.
+
+2. The gateway address is stable. The tokens keep trusting that one proxy address. They do not have
+   a `setGateway(...)` path.
+
+3. The gateway code is upgradeable. The proxy points at a `MintingGateway` implementation, and that
+   implementation can be replaced later.
+
+Today the split is:
+
+- guardian Safe: `pause()`
+- admin Safe: `adminMintBatch(...)`, `unpause()`, and the one-time bootstrap upgrade into the final
+  implementation
+- admin Safe-owned `ProxyAdmin`: gateway upgrades
+
+That is the main boundary today:
+
+- fast emergency stop through the guardian
+- normal admin actions and upgrades through the Safe
+
+The timelock is still the intended later hardening step once the contract is ready to go with a
+delayed governance flow.
+
+## Why It Is Shaped This Way
+
+The main decision here is that the token should not have a mutable trust list.
+
+We do not want a token contract that can keep changing which gateway it trusts. That is too much
+power in the wrong place, and it makes proofs, upgrades, and review harder to reason about. So the
+token takes the gateway address in its constructor and never changes it.
+
+At the same time, we probably will need to change gateway logic over time. That is why the gateway
+itself sits behind a proxy. The token keeps trusting the same address, but the logic behind that
+address can be upgraded later through governance.
+
+That split is the point of this package:
+
+- tokens stay simple and stable
+- gateway owns the moving parts
+- upgrades happen behind the gateway address, not by teaching the token to trust someone new
+
+Admin minting also goes through the gateway for the same reason. It is a temporary capability, but
+it is still part of the same authority boundary. That keeps the token surface smaller and keeps the
+current mint path in the same place as the long-term burn behavior.
+
+## Deployment Shape
+
+The deployment order still matters:
+
+1. Deploy a bootstrap `MintingGateway` implementation with zero canonical-token immutables.
+2. Deploy the gateway proxy with the admin Safe as its current `ProxyAdmin` owner.
+3. Deploy `ArgonToken` and `ArgonotToken` with the proxy address in their constructors.
+4. Deploy the final `MintingGateway` implementation with the Argon and Argonot token addresses baked
+   in as immutables.
+5. Have the admin Safe call `ProxyAdmin.upgradeAndCall(...)` once to move the proxy onto that final
+   implementation.
+
+The reverse direction does not exist: the token contracts do not have a mutable `setGateway(...)`
+path.
+
+The generated bootstrap manifest records:
+
+- the bootstrap gateway implementation address
+- the final gateway implementation address
+- the gateway proxy address
+- the proxy admin address
+- the token addresses
+- the Safe calldata needed to upgrade the proxy to the final implementation with fixed token
+  addresses
+
+See [deployments/mainnet/bootstrap/README.md](./deployments/mainnet/bootstrap/README.md) for the
+deployment handoff and [TODO.md](./TODO.md) for the remaining hardening work.
+
+## Commands
+
+Recovery-specific evidence and migration tooling now live in the separate
+`argonprotocol/hyperbridge-recovery` repository.
+
+Contract commands stay here:
+
+```sh
+yarn workspace @argonprotocol/ethereum-contracts test
+yarn workspace @argonprotocol/ethereum-contracts typecheck
+yarn workspace @argonprotocol/ethereum-contracts bootstrap:deploy --admin-safe 0x... --guardian-safe 0x...
+```
+
+Mainnet bootstrap generation uses the env-driven Hardhat 3 network config:
+
+```sh
+ETHEREUM_RPC_URL=https://...
+ETHEREUM_DEPLOYER_PRIVATE_KEY=0x...
+yarn workspace @argonprotocol/ethereum-contracts bootstrap:deploy --network mainnet --admin-safe 0x... --guardian-safe 0x...
+```
+
+## Current Scope
+
+This is still the bootstrap slice, not the full long-term mint-authority system.
+
+Today that means:
+
+- the gateway contract shape is in place
+- the stable proxy address is in place
+- the guardian pause path is in place
+- the current Safe-owned admin / upgrade path is in place
+- the admin batch mint path is in place
+- the restoration batch generator now lives in the standalone recovery repo
+- the admin mint path is still temporary
+- the restoration forensics work is still the real blocker before a mainnet mint run

--- a/chains/ethereum/contracts/TODO.md
+++ b/chains/ethereum/contracts/TODO.md
@@ -1,0 +1,14 @@
+# Ethereum Gateway TODO
+
+- [x] Ability to burn for transfer, with an event that has the data Argon needs for the outbound
+      proof flow.
+- [x] Put `MintingGateway` behind a stable proxy address and deploy canonical tokens against that
+      proxy address from the start.
+- [x] Split emergency pause from governance so a guardian can `pause()` immediately while only the
+      admin Safe can `unpause()`.
+- [ ] MintingAuthority and Council to approve new authority
+- [ ] Ability to submit mints
+- [ ] Move proxy administration from the Foundation Safe to the long-term `TimelockController` setup
+      when the governance flow is ready.
+- [ ] Monitor timelock and proxy admin for unexpected changes, and set up a process to respond to
+      them if they happen.

--- a/chains/ethereum/contracts/contracts/ArgonToken.sol
+++ b/chains/ethereum/contracts/contracts/ArgonToken.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { CanonicalMintableBurnableERC20 } from "./CanonicalMintableBurnableERC20.sol";
+
+contract ArgonToken is CanonicalMintableBurnableERC20 {
+	constructor(address gateway) CanonicalMintableBurnableERC20("Argon", "ARGN", gateway) {}
+}

--- a/chains/ethereum/contracts/contracts/ArgonotToken.sol
+++ b/chains/ethereum/contracts/contracts/ArgonotToken.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { CanonicalMintableBurnableERC20 } from "./CanonicalMintableBurnableERC20.sol";
+
+contract ArgonotToken is CanonicalMintableBurnableERC20 {
+	constructor(address gateway) CanonicalMintableBurnableERC20("Argonot", "ARGNOT", gateway) {}
+}

--- a/chains/ethereum/contracts/contracts/CanonicalMintableBurnableERC20.sol
+++ b/chains/ethereum/contracts/contracts/CanonicalMintableBurnableERC20.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+abstract contract CanonicalMintableBurnableERC20 is ERC20 {
+	error InvalidGateway(address gateway);
+	error OnlyGateway(address caller);
+
+	address public immutable gateway;
+
+	constructor(
+		string memory name_,
+		string memory symbol_,
+		address gatewayAddress
+	) ERC20(name_, symbol_) {
+		if (gatewayAddress == address(0) || gatewayAddress.code.length == 0) {
+			revert InvalidGateway(gatewayAddress);
+		}
+
+		gateway = gatewayAddress;
+	}
+
+	modifier onlyGateway() {
+		if (msg.sender != gateway) revert OnlyGateway(msg.sender);
+		_;
+	}
+
+	function mint(address to, uint256 amount) external onlyGateway {
+		_mint(to, amount);
+	}
+
+	function burnFrom(address account, uint256 amount) external onlyGateway {
+		_spendAllowance(account, msg.sender, amount);
+		_burn(account, amount);
+	}
+}

--- a/chains/ethereum/contracts/contracts/MintingGateway.sol
+++ b/chains/ethereum/contracts/contracts/MintingGateway.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { ICanonicalToken } from "./interfaces/ICanonicalToken.sol";
+
+contract MintingGateway is Initializable, OwnableUpgradeable, PausableUpgradeable {
+	uint8 public constant RUNTIME_DECIMALS = 6;
+	uint8 public constant TOKEN_DECIMALS = 18;
+	uint256 public constant RUNTIME_TO_ERC20_SCALE = 10 ** (TOKEN_DECIMALS - RUNTIME_DECIMALS);
+
+	mapping(address account => uint64 nonce) public accountNonces;
+	address public immutable argonToken;
+	address public immutable argonotToken;
+	address public guardian;
+
+	error ArrayLengthMismatch();
+	error NotGuardianOrOwner(address caller);
+	error UnsupportedToken(address token);
+	error ZeroAdminSafe();
+	error ZeroGuardian();
+	error ZeroAmount();
+	error ZeroRecipient(uint256 index);
+
+	event BurnForTransfer(
+		address indexed from,
+		address indexed token,
+		uint256 amountBaseUnits,
+		bytes32 argonDestination,
+		uint64 accountNonce
+	);
+
+	event AdminMintBatch(
+		address indexed token,
+		uint256 recipientCount,
+		uint256 totalAmountBaseUnits
+	);
+	event GuardianUpdated(address indexed previousGuardian, address indexed newGuardian);
+
+	/// @custom:oz-upgrades-unsafe-allow constructor
+	constructor(address argonTokenAddress, address argonotTokenAddress) {
+		argonToken = argonTokenAddress;
+		argonotToken = argonotTokenAddress;
+		_disableInitializers();
+	}
+
+	function initialize(address adminSafe, address guardianAddress) external initializer {
+		if (adminSafe == address(0)) revert ZeroAdminSafe();
+		if (guardianAddress == address(0)) revert ZeroGuardian();
+
+		__Ownable_init(adminSafe);
+		__Pausable_init();
+		guardian = guardianAddress;
+	}
+
+	function burnForTransfer(
+		address token,
+		uint256 amountBaseUnits,
+		bytes32 argonDestination
+	) external whenNotPaused {
+		_requireCanonicalToken(token);
+		if (amountBaseUnits == 0) revert ZeroAmount();
+
+		ICanonicalToken(token).burnFrom(msg.sender, toTokenAmount(amountBaseUnits));
+
+		uint64 accountNonce = accountNonces[msg.sender] + 1;
+		accountNonces[msg.sender] = accountNonce;
+
+		emit BurnForTransfer(msg.sender, token, amountBaseUnits, argonDestination, accountNonce);
+	}
+
+	function adminMintBatch(
+		address token,
+		address[] calldata recipients,
+		uint256[] calldata amountsBaseUnits
+	) external onlyOwner whenNotPaused {
+		_requireCanonicalToken(token);
+		if (recipients.length != amountsBaseUnits.length) revert ArrayLengthMismatch();
+
+		uint256 totalAmountBaseUnits = 0;
+
+		for (uint256 index = 0; index < recipients.length; index += 1) {
+			address recipient = recipients[index];
+			uint256 amountBaseUnits = amountsBaseUnits[index];
+
+			if (recipient == address(0)) revert ZeroRecipient(index);
+			if (amountBaseUnits == 0) revert ZeroAmount();
+
+			ICanonicalToken(token).mint(recipient, toTokenAmount(amountBaseUnits));
+			totalAmountBaseUnits += amountBaseUnits;
+		}
+
+		emit AdminMintBatch(token, recipients.length, totalAmountBaseUnits);
+	}
+
+	function pause() external {
+		if (msg.sender != guardian && msg.sender != owner()) {
+			revert NotGuardianOrOwner(msg.sender);
+		}
+
+		_pause();
+	}
+
+	function setGuardian(address guardianAddress) external onlyOwner {
+		if (guardianAddress == address(0)) revert ZeroGuardian();
+
+		address previousGuardian = guardian;
+		guardian = guardianAddress;
+
+		emit GuardianUpdated(previousGuardian, guardianAddress);
+	}
+
+	function toTokenAmount(uint256 amountBaseUnits) public pure returns (uint256) {
+		return amountBaseUnits * RUNTIME_TO_ERC20_SCALE;
+	}
+
+	function unpause() external onlyOwner {
+		_unpause();
+	}
+
+	function _requireCanonicalToken(address token) private view {
+		if (token != argonToken && token != argonotToken) revert UnsupportedToken(token);
+	}
+}

--- a/chains/ethereum/contracts/contracts/ProxyArtifacts.sol
+++ b/chains/ethereum/contracts/contracts/ProxyArtifacts.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ProxyAdmin as OpenZeppelinProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy as OpenZeppelinTransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract ProxyAdmin is OpenZeppelinProxyAdmin {
+    constructor(address initialOwner) OpenZeppelinProxyAdmin(initialOwner) {}
+}
+
+contract TransparentUpgradeableProxy is OpenZeppelinTransparentUpgradeableProxy {
+    constructor(address logic, address initialOwner, bytes memory data)
+        payable
+        OpenZeppelinTransparentUpgradeableProxy(logic, initialOwner, data)
+    {}
+}

--- a/chains/ethereum/contracts/contracts/interfaces/ICanonicalToken.sol
+++ b/chains/ethereum/contracts/contracts/interfaces/ICanonicalToken.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ICanonicalToken is IERC20 {
+	function burnFrom(address account, uint256 amount) external;
+
+	function decimals() external view returns (uint8);
+
+	function mint(address to, uint256 amount) external;
+}

--- a/chains/ethereum/contracts/deployments/hardhat/bootstrap/deployment-manifest.json
+++ b/chains/ethereum/contracts/deployments/hardhat/bootstrap/deployment-manifest.json
@@ -1,0 +1,107 @@
+{
+  "generatedAt": "2026-05-04T20:08:30.530Z",
+  "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "network": {
+    "name": "hardhat",
+    "chainId": "31337"
+  },
+  "adminSafe": "0x0000000000000000000000000000000000001234",
+  "guardianSafe": "0x0000000000000000000000000000000000005678",
+  "contracts": {
+    "argonToken": {
+      "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+      "constructorArgs": ["0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"],
+      "deploymentTxHash": "0xbb48be47d33550cc213f621c217aa510afc2aaab5f923ce7eca1d52ae2f17ab2"
+    },
+    "argonotToken": {
+      "address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
+      "constructorArgs": ["0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"],
+      "deploymentTxHash": "0x6d6e2008a74adb4c971c6a98d4e110a5bc4228c747c2c0bfa606bce930283f02"
+    },
+    "mintingGatewayImplementationBootstrap": {
+      "address": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+      "constructorArgs": [
+        "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "deploymentTxHash": "0x4e10d6ab03ccb573937048e224643833a372aa3a857e107e2d566bb79cbfbcc7"
+    },
+    "mintingGatewayImplementationFinal": {
+      "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+      "constructorArgs": [
+        "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+        "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+      ],
+      "deploymentTxHash": "0xdc971ebfa67dcfab1bb710ce549c961963544e6bcd776823a22a66567c9ba018"
+    },
+    "mintingGatewayProxy": {
+      "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+      "constructorArgs": [
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        "0x0000000000000000000000000000000000001234",
+        "0x485cc95500000000000000000000000000000000000000000000000000000000000012340000000000000000000000000000000000000000000000000000000000005678"
+      ],
+      "deploymentTxHash": "0x24cc960922b0bed65714a856ab906f0b34a21c4c364c508a0c52e902be59faf3"
+    },
+    "mintingGatewayProxyAdmin": {
+      "address": "0xCafac3dD18aC6c6e92c921884f9E4176737C052c",
+      "owner": "0x0000000000000000000000000000000000001234",
+      "deploymentTxHash": "0x24cc960922b0bed65714a856ab906f0b34a21c4c364c508a0c52e902be59faf3"
+    },
+    "mintingGateway": {
+      "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+      "constructorArgs": [
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        "0x0000000000000000000000000000000000001234",
+        "0x485cc95500000000000000000000000000000000000000000000000000000000000012340000000000000000000000000000000000000000000000000000000000005678"
+      ],
+      "deploymentTxHash": "0x24cc960922b0bed65714a856ab906f0b34a21c4c364c508a0c52e902be59faf3"
+    }
+  },
+  "runtimeBootstrap": {
+    "externalChain": {
+      "chainId": "31337",
+      "gatewayAddress": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
+    },
+    "externalChainAssets": [
+      {
+        "symbol": "ARGN",
+        "tokenAddress": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+        "gatewayAddress": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+        "decimals": 18,
+        "runtimeDecimals": 6,
+        "enabled": true
+      },
+      {
+        "symbol": "ARGNOT",
+        "tokenAddress": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
+        "gatewayAddress": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+        "decimals": 18,
+        "runtimeDecimals": 6,
+        "enabled": true
+      }
+    ],
+    "notes": [
+      "This branch does not yet include the runtime-side pallet_crosschain_transfer migration.",
+      "Use these seeded Ethereum addresses as the manifest inputs once the runtime-side state exists."
+    ]
+  },
+  "safeTransactions": [
+    {
+      "description": "Upgrade MintingGateway proxy to final implementation with fixed canonical tokens",
+      "target": "0xCafac3dD18aC6c6e92c921884f9E4176737C052c",
+      "value": "0",
+      "data": "0x9623609d000000000000000000000000e7f1725e7734ce288f8367e1bb143e90bb3f0512000000000000000000000000dc64a140aa3e981100a9beca4e685f962f0cf6c900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ],
+  "notes": [
+    "Canonical tokens are deployed with the MintingGateway proxy address fixed in their constructors.",
+    "The proxy is first deployed against a bootstrap MintingGateway implementation with zero canonical token immutables.",
+    "After the token contracts exist, the admin Safe upgrades the proxy through ProxyAdmin to the final MintingGateway implementation that has the Argon and Argonot token addresses baked in as immutables.",
+    "MintingGateway business ownership starts under the admin Safe.",
+    "The guardian Safe can pause immediately, while unpause remains on the admin Safe owner path.",
+    "The proxy admin is initially owned by the admin Safe.",
+    "A later hardening step can transfer ProxyAdmin ownership to a TimelockController once the governance flow is ready.",
+    "Long-term upgrades should happen through the stable gateway proxy address, not by rotating token trust."
+  ]
+}

--- a/chains/ethereum/contracts/deployments/mainnet/bootstrap/README.md
+++ b/chains/ethereum/contracts/deployments/mainnet/bootstrap/README.md
@@ -1,0 +1,25 @@
+# Mainnet Bootstrap Artifacts
+
+This directory is for the Ethereum-side bootstrap record that lines up the deployed contracts with
+the later Argon runtime migration.
+
+Expected generated artifacts:
+
+- `deployment-manifest.json` from
+  `yarn workspace @argonprotocol/ethereum-contracts bootstrap:deploy`
+- deployment transaction hashes and constructor arguments
+- MintingGateway bootstrap implementation address, final implementation address, proxy address, and
+  proxy admin address
+- Safe calldata to upgrade the MintingGateway proxy to the final implementation with fixed Argon and
+  Argonot token addresses
+- the Ethereum `chainId`, `MintingGateway` address, and canonical token addresses that the future
+  Argon-side runtime seeding step will need
+
+The current bootstrap slice is intentionally narrow:
+
+- `ArgonToken`
+- `ArgonotToken`
+- `MintingGateway` with `burnForTransfer(...)` and `adminMintBatch(...)`
+
+This branch does not yet include the runtime-side `pallet_crosschain_transfer` migration, so the
+bootstrap manifest here is the handoff artifact for that later step.

--- a/chains/ethereum/contracts/hardhat.config.ts
+++ b/chains/ethereum/contracts/hardhat.config.ts
@@ -1,0 +1,34 @@
+import hardhatEthers from '@nomicfoundation/hardhat-ethers';
+import { configVariable, defineConfig } from 'hardhat/config';
+
+export default defineConfig({
+  plugins: [hardhatEthers],
+  solidity: {
+    version: '0.8.24',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+      evmVersion: 'paris',
+    },
+  },
+  networks: {
+    hardhatMainnet: {
+      type: 'edr-simulated',
+      chainType: 'l1',
+    },
+    mainnet: {
+      type: 'http',
+      chainType: 'l1',
+      url: configVariable('ETHEREUM_RPC_URL'),
+      accounts: [configVariable('ETHEREUM_DEPLOYER_PRIVATE_KEY')],
+    },
+  },
+  paths: {
+    sources: './contracts',
+    tests: './test',
+    cache: './cache',
+    artifacts: './artifacts',
+  },
+});

--- a/chains/ethereum/contracts/package.json
+++ b/chains/ethereum/contracts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@argonprotocol/ethereum-contracts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "hardhat compile",
+    "tsc": "hardhat compile",
+    "tsup": "hardhat compile",
+    "typecheck": "tsc --noEmit",
+    "pretest": "hardhat compile",
+    "pretest:ci": "hardhat compile",
+    "test": "yarn pretest && yarn --cwd ../../.. exec vitest --run --config vitest.config.ts --project ethereum-contracts",
+    "bootstrap:deploy": "node --import tsx script/bootstrap/deploy.ts"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-ethers": "^4.0.10",
+    "@openzeppelin/contracts": "^5.4.0",
+    "@openzeppelin/contracts-upgradeable": "^5.4.0",
+    "@types/node": "22.17.1",
+    "ethers": "^6.15.0",
+    "hardhat": "^3.4.4",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.2"
+  },
+  "packageManager": "yarn@4.1.1"
+}

--- a/chains/ethereum/contracts/script/bootstrap/deploy.ts
+++ b/chains/ethereum/contracts/script/bootstrap/deploy.ts
@@ -1,0 +1,226 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Interface, getAddress } from 'ethers';
+import { network } from 'hardhat';
+
+const contractsRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const repoRoot = resolve(contractsRoot, '..', '..', '..');
+const ERC1967_ADMIN_SLOT = '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103';
+
+const args = parseArgs(process.argv.slice(2));
+const adminSafe = getRequiredAddress('admin-safe', 'ADMIN_SAFE_ADDRESS');
+const guardianSafe = getRequiredAddress('guardian-safe', 'GUARDIAN_SAFE_ADDRESS');
+
+async function main() {
+  const connection = await network.create(args.network);
+  try {
+    const { ethers } = connection;
+    const outputDir = resolve(
+      repoRoot,
+      args['output-dir'] ??
+        `chains/ethereum/contracts/deployments/${connection.networkName}/bootstrap`,
+    );
+
+    const [deployer] = await ethers.getSigners();
+    const connectedNetwork = await ethers.provider.getNetwork();
+
+    const gatewayImplementationFactory = await ethers.getContractFactory('MintingGateway');
+    const gatewayBootstrapImplementation = await gatewayImplementationFactory.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+    );
+    await gatewayBootstrapImplementation.waitForDeployment();
+
+    const initializeData = gatewayImplementationFactory.interface.encodeFunctionData('initialize', [
+      adminSafe,
+      guardianSafe,
+    ]);
+
+    const gatewayProxyFactory = await ethers.getContractFactory('TransparentUpgradeableProxy');
+    const gatewayProxy = await gatewayProxyFactory.deploy(
+      await gatewayBootstrapImplementation.getAddress(),
+      adminSafe,
+      initializeData,
+    );
+    await gatewayProxy.waitForDeployment();
+
+    const gatewayProxyAddress = await gatewayProxy.getAddress();
+    const proxyAdminAddress = await getProxyAdminAddress(ethers, gatewayProxyAddress);
+
+    const argonFactory = await ethers.getContractFactory('ArgonToken');
+    const argonToken = await argonFactory.deploy(gatewayProxyAddress);
+    await argonToken.waitForDeployment();
+
+    const argonotFactory = await ethers.getContractFactory('ArgonotToken');
+    const argonotToken = await argonotFactory.deploy(gatewayProxyAddress);
+    await argonotToken.waitForDeployment();
+
+    const gatewayFinalImplementation = await gatewayImplementationFactory.deploy(
+      await argonToken.getAddress(),
+      await argonotToken.getAddress(),
+    );
+    await gatewayFinalImplementation.waitForDeployment();
+
+    const proxyAdminInterface = new Interface([
+      'function upgradeAndCall(address proxy, address implementation, bytes data)',
+    ]);
+
+    const manifest = {
+      generatedAt: new Date().toISOString(),
+      deployer: deployer.address,
+      network: {
+        name: connection.networkName,
+        chainId: connectedNetwork.chainId.toString(),
+      },
+      adminSafe,
+      guardianSafe,
+      contracts: {
+        argonToken: buildContractRecord(await argonToken.getAddress(), argonToken, [
+          gatewayProxyAddress,
+        ]),
+        argonotToken: buildContractRecord(await argonotToken.getAddress(), argonotToken, [
+          gatewayProxyAddress,
+        ]),
+        mintingGatewayImplementationBootstrap: buildContractRecord(
+          await gatewayBootstrapImplementation.getAddress(),
+          gatewayBootstrapImplementation,
+          [ethers.ZeroAddress, ethers.ZeroAddress],
+        ),
+        mintingGatewayImplementationFinal: buildContractRecord(
+          await gatewayFinalImplementation.getAddress(),
+          gatewayFinalImplementation,
+          [await argonToken.getAddress(), await argonotToken.getAddress()],
+        ),
+        mintingGatewayProxy: buildContractRecord(gatewayProxyAddress, gatewayProxy, [
+          await gatewayBootstrapImplementation.getAddress(),
+          adminSafe,
+          initializeData,
+        ]),
+        mintingGatewayProxyAdmin: {
+          address: proxyAdminAddress,
+          owner: adminSafe,
+          deploymentTxHash: gatewayProxy.deploymentTransaction()?.hash ?? null,
+        },
+        mintingGateway: buildContractRecord(gatewayProxyAddress, gatewayProxy, [
+          await gatewayBootstrapImplementation.getAddress(),
+          adminSafe,
+          initializeData,
+        ]),
+      },
+      runtimeBootstrap: {
+        externalChain: {
+          chainId: connectedNetwork.chainId.toString(),
+          gatewayAddress: gatewayProxyAddress,
+        },
+        externalChainAssets: [
+          buildRuntimeAssetRecord('ARGN', await argonToken.getAddress(), gatewayProxyAddress),
+          buildRuntimeAssetRecord('ARGNOT', await argonotToken.getAddress(), gatewayProxyAddress),
+        ],
+        notes: [
+          'This branch does not yet include the runtime-side pallet_crosschain_transfer migration.',
+          'Use these seeded Ethereum addresses as the manifest inputs once the runtime-side state exists.',
+        ],
+      },
+      safeTransactions: [
+        {
+          description:
+            'Upgrade MintingGateway proxy to final implementation with fixed canonical tokens',
+          target: proxyAdminAddress,
+          value: '0',
+          data: proxyAdminInterface.encodeFunctionData('upgradeAndCall', [
+            gatewayProxyAddress,
+            await gatewayFinalImplementation.getAddress(),
+            '0x',
+          ]),
+        },
+      ],
+      notes: [
+        'Canonical tokens are deployed with the MintingGateway proxy address fixed in their constructors.',
+        'The proxy is first deployed against a bootstrap MintingGateway implementation with zero canonical token immutables.',
+        'After the token contracts exist, the admin Safe upgrades the proxy through ProxyAdmin to the final MintingGateway implementation that has the Argon and Argonot token addresses baked in as immutables.',
+        'MintingGateway business ownership starts under the admin Safe.',
+        'The guardian Safe can pause immediately, while unpause remains on the admin Safe owner path.',
+        'The proxy admin is initially owned by the admin Safe.',
+        'A later hardening step can transfer ProxyAdmin ownership to a TimelockController once the governance flow is ready.',
+        'Long-term upgrades should happen through the stable gateway proxy address, not by rotating token trust.',
+      ],
+    };
+
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(
+      join(outputDir, 'deployment-manifest.json'),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+  } finally {
+    await connection.close();
+  }
+}
+
+function buildContractRecord(
+  address: string,
+  contract: { deploymentTransaction(): { hash: string } | null },
+  constructorArgs: unknown[],
+) {
+  return {
+    address,
+    constructorArgs,
+    deploymentTxHash: contract.deploymentTransaction()?.hash ?? null,
+  };
+}
+
+function buildRuntimeAssetRecord(symbol: string, tokenAddress: string, gatewayAddress: string) {
+  return {
+    symbol,
+    tokenAddress,
+    gatewayAddress,
+    decimals: 18,
+    runtimeDecimals: 6,
+    enabled: true,
+  };
+}
+
+async function getProxyAdminAddress(
+  ethers: Awaited<ReturnType<typeof network.create>>['ethers'],
+  proxyAddress: string,
+) {
+  const raw = await ethers.provider.getStorage(proxyAddress, ERC1967_ADMIN_SLOT);
+  return getAddress(`0x${raw.slice(-40)}`);
+}
+
+function getRequiredAddress(argKey: string, envKey: string) {
+  const raw = args[argKey] ?? process.env[envKey];
+  if (!raw) {
+    throw new Error(`Missing required ${argKey} argument or ${envKey} environment variable`);
+  }
+
+  return getAddress(raw);
+}
+
+function parseArgs(argv: string[]) {
+  const parsed: Record<string, string> = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) continue;
+
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+
+    if (!next || next.startsWith('--')) {
+      parsed[key] = 'true';
+      continue;
+    }
+
+    parsed[key] = next;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+void main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/chains/ethereum/contracts/test/ArgonToken.test.ts
+++ b/chains/ethereum/contracts/test/ArgonToken.test.ts
@@ -1,0 +1,49 @@
+import { network } from 'hardhat';
+import { afterAll, describe, expect, it } from 'vitest';
+import { expectCustomError } from './assertions.js';
+
+const connection = await network.create();
+const { ethers } = connection;
+
+afterAll(async () => {
+  await connection.close();
+});
+
+describe('ArgonToken', () => {
+  it('binds to the gateway at construction time and does not expose mutable gateway setup', async () => {
+    const [, adminSafe, holder] = await ethers.getSigners();
+
+    const gatewayImplementationFactory = await ethers.getContractFactory('MintingGateway');
+    const gatewayImplementation = (await gatewayImplementationFactory.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+    )) as any;
+    await gatewayImplementation.waitForDeployment();
+
+    const initializeData = gatewayImplementationFactory.interface.encodeFunctionData('initialize', [
+      adminSafe.address,
+      adminSafe.address,
+    ]);
+
+    const gatewayProxyFactory = await ethers.getContractFactory('TransparentUpgradeableProxy');
+    const gatewayProxy = (await gatewayProxyFactory.deploy(
+      await gatewayImplementation.getAddress(),
+      adminSafe.address,
+      initializeData,
+    )) as any;
+    await gatewayProxy.waitForDeployment();
+
+    const tokenFactory = await ethers.getContractFactory('ArgonToken');
+    const token = (await tokenFactory.deploy(await gatewayProxy.getAddress())) as any;
+    await token.waitForDeployment();
+
+    expect(await token.gateway()).to.equal(await gatewayProxy.getAddress());
+    expect(token.interface.hasFunction('burn(uint256)')).to.equal(false);
+    expect(token.interface.hasFunction('setGateway(address)')).to.equal(false);
+    expect(token.interface.hasFunction('finalizeGateway()')).to.equal(false);
+
+    await expectCustomError(token.connect(holder).mint(holder.address, 1n), token, 'OnlyGateway', [
+      holder.address,
+    ]);
+  });
+});

--- a/chains/ethereum/contracts/test/MintingGateway.test.ts
+++ b/chains/ethereum/contracts/test/MintingGateway.test.ts
@@ -1,0 +1,277 @@
+import { network } from 'hardhat';
+import { afterAll, describe, expect, it } from 'vitest';
+import { expectCustomError, expectEvent } from './assertions.js';
+
+const SCALE = 1_000_000_000_000n;
+const ERC1967_ADMIN_SLOT = '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103';
+const connection = await network.create();
+const { ethers } = connection;
+
+afterAll(async () => {
+  await connection.close();
+});
+
+describe('MintingGateway', () => {
+  async function deployGatewayStack() {
+    const [, adminSafe, guardian, holder, recipient] = await ethers.getSigners();
+
+    const gatewayImplementationFactory = await ethers.getContractFactory('MintingGateway');
+    const gatewayBootstrapImplementation = (await gatewayImplementationFactory.deploy(
+      ethers.ZeroAddress,
+      ethers.ZeroAddress,
+    )) as any;
+    await gatewayBootstrapImplementation.waitForDeployment();
+
+    const initializeData = gatewayImplementationFactory.interface.encodeFunctionData('initialize', [
+      adminSafe.address,
+      guardian.address,
+    ]);
+
+    const gatewayProxyFactory = await ethers.getContractFactory('TransparentUpgradeableProxy');
+    const gatewayProxy = (await gatewayProxyFactory.deploy(
+      await gatewayBootstrapImplementation.getAddress(),
+      adminSafe.address,
+      initializeData,
+    )) as any;
+    await gatewayProxy.waitForDeployment();
+
+    const gateway = (await ethers.getContractAt(
+      'MintingGateway',
+      await gatewayProxy.getAddress(),
+    )) as any;
+
+    const proxyAdminStorage = await ethers.provider.getStorage(
+      await gatewayProxy.getAddress(),
+      ERC1967_ADMIN_SLOT,
+    );
+    const proxyAdminAddress = ethers.getAddress(`0x${proxyAdminStorage.slice(-40)}`);
+    const proxyAdmin = (await ethers.getContractAt('ProxyAdmin', proxyAdminAddress)) as any;
+
+    const argonFactory = await ethers.getContractFactory('ArgonToken');
+    const argonotFactory = await ethers.getContractFactory('ArgonotToken');
+
+    const argon = (await argonFactory.deploy(await gatewayProxy.getAddress())) as any;
+    const argonot = (await argonotFactory.deploy(await gatewayProxy.getAddress())) as any;
+    await Promise.all([argon.waitForDeployment(), argonot.waitForDeployment()]);
+
+    const gatewayFinalImplementation = (await gatewayImplementationFactory.deploy(
+      await argon.getAddress(),
+      await argonot.getAddress(),
+    )) as any;
+    await gatewayFinalImplementation.waitForDeployment();
+
+    return {
+      adminSafe,
+      guardian,
+      holder,
+      recipient,
+      gateway,
+      proxyAdmin,
+      gatewayFinalImplementation,
+      argon,
+      argonot,
+    };
+  }
+
+  async function deployFixture() {
+    const stack = await deployGatewayStack();
+
+    await stack.proxyAdmin
+      .connect(stack.adminSafe)
+      .upgradeAndCall(
+        await stack.gateway.getAddress(),
+        await stack.gatewayFinalImplementation.getAddress(),
+        '0x',
+      );
+
+    await stack.gateway
+      .connect(stack.adminSafe)
+      .adminMintBatch(await stack.argon.getAddress(), [stack.holder.address], [1_000n]);
+
+    await stack.gateway
+      .connect(stack.adminSafe)
+      .adminMintBatch(await stack.argonot.getAddress(), [stack.holder.address], [2_000n]);
+
+    return stack;
+  }
+
+  it('burns canonical tokens and increments one nonce stream per account', async () => {
+    const { argon, argonot, gateway, holder } = await deployFixture();
+    const destination = ethers.encodeBytes32String('argon-destination');
+
+    await expectCustomError(
+      gateway.connect(holder).burnForTransfer(await argon.getAddress(), 250n, destination),
+      argon,
+      'ERC20InsufficientAllowance',
+      [await gateway.getAddress(), 0n, 250n * SCALE],
+    );
+
+    await argon.connect(holder).approve(await gateway.getAddress(), 250n * SCALE);
+
+    await expectEvent(
+      gateway.connect(holder).burnForTransfer(await argon.getAddress(), 250n, destination),
+      gateway,
+      'BurnForTransfer',
+      [holder.address, await argon.getAddress(), 250n, destination, 1n],
+    );
+
+    expect(await argon.balanceOf(holder.address)).to.equal(750n * SCALE);
+    expect(await argon.allowance(holder.address, await gateway.getAddress())).to.equal(0n);
+    expect(await gateway.accountNonces(holder.address)).to.equal(1n);
+
+    await argonot.connect(holder).approve(await gateway.getAddress(), 10n * SCALE);
+
+    await expectEvent(
+      gateway.connect(holder).burnForTransfer(await argonot.getAddress(), 10n, destination),
+      gateway,
+      'BurnForTransfer',
+      [holder.address, await argonot.getAddress(), 10n, destination, 2n],
+    );
+
+    expect(await argonot.allowance(holder.address, await gateway.getAddress())).to.equal(0n);
+    expect(await gateway.accountNonces(holder.address)).to.equal(2n);
+  });
+
+  it('rejects unsupported tokens and zero-amount burns', async () => {
+    const { gateway, holder } = await deployFixture();
+    const destination = ethers.encodeBytes32String('argon-destination');
+
+    const extraTokenFactory = await ethers.getContractFactory('ArgonToken');
+    const extraToken = (await extraTokenFactory.deploy(await gateway.getAddress())) as any;
+    await extraToken.waitForDeployment();
+
+    await expectCustomError(
+      gateway.connect(holder).burnForTransfer(await extraToken.getAddress(), 1n, destination),
+      gateway,
+      'UnsupportedToken',
+      [await extraToken.getAddress()],
+    );
+
+    await expectCustomError(
+      gateway.connect(holder).burnForTransfer(await extraToken.getAddress(), 0n, destination),
+      gateway,
+      'UnsupportedToken',
+      [await extraToken.getAddress()],
+    );
+  });
+
+  it('keeps gateway owner actions on the admin safe', async () => {
+    const { adminSafe, guardian, gateway, proxyAdmin, gatewayFinalImplementation, argon, argonot } =
+      await deployGatewayStack();
+
+    expect(await gateway.owner()).to.equal(adminSafe.address);
+    expect(await gateway.guardian()).to.equal(guardian.address);
+
+    await proxyAdmin
+      .connect(adminSafe)
+      .upgradeAndCall(
+        await gateway.getAddress(),
+        await gatewayFinalImplementation.getAddress(),
+        '0x',
+      );
+
+    expect(await gateway.argonToken()).to.equal(await argon.getAddress());
+    expect(await gateway.argonotToken()).to.equal(await argonot.getAddress());
+  });
+
+  it('starts on a bootstrap implementation and upgrades once tokens exist', async () => {
+    const { adminSafe, gateway, proxyAdmin, gatewayFinalImplementation, argon, argonot } =
+      await deployGatewayStack();
+
+    expect(await gateway.argonToken()).to.equal(ethers.ZeroAddress);
+    expect(await gateway.argonotToken()).to.equal(ethers.ZeroAddress);
+
+    await proxyAdmin
+      .connect(adminSafe)
+      .upgradeAndCall(
+        await gateway.getAddress(),
+        await gatewayFinalImplementation.getAddress(),
+        '0x',
+      );
+
+    expect(await gateway.argonToken()).to.equal(await argon.getAddress());
+    expect(await gateway.argonotToken()).to.equal(await argonot.getAddress());
+  });
+
+  it('assigns proxy admin ownership to the admin safe for now', async () => {
+    const { adminSafe, proxyAdmin } = await deployGatewayStack();
+
+    expect(await proxyAdmin.owner()).to.equal(adminSafe.address);
+  });
+
+  it('rejects zero-amount burns for configured tokens', async () => {
+    const { argon, gateway, holder } = await deployFixture();
+    const destination = ethers.encodeBytes32String('argon-destination');
+
+    await expectCustomError(
+      gateway.connect(holder).burnForTransfer(await argon.getAddress(), 0n, destination),
+      gateway,
+      'ZeroAmount',
+    );
+  });
+
+  it('runs admin minting through the gateway with the admin safe', async () => {
+    const { adminSafe, argon, gateway, recipient } = await deployFixture();
+
+    await gateway
+      .connect(adminSafe)
+      .adminMintBatch(await argon.getAddress(), [recipient.address], [50n]);
+
+    expect(await argon.balanceOf(recipient.address)).to.equal(50n * SCALE);
+  });
+
+  it('lets the admin safe rotate the guardian and rejects unauthorized changes', async () => {
+    const { adminSafe, gateway, guardian, holder } = await deployFixture();
+
+    await expectCustomError(
+      gateway.connect(holder).setGuardian(holder.address),
+      gateway,
+      'OwnableUnauthorizedAccount',
+      [holder.address],
+    );
+
+    await expectCustomError(
+      gateway.connect(adminSafe).setGuardian(ethers.ZeroAddress),
+      gateway,
+      'ZeroGuardian',
+    );
+
+    await expectEvent(
+      gateway.connect(adminSafe).setGuardian(holder.address),
+      gateway,
+      'GuardianUpdated',
+      [guardian.address, holder.address],
+    );
+
+    expect(await gateway.guardian()).to.equal(holder.address);
+  });
+
+  it('lets the guardian pause immediately while only the admin safe can unpause', async () => {
+    const { adminSafe, argon, gateway, guardian, holder, recipient } = await deployFixture();
+    const destination = ethers.encodeBytes32String('argon-destination');
+
+    await gateway.connect(guardian).pause();
+
+    await argon.connect(holder).approve(await gateway.getAddress(), 10n * SCALE);
+
+    await expectCustomError(
+      gateway.connect(holder).burnForTransfer(await argon.getAddress(), 10n, destination),
+      gateway,
+      'EnforcedPause',
+    );
+
+    await expectCustomError(
+      gateway.connect(guardian).unpause(),
+      gateway,
+      'OwnableUnauthorizedAccount',
+      [guardian.address],
+    );
+
+    await gateway.connect(adminSafe).unpause();
+    await gateway
+      .connect(adminSafe)
+      .adminMintBatch(await argon.getAddress(), [recipient.address], [1n]);
+
+    expect(await argon.balanceOf(recipient.address)).to.equal(1n * SCALE);
+  });
+});

--- a/chains/ethereum/contracts/test/assertions.ts
+++ b/chains/ethereum/contracts/test/assertions.ts
@@ -1,0 +1,63 @@
+import { expect } from 'vitest';
+
+export async function expectCustomError(
+  action: Promise<unknown>,
+  contract: { interface: { parseError(data: string): { name: string; args: Iterable<unknown> } | null } },
+  errorName: string,
+  expectedArgs: unknown[] = [],
+) {
+  try {
+    await action;
+  } catch (error) {
+    const data = getErrorData(error);
+    const decodedError = contract.interface.parseError(data);
+
+    expect(decodedError?.name).to.equal(errorName);
+    expect(decodedError ? Array.from(decodedError.args) : []).to.deep.equal(expectedArgs);
+    return;
+  }
+
+  throw new Error(`Expected transaction to revert with ${errorName}`);
+}
+
+export async function expectEvent(
+  action: Promise<{ wait(): Promise<{ logs: Array<{ address: string; data: string; topics: string[] }> }> }>,
+  contract: {
+    interface: {
+      parseLog(log: { address: string; data: string; topics: string[] }):
+        | { name: string; args: Iterable<unknown> }
+        | null;
+    };
+    getAddress(): Promise<string>;
+  },
+  eventName: string,
+  expectedArgs: unknown[],
+) {
+  const tx = await action;
+  const receipt = await tx.wait();
+  const contractAddress = (await contract.getAddress()).toLowerCase();
+
+  const parsedLogs = receipt.logs
+    .filter(log => log.address.toLowerCase() === contractAddress)
+    .flatMap(log => {
+      const parsedLog = contract.interface.parseLog(log);
+      return parsedLog === null ? [] : [parsedLog];
+    })
+    .filter(log => log.name === eventName);
+
+  expect(parsedLogs.length).to.be.greaterThan(0);
+  expect(Array.from(parsedLogs[0].args)).to.deep.equal(expectedArgs);
+}
+
+function getErrorData(error: unknown) {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'data' in error &&
+    typeof error.data === 'string'
+  ) {
+    return error.data;
+  }
+
+  throw error;
+}

--- a/chains/ethereum/contracts/test/setupVitest.ts
+++ b/chains/ethereum/contracts/test/setupVitest.ts
@@ -1,0 +1,7 @@
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const contractsRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+
+process.env.HARDHAT_CONFIG = resolve(contractsRoot, 'hardhat.config.ts');
+process.chdir(contractsRoot);

--- a/chains/ethereum/contracts/tsconfig.json
+++ b/chains/ethereum/contracts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": [
+      "node",
+      "vitest/globals",
+      "hardhat"
+    ],
+    "noEmit": true
+  },
+  "include": ["hardhat.config.ts", "script/**/*.ts", "test/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "localchain",
     "localchain/npm/*",
     "client/nodejs",
-    "testing/nodejs"
+    "testing/nodejs",
+    "chains/ethereum/contracts"
   ],
   "devDependencies": {
     "@lerna-lite/version": "^4.0.0",

--- a/pallets/inbound_transfer_log/src/mock.rs
+++ b/pallets/inbound_transfer_log/src/mock.rs
@@ -66,6 +66,7 @@ pub mod gateway {
 	use pallet_token_gateway::types::EvmToSubstrate;
 	use sp_core::{H160, H256};
 	use sp_runtime::AccountId32;
+	use std::collections::BTreeMap;
 
 	type Block = frame_system::mocking::MockBlock<GatewayTest>;
 
@@ -334,8 +335,7 @@ pub mod gateway {
 			_keys: Vec<Vec<u8>>,
 			_root: ismp::consensus::StateCommitment,
 			_proof: &Proof,
-		) -> Result<sp_std::collections::btree_map::BTreeMap<Vec<u8>, Option<Vec<u8>>>, IsmpError>
-		{
+		) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, IsmpError> {
 			unimplemented!("mock state proof")
 		}
 	}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     projects: [
       {
         test: {
+          name: 'bitcoin',
           testTimeout: 30_000,
           hookTimeout: 30_000,
           include: ['bitcoin/nodejs/ts/__test__/**/*.test.ts'],
@@ -18,6 +19,7 @@ export default defineConfig({
       },
       {
         test: {
+          name: 'localchain',
           testTimeout: 120_000,
           hookTimeout: 120_000,
           retry: 2,
@@ -26,11 +28,24 @@ export default defineConfig({
       },
       {
         test: {
+          name: 'mainchain-client',
           testTimeout: 120_000,
           hookTimeout: 120_000,
           retry: 0,
           maxConcurrency: 1,
           include: ['client/nodejs/src/__test__/**/*.test.ts'],
+        },
+      },
+      {
+        root: 'chains/ethereum/contracts',
+        test: {
+          name: 'ethereum-contracts',
+          testTimeout: 120_000,
+          hookTimeout: 120_000,
+          retry: 0,
+          maxConcurrency: 1,
+          include: ['test/**/*.test.ts'],
+          setupFiles: ['test/setupVitest.ts'],
         },
       },
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@adraffy/ens-normalize@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@adraffy/ens-normalize@npm:1.10.1"
+  checksum: 10c0/fdd647604e8fac6204921888aaf5a6bc65eabf0d2921bc5f93b64d01f4bc33ead167c1445f7de05468d05cd92ac31b74c68d2be840c62b79d73693308f885c06
+  languageName: node
+  linkType: hard
+
 "@argonprotocol/bitcoin@workspace:bitcoin/nodejs":
   version: 0.0.0-use.local
   resolution: "@argonprotocol/bitcoin@workspace:bitcoin/nodejs"
@@ -20,6 +27,21 @@ __metadata:
     esbuild-plugin-wasm: "npm:^1.1.0"
     tsup: "npm:^8.5.0"
     tsx: "npm:^4.20.4"
+    typescript: "npm:^5.9.2"
+  languageName: unknown
+  linkType: soft
+
+"@argonprotocol/ethereum-contracts@workspace:chains/ethereum/contracts":
+  version: 0.0.0-use.local
+  resolution: "@argonprotocol/ethereum-contracts@workspace:chains/ethereum/contracts"
+  dependencies:
+    "@nomicfoundation/hardhat-ethers": "npm:^4.0.10"
+    "@openzeppelin/contracts": "npm:^5.4.0"
+    "@openzeppelin/contracts-upgradeable": "npm:^5.4.0"
+    "@types/node": "npm:22.17.1"
+    ethers: "npm:^6.15.0"
+    hardhat: "npm:^3.4.4"
+    tsx: "npm:^4.20.6"
     typescript: "npm:^5.9.2"
   languageName: unknown
   linkType: soft
@@ -2043,12 +2065,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@noble/curves@npm:1.2.0"
+  dependencies:
+    "@noble/hashes": "npm:1.3.2"
+  checksum: 10c0/0bac7d1bbfb3c2286910b02598addd33243cb97c3f36f987ecc927a4be8d7d88e0fcb12b0f0ef8a044e7307d1844dd5c49bb724bfa0a79c8ec50ba60768c97f6
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:1.4.2, @noble/curves@npm:~1.4.0":
+  version: 1.4.2
+  resolution: "@noble/curves@npm:1.4.2"
+  dependencies:
+    "@noble/hashes": "npm:1.4.0"
+  checksum: 10c0/65620c895b15d46e8087939db6657b46a1a15cd4e0e4de5cd84b97a0dfe0af85f33a431bb21ac88267e3dc508618245d4cb564213959d66a84d690fe18a63419
+  languageName: node
+  linkType: hard
+
 "@noble/curves@npm:^1.3.0":
   version: 1.7.0
   resolution: "@noble/curves@npm:1.7.0"
   dependencies:
     "@noble/hashes": "npm:1.6.0"
   checksum: 10c0/3317ec9b7699d2476707a89ceb3ddce60e69bac287561a31dd533669408633e093860fea5067eb9c54e5a7ced0705da1cba8859b6b1e0c48d3afff55fe2e77d0
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:~1.8.1":
+  version: 1.8.2
+  resolution: "@noble/curves@npm:1.8.2"
+  dependencies:
+    "@noble/hashes": "npm:1.7.2"
+  checksum: 10c0/e7ef119b114681d6b7530b29a21f9bbea6fa6973bc369167da2158d05054cc6e6dbfb636ba89fad7707abacc150de30188b33192f94513911b24bdb87af50bbd
   languageName: node
   linkType: hard
 
@@ -2061,10 +2110,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@noble/hashes@npm:1.3.2"
+  checksum: 10c0/2482cce3bce6a596626f94ca296e21378e7a5d4c09597cbc46e65ffacc3d64c8df73111f2265444e36a3168208628258bbbaccba2ef24f65f58b2417638a20e7
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.4.0, @noble/hashes@npm:~1.4.0":
+  version: 1.4.0
+  resolution: "@noble/hashes@npm:1.4.0"
+  checksum: 10c0/8c3f005ee72e7b8f9cff756dfae1241485187254e3f743873e22073d63906863df5d4f13d441b7530ea614b7a093f0d889309f28b59850f33b66cb26a779a4a5
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:1.6.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.3":
   version: 1.6.0
   resolution: "@noble/hashes@npm:1.6.0"
   checksum: 10c0/e7e75898257fb36d933935fcdf1cc67ca7c083eb7b2411aa57fde7eb494c2cea0bec03686462032e25d5b0e1e4ab7357d1afb6718f6a68515db1f392141e9f14
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.7.2, @noble/hashes@npm:~1.7.1":
+  version: 1.7.2
+  resolution: "@noble/hashes@npm:1.7.2"
+  checksum: 10c0/b1411eab3c0b6691d847e9394fe7f1fcd45eeb037547c8f97e7d03c5068a499b4aef188e8e717eee67389dca4fee17d69d7e0f58af6c092567b0b76359b114b2
   languageName: node
   linkType: hard
 
@@ -2106,6 +2176,206 @@ __metadata:
     "@nodelib/fs.scandir": "npm:2.1.5"
     fastq: "npm:^1.6.0"
   checksum: 10c0/db9de047c3bb9b51f9335a7bb46f4fcfb6829fb628318c12115fbaf7d369bfce71c15b103d1fc3b464812d936220ee9bc1c8f762d032c9f6be9acc99249095b1
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-darwin-arm64@npm:0.12.0-next.31":
+  version: 0.12.0-next.31
+  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.12.0-next.31"
+  checksum: 10c0/f15969a477c9f687d33417745f7da597bbf729a72f00d52093c69611afacb85281c7faa4b7eccdfdae11bff867eca31a60e74d3ccb91036fedecc7e71b82c766
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-darwin-x64@npm:0.12.0-next.31":
+  version: 0.12.0-next.31
+  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.12.0-next.31"
+  checksum: 10c0/c5cdc69ca18157dd81f257c0aa3a58740334aa99eeac9be37f2058bd448d720417e62758e4ec29b274e5841ed3dcd1aabad905c3115a917b603173001e9948a8
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-arm64-gnu@npm:0.12.0-next.31":
+  version: 0.12.0-next.31
+  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.12.0-next.31"
+  checksum: 10c0/f5266de3fd17a30fc6fcf3be5f675415724a17ec9a75f11f3220b9c7840b75ad5aa5e47ab0d51c87a1cf735f61c4ac1c3869c7dd662348bfd91efb8080e2f85b
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-arm64-musl@npm:0.12.0-next.31":
+  version: 0.12.0-next.31
+  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.12.0-next.31"
+  checksum: 10c0/d2be64d93201af0f2b740c52ee9b52a6b946f2a234f770251b1b6507db991757381fa8f511099ffe231781e61c501602cefdccd86f2b59ef1c048da995a9c8d0
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-x64-gnu@npm:0.12.0-next.31":
+  version: 0.12.0-next.31
+  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.12.0-next.31"
+  checksum: 10c0/f2fd331ba664108c8b61ba8d4eab57e11b571d5b45a1b2e3c9bf0d703ee1c5fa90999d7e32a0d94fb20ad290c85f96447dfc8bc2f962676c91c5bbe6597e6a09
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-x64-musl@npm:0.12.0-next.31":
+  version: 0.12.0-next.31
+  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.12.0-next.31"
+  checksum: 10c0/7b373783c43db3fecd1699d333b508458a2b10a06130951f5c62c42f35ce365a4269e1cee73edb9f7b6c397591b0642f94469711f2b9fd10c37dc73adddf2bc5
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-win32-x64-msvc@npm:0.12.0-next.31":
+  version: 0.12.0-next.31
+  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.12.0-next.31"
+  checksum: 10c0/e36de755cc4042958450380a444c99c1a3cbeccf520b172dcb833105deeab1098785dec43c401de3b809882e4561b7b9f9706bdc7b438f0092a207da8a9a303c
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr@npm:0.12.0-next.31":
+  version: 0.12.0-next.31
+  resolution: "@nomicfoundation/edr@npm:0.12.0-next.31"
+  dependencies:
+    "@nomicfoundation/edr-darwin-arm64": "npm:0.12.0-next.31"
+    "@nomicfoundation/edr-darwin-x64": "npm:0.12.0-next.31"
+    "@nomicfoundation/edr-linux-arm64-gnu": "npm:0.12.0-next.31"
+    "@nomicfoundation/edr-linux-arm64-musl": "npm:0.12.0-next.31"
+    "@nomicfoundation/edr-linux-x64-gnu": "npm:0.12.0-next.31"
+    "@nomicfoundation/edr-linux-x64-musl": "npm:0.12.0-next.31"
+    "@nomicfoundation/edr-win32-x64-msvc": "npm:0.12.0-next.31"
+  checksum: 10c0/937096abb55fb89cb7a50478c232ddaea0dec3dd8d75e7250f90362fa25420fde2194cda37767e5d822b11d1aa2776528b28085ff986dea204ab66bded7f091b
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/hardhat-errors@npm:^3.0.11, @nomicfoundation/hardhat-errors@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "@nomicfoundation/hardhat-errors@npm:3.0.12"
+  dependencies:
+    "@nomicfoundation/hardhat-utils": "npm:^4.1.0"
+  checksum: 10c0/ef190519b64752bccb8561e96792f3ef96b31452c37a2d338fb01162eee0ca361b41e663b5161c06ca05b2fec4f389e1574ae95d924fc5c3824fbf06b5f77998
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/hardhat-ethers@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "@nomicfoundation/hardhat-ethers@npm:4.0.10"
+  dependencies:
+    "@nomicfoundation/hardhat-errors": "npm:^3.0.12"
+    "@nomicfoundation/hardhat-utils": "npm:^4.1.0"
+    ethereum-cryptography: "npm:^2.2.1"
+    ethers: "npm:^6.14.0"
+  peerDependencies:
+    hardhat: ^3.4.0
+  checksum: 10c0/fbd02ddc8e79881b76d8ee7cde6918f84e72c47671f4aea8c63d274abdee8e7d34f6c752297c8a1f33734f6546dae72eb0c021658804ac0e331ee95a2732bfdb
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/hardhat-utils@npm:^4.0.3, @nomicfoundation/hardhat-utils@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@nomicfoundation/hardhat-utils@npm:4.1.0"
+  dependencies:
+    "@streamparser/json-node": "npm:^0.0.22"
+    env-paths: "npm:^2.2.0"
+    ethereum-cryptography: "npm:^2.2.1"
+    fast-equals: "npm:^5.4.0"
+    json-stream-stringify: "npm:^3.1.6"
+    rfdc: "npm:^1.3.1"
+    undici: "npm:^6.16.1"
+  checksum: 10c0/5466a1d3d0c227b41d83330bd9277be542ab0d623e36314d329c50ddbc46788ce9965ff79d701b71264e57a53c77e181334bc7388a81222be6a1a0e1be4aae9e
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/hardhat-vendored@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@nomicfoundation/hardhat-vendored@npm:3.0.3"
+  checksum: 10c0/e7d65ca1e72660daf045973dd9f00e65aad0719f41612f67bf0c6a594f4f414dafedeee06f1a48c844bceb4c1af8a4f6bdf62b4f09a47d2b43961d2d56b3acbb
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/hardhat-zod-utils@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@nomicfoundation/hardhat-zod-utils@npm:3.0.4"
+  dependencies:
+    "@nomicfoundation/hardhat-errors": "npm:^3.0.11"
+    "@nomicfoundation/hardhat-utils": "npm:^4.0.3"
+  peerDependencies:
+    zod: ^3.23.8
+  checksum: 10c0/0822bcbd896c8fcbb52beb795053167317278c6f6a179210d5f07490ffd46ae632e94871e2799663f64704ac99632edffbcac8700763164aae3d34bebbdc9631
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/solidity-analyzer-darwin-arm64@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@nomicfoundation/solidity-analyzer-darwin-arm64@npm:0.1.2"
+  checksum: 10c0/ef3b13bb2133fea6621db98f991036a3a84d2b240160edec50beafa6ce821fe2f0f5cd4aa61adb9685aff60cd0425982ffd15e0b868b7c768e90e26b8135b825
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/solidity-analyzer-darwin-x64@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@nomicfoundation/solidity-analyzer-darwin-x64@npm:0.1.2"
+  checksum: 10c0/3cb6a00cd200b94efd6f59ed626c705c6f773b92ccf8b90471285cd0e81b35f01edb30c1aa5a4633393c2adb8f20fd34e90c51990dc4e30658e8a67c026d16c9
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/solidity-analyzer-linux-arm64-gnu@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@nomicfoundation/solidity-analyzer-linux-arm64-gnu@npm:0.1.2"
+  checksum: 10c0/cb9725e7bdc3ba9c1feaef96dbf831c1a59c700ca633a9929fd97debdcb5ce06b5d7b4e6dbc076279978707214d01e2cd126d8e3f4cabc5c16525c031a47b95c
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/solidity-analyzer-linux-arm64-musl@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@nomicfoundation/solidity-analyzer-linux-arm64-musl@npm:0.1.2"
+  checksum: 10c0/82a90b1d09ad266ddc510ece2e397f51fdaf29abf7263d2a3a85accddcba2ac24cceb670a3120800611cdcc552eed04919d071e259fdda7564818359ed541f5d
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/solidity-analyzer-linux-x64-gnu@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@nomicfoundation/solidity-analyzer-linux-x64-gnu@npm:0.1.2"
+  checksum: 10c0/d1f20d4d55683bd041ead957e5461b2e43a39e959f905e8866de1d65f8d96118e9b861e994604d9002cb7f056be0844e36c241a6bb531c336b399609977c0998
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/solidity-analyzer-linux-x64-musl@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@nomicfoundation/solidity-analyzer-linux-x64-musl@npm:0.1.2"
+  checksum: 10c0/6c17f9af3aaf184c0a217cf723076051c502d85e731dbc97f34b838f9ae1b597577abac54a2af49b3fd986b09131c52fa21fd5393b22d05e1ec7fee96a8249c2
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/solidity-analyzer-win32-x64-msvc@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@nomicfoundation/solidity-analyzer-win32-x64-msvc@npm:0.1.2"
+  checksum: 10c0/da198464f5ee0d19b6decdfaa65ee0df3097b8960b8483bb7080931968815a5d60f27191229d47a198955784d763d5996f0b92bfde3551612ad972c160b0b000
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/solidity-analyzer@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "@nomicfoundation/solidity-analyzer@npm:0.1.2"
+  dependencies:
+    "@nomicfoundation/solidity-analyzer-darwin-arm64": "npm:0.1.2"
+    "@nomicfoundation/solidity-analyzer-darwin-x64": "npm:0.1.2"
+    "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "npm:0.1.2"
+    "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "npm:0.1.2"
+    "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "npm:0.1.2"
+    "@nomicfoundation/solidity-analyzer-linux-x64-musl": "npm:0.1.2"
+    "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "npm:0.1.2"
+  dependenciesMeta:
+    "@nomicfoundation/solidity-analyzer-darwin-arm64":
+      optional: true
+    "@nomicfoundation/solidity-analyzer-darwin-x64":
+      optional: true
+    "@nomicfoundation/solidity-analyzer-linux-arm64-gnu":
+      optional: true
+    "@nomicfoundation/solidity-analyzer-linux-arm64-musl":
+      optional: true
+    "@nomicfoundation/solidity-analyzer-linux-x64-gnu":
+      optional: true
+    "@nomicfoundation/solidity-analyzer-linux-x64-musl":
+      optional: true
+    "@nomicfoundation/solidity-analyzer-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/e4f503e9287e18967535af669ca7e26e2682203c45a34ea85da53122da1dee1278f2b8c76c20c67fadd7c1b1a98eeecffd2cbc136860665e3afa133817c0de54
   languageName: node
   linkType: hard
 
@@ -2438,6 +2708,22 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": "npm:^27.0.0"
   checksum: 10c0/b8d41098ba6fc194d13d641f9441347e3a3b96c0efabac0e14f57319340a2d4d1c8676e4cb37ab3062c5c323c617e790b0126916e9bf7b201b0cced0826f8ae2
+  languageName: node
+  linkType: hard
+
+"@openzeppelin/contracts-upgradeable@npm:^5.4.0":
+  version: 5.6.1
+  resolution: "@openzeppelin/contracts-upgradeable@npm:5.6.1"
+  peerDependencies:
+    "@openzeppelin/contracts": 5.6.1
+  checksum: 10c0/049633532c1b39bbd15dd5be0fd43f7cd1052b6fef4a9925e5caa22886b23dc937daa7410560486699cd90eca928cb8c5c26ec7c623f2b964acb3abeb4254003
+  languageName: node
+  linkType: hard
+
+"@openzeppelin/contracts@npm:^5.4.0":
+  version: 5.6.1
+  resolution: "@openzeppelin/contracts@npm:5.6.1"
+  checksum: 10c0/f00ecd2b63ca99361e772a9355a587345a2b2af8ead3e88996e0bd1eef89221c3f762cfb77632c1a6ea866a5d3bc030eea1790bd9d326d8ad71f8edee20a5b37
   languageName: node
   linkType: hard
 
@@ -3173,10 +3459,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/base@npm:~1.1.6":
+  version: 1.1.9
+  resolution: "@scure/base@npm:1.1.9"
+  checksum: 10c0/77a06b9a2db8144d22d9bf198338893d77367c51b58c72b99df990c0a11f7cadd066d4102abb15e3ca6798d1529e3765f55c4355742465e49aed7a0c01fe76e8
+  languageName: node
+  linkType: hard
+
 "@scure/base@npm:~1.2.5":
   version: 1.2.6
   resolution: "@scure/base@npm:1.2.6"
   checksum: 10c0/49bd5293371c4e062cb6ba689c8fe3ea3981b7bb9c000400dc4eafa29f56814cdcdd27c04311c2fec34de26bc373c593a1d6ca6d754398a488d587943b7c128a
+  languageName: node
+  linkType: hard
+
+"@scure/bip32@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@scure/bip32@npm:1.4.0"
+  dependencies:
+    "@noble/curves": "npm:~1.4.0"
+    "@noble/hashes": "npm:~1.4.0"
+    "@scure/base": "npm:~1.1.6"
+  checksum: 10c0/6849690d49a3bf1d0ffde9452eb16ab83478c1bc0da7b914f873e2930cd5acf972ee81320e3df1963eb247cf57e76d2d975b5f97093d37c0e3f7326581bf41bd
   languageName: node
   linkType: hard
 
@@ -3188,6 +3492,16 @@ __metadata:
     "@noble/hashes": "npm:~1.8.0"
     "@scure/base": "npm:~1.2.5"
   checksum: 10c0/e3d4c1f207df16abcd79babcdb74d36f89bdafc90bf02218a5140cc5cba25821d80d42957c6705f35210cc5769714ea9501d4ae34732cdd1c26c9ff182a219f7
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@scure/bip39@npm:1.3.0"
+  dependencies:
+    "@noble/hashes": "npm:~1.4.0"
+    "@scure/base": "npm:~1.1.6"
+  checksum: 10c0/1ae1545a7384a4d9e33e12d9e9f8824f29b0279eb175b0f0657c0a782c217920054f9a1d28eb316a417dfc6c4e0b700d6fbdc6da160670107426d52fcbe017a8
   languageName: node
   linkType: hard
 
@@ -3217,6 +3531,13 @@ __metadata:
   version: 0.4.1
   resolution: "@sec-ant/readable-stream@npm:0.4.1"
   checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:^9.4.0":
+  version: 9.47.1
+  resolution: "@sentry/core@npm:9.47.1"
+  checksum: 10c0/ecd33f2c2909d3f1419911d61f8729773228cc6f7626bee7d21b318b1f70485e6cee33482476a9af6c76c0cdeeb8a09155cc1f41b01b20279a0f36336eb0b458
   languageName: node
   linkType: hard
 
@@ -3261,6 +3582,22 @@ __metadata:
   version: 1.0.0
   resolution: "@standard-schema/spec@npm:1.0.0"
   checksum: 10c0/a1ab9a8bdc09b5b47aa8365d0e0ec40cc2df6437be02853696a0e377321653b0d3ac6f079a8c67d5ddbe9821025584b1fb71d9cc041a6666a96f1fadf2ece15f
+  languageName: node
+  linkType: hard
+
+"@streamparser/json-node@npm:^0.0.22":
+  version: 0.0.22
+  resolution: "@streamparser/json-node@npm:0.0.22"
+  dependencies:
+    "@streamparser/json": "npm:^0.0.22"
+  checksum: 10c0/3b84fbbf93f183dd00e43db5ed994cdc23993548faf8b318fff52c45ca6413ddb03e2be99e407141a8a89673bb19a84949be97b8bb1d22a25bde5c3cdac43074
+  languageName: node
+  linkType: hard
+
+"@streamparser/json@npm:^0.0.22":
+  version: 0.0.22
+  resolution: "@streamparser/json@npm:0.0.22"
+  checksum: 10c0/4496e286d607e37552c75e1e63ed7e722392d4d91939401ec11eb63c8c7d1fb7a2cf5733f1a60dc63ad95996f12d62f5639724b2c31584bb8ace51b1f3910ccc
   languageName: node
   linkType: hard
 
@@ -3393,6 +3730,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~6.21.0"
   checksum: 10c0/b04063bdabfc4146af05d14d4fd23ee68615194473d0ef971ddef549b80b791f52c8f93abdd8d1092ee0257f3dea862fa233519244fd051e79233cdce614de14
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:22.7.5":
+  version: 22.7.5
+  resolution: "@types/node@npm:22.7.5"
+  dependencies:
+    undici-types: "npm:~6.19.2"
+  checksum: 10c0/cf11f74f1a26053ec58066616e3a8685b6bcd7259bc569738b8f752009f9f0f7f85a1b2d24908e5b0f752482d1e8b6babdf1fbb25758711ec7bb9500bfcd6e60
   languageName: node
   linkType: hard
 
@@ -3783,6 +4129,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"adm-zip@npm:^0.4.16":
+  version: 0.4.16
+  resolution: "adm-zip@npm:0.4.16"
+  checksum: 10c0/c56c6e138fd19006155fc716acae14d54e07c267ae19d78c8a8cdca04762bf20170a71a41aa8d8bad2f13b70d4f3e9a191009bafa5280e05a440ee506f871a55
+  languageName: node
+  linkType: hard
+
+"aes-js@npm:4.0.0-beta.5":
+  version: 4.0.0-beta.5
+  resolution: "aes-js@npm:4.0.0-beta.5"
+  checksum: 10c0/444f4eefa1e602cbc4f2a3c644bc990f93fd982b148425fee17634da510586fc09da940dcf8ace1b2d001453c07ff042e55f7a0482b3cc9372bf1ef75479090c
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -3792,6 +4152,13 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+  languageName: node
+  linkType: hard
+
+"ansi-colors@npm:^4.1.1":
+  version: 4.1.3
+  resolution: "ansi-colors@npm:4.1.3"
+  checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
   languageName: node
   linkType: hard
 
@@ -4535,6 +4902,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enquirer@npm:^2.3.0":
+  version: 2.4.1
+  resolution: "enquirer@npm:2.4.1"
+  dependencies:
+    ansi-colors: "npm:^4.1.1"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/43850479d7a51d36a9c924b518dcdc6373b5a8ae3401097d336b7b7e258324749d0ad37a1fcaa5706f04799baa05585cd7af19ebdf7667673e7694435fcea918
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -4654,7 +5031,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0":
+"esbuild@npm:^0.27.0, esbuild@npm:~0.27.0":
   version: 0.27.7
   resolution: "esbuild@npm:0.27.7"
   dependencies:
@@ -5059,6 +5436,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ethereum-cryptography@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "ethereum-cryptography@npm:2.2.1"
+  dependencies:
+    "@noble/curves": "npm:1.4.2"
+    "@noble/hashes": "npm:1.4.0"
+    "@scure/bip32": "npm:1.4.0"
+    "@scure/bip39": "npm:1.3.0"
+  checksum: 10c0/c6c7626d393980577b57f709878b2eb91f270fe56116044b1d7afb70d5c519cddc0c072e8c05e4a335e05342eb64d9c3ab39d52f78bb75f76ad70817da9645ef
+  languageName: node
+  linkType: hard
+
+"ethers@npm:^6.14.0, ethers@npm:^6.15.0":
+  version: 6.16.0
+  resolution: "ethers@npm:6.16.0"
+  dependencies:
+    "@adraffy/ens-normalize": "npm:1.10.1"
+    "@noble/curves": "npm:1.2.0"
+    "@noble/hashes": "npm:1.3.2"
+    "@types/node": "npm:22.7.5"
+    aes-js: "npm:4.0.0-beta.5"
+    tslib: "npm:2.7.0"
+    ws: "npm:8.17.1"
+  checksum: 10c0/65c0ff7016b1592b1961c3b68508902b89fc75e1ad025bab3a722df1b5699fd077551875a7285e65b2d0cfea9a85b2459bb84010a0fa4e4494d231848aee3a73
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^4.0.0":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
@@ -5140,6 +5544,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
+"fast-equals@npm:^5.4.0":
+  version: 5.4.0
+  resolution: "fast-equals@npm:5.4.0"
+  checksum: 10c0/4fdce3a8f814e78af7296ca4ebe82f4765074a6dfe557ee98c18f5d2958c3de59025fbff7556d65f250165ccef424d37f9952ee159400f8ebe5f2edb704ec80e
   languageName: node
   linkType: hard
 
@@ -5639,6 +6050,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hardhat@npm:^3.4.4":
+  version: 3.4.4
+  resolution: "hardhat@npm:3.4.4"
+  dependencies:
+    "@nomicfoundation/edr": "npm:0.12.0-next.31"
+    "@nomicfoundation/hardhat-errors": "npm:^3.0.12"
+    "@nomicfoundation/hardhat-utils": "npm:^4.1.0"
+    "@nomicfoundation/hardhat-vendored": "npm:^3.0.3"
+    "@nomicfoundation/hardhat-zod-utils": "npm:^3.0.4"
+    "@nomicfoundation/solidity-analyzer": "npm:^0.1.1"
+    "@sentry/core": "npm:^9.4.0"
+    adm-zip: "npm:^0.4.16"
+    chokidar: "npm:^4.0.3"
+    enquirer: "npm:^2.3.0"
+    ethereum-cryptography: "npm:^2.2.1"
+    micro-eth-signer: "npm:^0.14.0"
+    p-map: "npm:^7.0.2"
+    resolve.exports: "npm:^2.0.3"
+    semver: "npm:^7.6.3"
+    tsx: "npm:^4.19.3"
+    ws: "npm:^8.18.0"
+    zod: "npm:^3.23.8"
+  bin:
+    hardhat: dist/src/cli.js
+  checksum: 10c0/6157d005615cdd2a0a957bb054d2e10c2f98e84073fff3682a0f7f479405a525bbb8181878b072333c0c9809b43b7450707029519f14c4b0d14dce2995de722e
+  languageName: node
+  linkType: hard
+
 "has-ansi@npm:^2.0.0":
   version: 2.0.0
   resolution: "has-ansi@npm:2.0.0"
@@ -5969,6 +6408,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stream-stringify@npm:^3.1.6":
+  version: 3.1.6
+  resolution: "json-stream-stringify@npm:3.1.6"
+  checksum: 10c0/cb45e65143f4634ebb2dc0732410a942eaf86f88a7938b2f6397f4c6b96a7ba936e74d4d17db48c9221f669153996362b2ff50fe8c7fed8a7548646f98ae1f58
+  languageName: node
+  linkType: hard
+
 "json-stringify-safe@npm:^5.0.1":
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
@@ -6184,7 +6630,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micro-packed@npm:~0.7.3":
+"micro-eth-signer@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "micro-eth-signer@npm:0.14.0"
+  dependencies:
+    "@noble/curves": "npm:~1.8.1"
+    "@noble/hashes": "npm:~1.7.1"
+    micro-packed: "npm:~0.7.2"
+  checksum: 10c0/62c90d54d2b97cb4eaf713c69bc4ceb5903012d0237c26f0966076cfb89c4527de68b395e1bc29e6f237152ce08f7b551fb57b332003518a1331c2c0890fb164
+  languageName: node
+  linkType: hard
+
+"micro-packed@npm:~0.7.2, micro-packed@npm:~0.7.3":
   version: 0.7.3
   resolution: "micro-packed@npm:0.7.3"
   dependencies:
@@ -6596,7 +7053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:^7.0.4":
+"p-map@npm:^7.0.2, p-map@npm:^7.0.4":
   version: 7.0.4
   resolution: "p-map@npm:7.0.4"
   checksum: 10c0/a5030935d3cb2919d7e89454d1ce82141e6f9955413658b8c9403cfe379283770ed3048146b44cde168aa9e8c716505f196d5689db0ae3ce9a71521a2fef3abd
@@ -7158,6 +7615,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve.exports@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "resolve.exports@npm:2.0.3"
+  checksum: 10c0/1ade1493f4642a6267d0a5e68faeac20b3d220f18c28b140343feb83694d8fed7a286852aef43689d16042c61e2ddb270be6578ad4a13990769e12065191200d
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.1.6":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
@@ -7195,6 +7659,13 @@ __metadata:
   version: 1.1.0
   resolution: "reusify@npm:1.1.0"
   checksum: 10c0/4eff0d4a5f9383566c7d7ec437b671cc51b25963bd61bf127c3f3d3f68e44a026d99b8d2f1ad344afff8d278a8fe70a8ea092650a716d22287e8bef7126bb2fa
+  languageName: node
+  linkType: hard
+
+"rfdc@npm:^1.3.1":
+  version: 1.4.1
+  resolution: "rfdc@npm:1.4.1"
+  checksum: 10c0/4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
   languageName: node
   linkType: hard
 
@@ -7365,21 +7836,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.6.3, semver@npm:^7.7.4":
+  version: 7.7.4
+  resolution: "semver@npm:7.7.4"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.7.1":
   version: 7.7.1
   resolution: "semver@npm:7.7.1"
   bin:
     semver: bin/semver.js
   checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.7.4":
-  version: 7.7.4
-  resolution: "semver@npm:7.7.4"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
   languageName: node
   linkType: hard
 
@@ -7856,6 +8327,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.7.0":
+  version: 2.7.0
+  resolution: "tslib@npm:2.7.0"
+  checksum: 10c0/469e1d5bf1af585742128827000711efa61010b699cb040ab1800bcd3ccdd37f63ec30642c9e07c4439c1db6e46345582614275daca3e0f4abae29b0083f04a6
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -7902,6 +8380,22 @@ __metadata:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
   checksum: 10c0/2eddc1138ad992a2e67d826e92e0b0c4f650367355866c77df8368ade9489e0a8bf2b52b352e97fec83dc690af05881c29c489af27acb86ac2cef38b0d029087
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.19.3, tsx@npm:^4.20.6":
+  version: 4.21.0
+  resolution: "tsx@npm:4.21.0"
+  dependencies:
+    esbuild: "npm:~0.27.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/f5072923cd8459a1f9a26df87823a2ab5754641739d69df2a20b415f61814322b751fa6be85db7c6ec73cf68ba8fac2fd1cfc76bdb0aa86ded984d84d5d2126b
   languageName: node
   linkType: hard
 
@@ -8036,7 +8530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.19.8":
+"undici-types@npm:~6.19.2, undici-types@npm:~6.19.8":
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
   checksum: 10c0/078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344
@@ -8050,7 +8544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
+"undici@npm:^6.16.1, undici@npm:^6.25.0":
   version: 6.25.0
   resolution: "undici@npm:6.25.0"
   checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
@@ -8433,6 +8927,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:8.17.1":
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/f4a49064afae4500be772abdc2211c8518f39e1c959640457dcee15d4488628620625c783902a52af2dd02f68558da2868fd06e6fd0e67ebcd09e6881b1b5bfe
+  languageName: node
+  linkType: hard
+
 "ws@npm:^8.18.0, ws@npm:^8.8.1":
   version: 8.18.0
   resolution: "ws@npm:8.18.0"
@@ -8570,5 +9079,12 @@ __metadata:
     grammex: "npm:^3.1.11"
     graphmatch: "npm:^1.1.0"
   checksum: 10c0/6baa15863f1bbf0131a50f80df82bdc1d174f45e81587ff6a2ac2ad13a0c4a1f80e883794d5711ad31acdd85195ebe052375e43db5c4bcbaff98f040c082234e
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.8":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard


### PR DESCRIPTION
This is the first commit to an ERC20 gateway for a direct burn/mint transfer system to Ethereum. The first contract is built to have plain erc20 contracts with mint/burn from a gateway. This gateway is a hard coded proxy that sits in front of a pausable, upgradeable contract. We will start with upgradeable contracts via Safes, and migrate to running via a chain governed council that will sign through the collect process.

NOTE: this model requires a user to authorize the spend out of their balance prior along with approval to burn for transfer. This can be hidden inside the Operations/Treasury apps, but if we need hard wallets or external wallet use in the future, we will ALWAYS be locked into this pattern of approvals. There are a few alternatives (send signature into the method (Permits), grant open access the gateway (dangerous for accounts with compromised gateway) if we want to examine them.