### PR TITLE
Harden GitHub Actions release and publish workflows

### DIFF
--- a/.github/templates/docker/action.yml
+++ b/.github/templates/docker/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Set up tags
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: ${{ inputs.image }}
         labels: |
@@ -42,20 +42,20 @@ runs:
         tags: ${{ inputs.tags }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Login to container registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ inputs.github-token }}
 
     - name: Build and push image to container registry
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       id: push
       with:
         platforms: linux/amd64,linux/arm64

--- a/.github/templates/minio/action.yml
+++ b/.github/templates/minio/action.yml
@@ -10,6 +10,7 @@ runs:
       shell: bash
       run: |
         set -eu
+        release_file="minio.RELEASE.2025-09-07T16-13-09Z"
         platform="darwin"
         if [[ "$RUNNER_OS" == "Linux" ]]; then
           platform="linux"
@@ -17,20 +18,21 @@ runs:
 
         arch=$(uname -m)
         arch_part="amd64"
+        expected_sha="4759080aeef7385aaceaac1131c30aaeb99605921553967dc6d3ef4e16ac64f9"
         if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
           arch_part="arm64"
+          expected_sha="7c3b3039b76e55a1b80935848ed83998d5e8d317374f87851f46a019ff5c0aa4"
         fi
 
-        url="https://dl.min.io/server/minio/release/${platform}-${arch_part}/minio"
-        curl --fail --location --silent --show-error "$url" -o minio
-        curl --fail --location --silent --show-error "${url}.sha256sum" -o minio.sha256sum
-        expected_sha=$(awk '{print $1}' minio.sha256sum)
-        actual_sha=$(shasum -a 256 minio)
-        actual_sha=${actual_sha%% *}
-        if [[ "$actual_sha" != "$expected_sha" ]]; then
-          echo "Minio checksum verification failed for $url" >&2
-          exit 1
+        if [[ "$platform" == "linux" && "$arch_part" == "amd64" ]]; then
+          expected_sha="7c5bd8512c6e966455b1d198209358b2d191c77a83ab377c4073281065fb855f"
+        elif [[ "$platform" == "linux" && "$arch_part" == "arm64" ]]; then
+          expected_sha="5c83cd2cf151717ba0243f73e1c7802ff36e272b67144bdd7f1f7d684fd6f03d"
         fi
+
+        url="https://dl.min.io/server/minio/release/${platform}-${arch_part}/${release_file}"
+        curl --fail --location --silent --show-error "$url" -o minio
+        echo "${expected_sha}  minio" | shasum -a 256 -c -
         chmod +x minio
         sudo mv minio /usr/local/bin
 

--- a/.github/templates/minio/action.yml
+++ b/.github/templates/minio/action.yml
@@ -5,31 +5,32 @@ description: |
 runs:
   using: "composite"
   steps:
-    - name: Install Minio on Linux
-      if: ${{ runner.os == 'Linux' }}
+    - name: Install Minio
+      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       shell: bash
       run: |
-        arch=$(uname -m)
-        if [ "$arch" = "aarch64" ]; then
-          url="https://dl.min.io/server/minio/release/linux-arm64/minio"
-        else
-          url="https://dl.min.io/server/minio/release/linux-amd64/minio"
+        set -eu
+        platform="darwin"
+        if [[ "$RUNNER_OS" == "Linux" ]]; then
+          platform="linux"
         fi
-        wget "$url"
-        chmod +x minio
-        sudo mv minio /usr/local/bin
 
-    - name: Install Minio on macOS
-      if: ${{ runner.os == 'macOS' }}
-      shell: bash
-      run: |
         arch=$(uname -m)
-        if [ "$arch" = "arm64" ]; then
-          url="https://dl.min.io/server/minio/release/darwin-arm64/minio"
-        else
-          url="https://dl.min.io/server/minio/release/darwin-amd64/minio"
+        arch_part="amd64"
+        if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
+          arch_part="arm64"
         fi
-        wget "$url"
+
+        url="https://dl.min.io/server/minio/release/${platform}-${arch_part}/minio"
+        curl --fail --location --silent --show-error "$url" -o minio
+        curl --fail --location --silent --show-error "${url}.sha256sum" -o minio.sha256sum
+        expected_sha=$(awk '{print $1}' minio.sha256sum)
+        actual_sha=$(shasum -a 256 minio)
+        actual_sha=${actual_sha%% *}
+        if [[ "$actual_sha" != "$expected_sha" ]]; then
+          echo "Minio checksum verification failed for $url" >&2
+          exit 1
+        fi
         chmod +x minio
         sudo mv minio /usr/local/bin
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
           echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           cache: 'false'
 
@@ -62,7 +62,7 @@ jobs:
       - name: Free Disk Space
         uses: ./.github/templates/clear-space
 
-      - uses: ikalnytskyi/action-setup-postgres@v7
+      - uses: ikalnytskyi/action-setup-postgres@10ab8a56cc77b4823c2bfa57b1d4dd5605ef0481 # v7
       - uses: ./.github/templates/minio
 
       - name: Install linux dependencies
@@ -90,12 +90,12 @@ jobs:
           name: cargo-${{ matrix.target }}
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           cache: 'false'
           target: ${{matrix.target}}
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         with:
           tool: sqlx-cli@0.8.3
 

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -26,7 +26,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to container registry
-        if: ${{ github.event.release.draft == false }}
+        if: ${{ github.event.release.draft == false && steps.get_latest.outputs.latest != '' }}
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
@@ -34,7 +34,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update latest
-        if: ${{ github.event.release.draft == false }}
+        if: ${{ github.event.release.draft == false && steps.get_latest.outputs.latest != '' }}
         run: |
           if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+)*([.-][0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
             echo "Invalid latest release tag: $VERSION" >&2

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Login to container registry
         if: ${{ github.event.release.draft == false }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -36,11 +36,15 @@ jobs:
       - name: Update latest
         if: ${{ github.event.release.draft == false }}
         run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+            echo "Invalid latest release tag: $VERSION" >&2
+            exit 1
+          fi
           for name in argon-miner argon-oracle argon-notary; do
-            image=ghcr.io/argonprotocol/$name
-            docker pull $image:${{ env.VERSION }}
-            docker tag $image:${{ env.VERSION }} $image:latest
-            docker push $image:latest
+            image="ghcr.io/argonprotocol/$name"
+            docker pull "$image:$VERSION"
+            docker tag "$image:$VERSION" "$image:latest"
+            docker push "$image:latest"
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Update latest
         if: ${{ github.event.release.draft == false }}
         run: |
-          if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+          if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+)*([.-][0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
             echo "Invalid latest release tag: $VERSION" >&2
             exit 1
           fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,13 +65,13 @@ jobs:
           name: cargo-${{ matrix.target }}
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           cache: 'false'
           target: ${{ matrix.target }}
 
       - name: Install sqlx-cli
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         with:
           tool: sqlx-cli@0.8.3
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -380,7 +380,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*([.-][0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
             echo "Invalid release tag: $RELEASE_TAG" >&2
             exit 1
           fi

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -64,7 +64,7 @@ jobs:
         run: yarn install
 
       - name: Install
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           cache: 'false'
           target: ${{ matrix.target }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Set HOME_DIR for Mac builds
         if: ${{ !startsWith(matrix.os, 'ubuntu') }}
-        run: echo "TARGET_BASEDIR=${{ github.workspace }}" >> "$GITHUB_ENV"
+        run: echo "TARGET_BASEDIR=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Set HOME_DIR
@@ -239,7 +239,7 @@ jobs:
           name: cargo-${{ env.TARGET }}
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           cache: 'false'
 
@@ -359,7 +359,7 @@ jobs:
         run: yarn artifacts
         working-directory: ./localchain
 
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           branch: napi-bindings
           commit_message: Check-in binding files
@@ -375,13 +375,25 @@ jobs:
         shell: bash
         working-directory: ./localchain
 
+      - name: Validate release tag
+        if: github.ref_name != 'main'
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
+
       - name: Upload artifacts to release
         if: github.ref_name != 'main'
         run: |
           tar -czf bitcoin-wasm.tar.gz -C bitcoin/nodejs/ts/wasm .
-          RELEASE_EXISTS=$(gh release list --json tagName,isDraft --jq ".[] | select(.tagName==\"${{ github.ref_name }}\" and .isDraft == true) | .tagName" | head -n 1)
+          RELEASE_EXISTS=$(gh release list --json tagName,isDraft --jq ".[] | select(.tagName==\"$RELEASE_TAG\" and .isDraft == true) | .tagName" | head -n 1)
           if [[ -n "$RELEASE_EXISTS" ]]; then
-            gh release upload ${{ github.ref_name }} \
+            gh release upload "$RELEASE_TAG" \
               ./localchain/npm/**/*.node \
               bitcoin-wasm.tar.gz \
               --clobber

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -117,7 +117,7 @@ jobs:
           if [[ -z "$RELEASE_TAG" || "$RELEASE_TAG" == "null" ]]; then
             RELEASE_TAG="$RELEASE_REF_NAME"
           fi
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*([.-][0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
             echo "Invalid release tag: $RELEASE_TAG" >&2
             exit 1
           fi

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -36,7 +36,7 @@ jobs:
           SOURCE_RUN_ID: ${{ github.event.client_payload.source_run_id }}
           PAYLOAD_SHA: ${{ github.event.client_payload.head_sha }}
         run: |
-          set -euo pipefail
+          set -eu
 
           if [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
             echo "Invalid source_run_id payload" >&2
@@ -99,41 +99,46 @@ jobs:
           path: bitcoin/nodejs/ts/wasm
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve release tag
+      - name: Validate release tag
         if: github.event_name != 'repository_dispatch'
         id: release_tag
+        env:
+          RELEASE_INPUT_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag }}"
-          if [[ -z "$TAG" || "$TAG" == "null" ]]; then
-            TAG="${{ github.event.release.tag_name }}"
+          RELEASE_TAG="$RELEASE_INPUT_TAG"
+          if [[ -z "$RELEASE_TAG" || "$RELEASE_TAG" == "null" ]]; then
+            RELEASE_TAG="$RELEASE_EVENT_TAG"
           fi
-          if [[ "$TAG" == refs/tags/* ]]; then
-            TAG="${TAG#refs/tags/}"
+          if [[ "$RELEASE_TAG" == refs/tags/* ]]; then
+            RELEASE_TAG="${RELEASE_TAG#refs/tags/}"
           fi
-          if [[ -z "$TAG" || "$TAG" == "null" ]]; then
-            TAG="${{ github.ref_name }}"
+          if [[ -z "$RELEASE_TAG" || "$RELEASE_TAG" == "null" ]]; then
+            RELEASE_TAG="$RELEASE_REF_NAME"
           fi
-          if [[ -z "$TAG" || "$TAG" == "null" ]]; then
-            echo "Unable to resolve release tag" >&2
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG" >&2
             exit 1
           fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Validate workflow dispatch release is published
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
         run: |
-          set -euo pipefail
+          set -eu
 
-          TAG="${{ steps.release_tag.outputs.tag }}"
-          if ! RELEASE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")"; then
-            echo "No release found for tag $TAG. Ensure the release exists and is published before running this workflow." >&2
+          if ! RELEASE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"; then
+            echo "No release found for tag $RELEASE_TAG. Ensure the release exists and is published before running this workflow." >&2
             exit 1
           fi
 
           if ! jq -e '.draft == false and (.published_at != null)' <<<"$RELEASE_JSON" >/dev/null; then
-            echo "workflow_dispatch requires an already published release for tag $TAG" >&2
+            echo "workflow_dispatch requires an already published release for tag $RELEASE_TAG" >&2
             exit 1
           fi
 
@@ -172,7 +177,9 @@ jobs:
 
       - name: Bump workspace versions for dev publish
         if: github.event_name == 'repository_dispatch'
-        run: VERSION=${{ steps.npm_dev_version.outputs.version }} yarn version:bump
+        run: yarn version:bump
+        env:
+          VERSION: ${{ steps.npm_dev_version.outputs.version }}
 
       - name: Verify artifacts
         run: ls -R ./npm
@@ -182,7 +189,7 @@ jobs:
         if: ${{ vars.NPM_ENABLED == 'true' }}
         run: |
           PUBLISH_ARGS=(--access public)
-          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "repository_dispatch" ]]; then
             PUBLISH_ARGS+=(--tag dev)
           fi
           npm publish "${PUBLISH_ARGS[@]}" --workspace=client/nodejs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Validate release tag
         run: |
-          if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+          if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+)*([.-][0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
             echo "Invalid release tag: $VERSION" >&2
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,16 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - v[0-9]+.*
-  workflow_dispatch:
-    inputs:
-      TAG:
-        description: 'The tag to publish'
-        required: true
-
+  release:
+    types:
+      - published
 
 defaults:
   run:
     shell: bash
 
 env:
-  VERSION: ${{ github.event.inputs.TAG || github.ref_name }}
+  VERSION: ${{ github.event.release.tag_name }}
 
 jobs:
   docker:
@@ -30,14 +24,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v5
 
+      - name: Validate release tag
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+            echo "Invalid release tag: $VERSION" >&2
+            exit 1
+          fi
+
       - name: Download artifacts
         run: |
-          gh release download ${{env.VERSION}} --dir ./amd64 --pattern *x86_64-unknown-linux-gnu*
+          gh release download "$VERSION" --dir ./amd64 --pattern '*x86_64-unknown-linux-gnu*'
           ls ./amd64
-          find ./amd64 -name "*.tar.gz" -exec tar -xf {} -C ./amd64 \;
+          find ./amd64 -name "*.tar.gz" -exec tar -xf '{}' -C ./amd64 \;
           ls -R ./amd64
-          gh release download ${{env.VERSION}} --dir ./arm64 --pattern *aarch64-unknown-linux-gnu*
-          find ./arm64 -name "*.tar.gz" -exec tar -xf {} -C ./arm64 \;
+          gh release download "$VERSION" --dir ./arm64 --pattern '*aarch64-unknown-linux-gnu*'
+          find ./arm64 -name "*.tar.gz" -exec tar -xf '{}' -C ./arm64 \;
           ls -R ./arm64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,10 +47,10 @@ jobs:
         id: check_latest
         run: |
           LATEST_RELEASE=$(gh release list --exclude-pre-releases --json tagName,isLatest --jq ".[] | select(.isLatest == true) | .tagName" | head -n 1)
-           if [ "${{ env.VERSION }}" == "$LATEST_RELEASE" ]; then
-            echo "isLatest=true" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" == "$LATEST_RELEASE" ]]; then
+            echo "isLatest=true" >> "$GITHUB_OUTPUT"
           else
-            echo "isLatest=false" >> $GITHUB_OUTPUT
+            echo "isLatest=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +63,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flavor: ${{ steps.check_latest.outputs.isLatest == 'true' && 'latest=true' || 'latest=false' }}
           tags: |
-            type=semver,pattern=${{env.VERSION}}
+            type=semver,pattern=${{ env.VERSION }}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
@@ -74,7 +75,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flavor: ${{ steps.check_latest.outputs.isLatest == 'true' && 'latest=true' || 'latest=false' }}
           tags: |
-            type=semver,pattern=${{env.VERSION}}
+            type=semver,pattern=${{ env.VERSION }}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
@@ -86,6 +87,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flavor: ${{ steps.check_latest.outputs.isLatest == 'true' && 'latest=true' || 'latest=false' }}
           tags: |
-            type=semver,pattern=${{env.VERSION}}
+            type=semver,pattern=${{ env.VERSION }}
             type=semver,pattern={{major}}.{{minor}}
             type=sha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   CARGO_TERM_COLOR: always
   SQLX_OFFLINE: true
+  RELEASE_TAG: ${{ github.ref_name }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,22 +37,29 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate release tag
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
       - name: If published release exists, exit
         run: |
-          PUBLISHED_RELEASE_EXISTS=$(gh release list --json tagName,isDraft --jq ".[] | select(.tagName==\"${{ github.ref_name }}\" and .isDraft == false) | .tagName" | head -n 1)
+          PUBLISHED_RELEASE_EXISTS=$(gh release list --json tagName,isDraft --jq ".[] | select(.tagName==\"$RELEASE_TAG\" and .isDraft == false) | .tagName" | head -n 1)
           if [[ -n "$PUBLISHED_RELEASE_EXISTS" ]]; then
-           exit 1
+            exit 1
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if draft release exists
         run: |
-          RELEASE_EXISTS=$(gh release list --json tagName --jq ".[] | select(.tagName==\"${{ github.ref_name }}\") | .tagName" | head -n 1)
+          RELEASE_EXISTS=$(gh release list --json tagName --jq ".[] | select(.tagName==\"$RELEASE_TAG\") | .tagName" | head -n 1)
           if [[ -n "$RELEASE_EXISTS" ]]; then
-           echo "RELEASE_EXISTS=true" >> $GITHUB_ENV
+            echo "RELEASE_EXISTS=true" >> "$GITHUB_ENV"
           else
-            echo "RELEASE_EXISTS=false" >> $GITHUB_ENV
+            echo "RELEASE_EXISTS=false" >> "$GITHUB_ENV"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -59,12 +67,12 @@ jobs:
       - name: Extract changelog for the current version
         run: |
           # Extract changelog section for the specified version
-          sed -n "/^## \[${{ github.ref_name }}\]/,/^### \[v/p" CHANGELOG.md | sed '$d' > changelog.txt
-          cat changelog.txt  # Print the extracted changelog
+          sed -n "/^## \[$RELEASE_TAG\]/,/^### \[v/p" CHANGELOG.md | sed '$d' > changelog.txt
+          cat changelog.txt
 
       - name: Create draft release if not exists
         if: env.RELEASE_EXISTS == 'false'
-        run: gh release create ${{ github.ref_name }} --draft --title "${{ github.ref_name }}" --notes-file changelog.txt --target ${{ github.ref_name }}
+        run: gh release create "$RELEASE_TAG" --draft --title "$RELEASE_TAG" --notes-file changelog.txt --target "$RELEASE_TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -131,16 +139,16 @@ jobs:
           echo "OPENSSL_NO_VENDOR=1" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           cache: 'false'
           target: ${{ matrix.target }}
 
-      - uses: taiki-e/setup-cross-toolchain-action@v1
+      - uses: taiki-e/setup-cross-toolchain-action@129361238c06ff2cc1c4ca5c5d2217af441ffdf6 # v1
         with:
           target: ${{ matrix.target }}
 
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu'))
         with:
           bin: argon-node
@@ -148,38 +156,38 @@ jobs:
           target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: refs/tags/${{ github.ref_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
 
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu'))
         with:
           bin: argon-notary
           target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: refs/tags/${{ github.ref_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
 
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         with:
           bin: argon-localchain
           target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: refs/tags/${{ github.ref_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
 
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu'))
         with:
           bin: argon-oracle
           target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: refs/tags/${{ github.ref_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
 
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         with:
           bin: argon-bitcoin-cli
           target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: refs/tags/${{ github.ref_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Validate release tag
         run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*(?:[-.][0-9A-Za-z._-]+)?$ ]]; then
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+)*([.-][0-9A-Za-z][0-9A-Za-z._-]*)?$ ]]; then
             echo "Invalid release tag: $RELEASE_TAG" >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,9 @@ jobs:
       - name: Extract changelog for the current version
         run: |
           # Extract changelog section for the specified version
-          sed -n "/^## \[$RELEASE_TAG\]/,/^### \[v/p" CHANGELOG.md | sed '$d' > changelog.txt
-          cat changelog.txt
+          RELEASE_TAG_PATTERN=$(printf '%s\n' "$RELEASE_TAG" | sed 's/[][\\/.*^$+?(){}|]/\\&/g')
+          sed -n "/^## \[$RELEASE_TAG_PATTERN\]/,/^### \[v/p" CHANGELOG.md | sed '$d' > changelog.txt
+          cat changelog.txt  # Print the extracted changelog
 
       - name: Create draft release if not exists
         if: env.RELEASE_EXISTS == 'false'

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -2,6 +2,8 @@ name: Build Deterministic Runtimes
 
 env:
   SUBWASM_VERSION: 0.21.3
+  SUBWASM_SHA256: 0560d1b8785be9a0d04cb0bf939feaaa621c2d0809f818225698d5c44198550c
+  SRTOOL_COMMIT: 70b86b039233ba31ebe3140987e51fae913dd81e
   BUILD_OPTS: --features on-chain-release-build
 
 on:
@@ -33,7 +35,15 @@ jobs:
 
       - name: Build custom srtool image (Rust ${{ env.RUST_VERSION }})
         run: |
-          git clone https://github.com/paritytech/srtool.git --depth 1
+          set -eu
+          git init srtool
+          git -C srtool remote add origin https://github.com/paritytech/srtool.git
+          git -C srtool fetch --depth 1 origin "$SRTOOL_COMMIT"
+          git -C srtool checkout --detach FETCH_HEAD
+          if [[ "$(git -C srtool rev-parse HEAD)" != "$SRTOOL_COMMIT" ]]; then
+            echo "srtool checkout did not match pinned commit $SRTOOL_COMMIT" >&2
+            exit 1
+          fi
           cd srtool
           docker build --build-arg RUSTC_VERSION=${{ env.RUST_VERSION }} -t srtool .
 
@@ -84,8 +94,11 @@ jobs:
       # We now get extra information thanks to subwasm,
       - name: Install subwasm ${{ env.SUBWASM_VERSION }}
         run: |
-          wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
-          sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+          set -eu
+          artifact="subwasm_linux_amd64_v${SUBWASM_VERSION}.deb"
+          wget "https://github.com/chevdor/subwasm/releases/download/v${SUBWASM_VERSION}/${artifact}"
+          echo "${SUBWASM_SHA256}  ${artifact}" | shasum -a 256 -c -
+          sudo dpkg -i "$artifact"
           subwasm --version
       - name: Show Runtime information
         run: |
@@ -114,7 +127,7 @@ jobs:
 
       # Release published: add artifacts to release
       - name: Add artifacts to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/v')
         with:
           append_body: true

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Free Disk Space
         uses: ./.github/templates/clear-space
 
-      - uses: ikalnytskyi/action-setup-postgres@v7
+      - uses: ikalnytskyi/action-setup-postgres@10ab8a56cc77b4823c2bfa57b1d4dd5605ef0481 # v7
       - uses: ./.github/templates/minio
 
       - name: Install linux dependencies
@@ -55,12 +55,12 @@ jobs:
           name: cargo-x86_64-unknown-linux-gnu
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           cache: 'false'
           target: x86_64-unknown-linux-gnu
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         with:
           tool: sqlx-cli@0.8.3
 

--- a/.github/workflows/try_runtime.yml
+++ b/.github/workflows/try_runtime.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
   actions: write
 
+env:
+  TRY_RUNTIME_VERSION: 0.8.0
+  TRY_RUNTIME_SHA256: e269a1af856494e21b5ee17d0305c3a3a97ebca46d2c4b4db3ddddc290828b14
+
 jobs:
   build-runtimes:
     runs-on: ubuntu-22.04
@@ -22,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Install
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           cache: 'false'
 
@@ -59,7 +63,9 @@ jobs:
     steps:
       - name: Download try-runtime-cli
         run: |
-          curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.8.0/try-runtime-x86_64-unknown-linux-musl -o try-runtime
+          set -eu
+          curl --fail --location --silent --show-error "https://github.com/paritytech/try-runtime-cli/releases/download/v${TRY_RUNTIME_VERSION}/try-runtime-x86_64-unknown-linux-musl" -o try-runtime
+          echo "${TRY_RUNTIME_SHA256}  try-runtime" | shasum -a 256 -c -
           chmod +x ./try-runtime
         shell: bash
 


### PR DESCRIPTION
## Summary
- pin third-party GitHub Actions to immutable SHAs across the release and build workflows
- verify downloaded CI tools and artifacts for try-runtime, srtool/subwasm, and MinIO
- tighten workflow shell handling and move stable Docker publishing to the published-release boundary

## Notes
- removes the extra manual Docker publish dispatch path
- keeps the existing release and node asset-builder workflows separated