### PR TITLE
fix(fee-control): preserve feeless tx priority by dispatch class

### DIFF
--- a/pallets/fee_control/src/check_fee_wrapper.rs
+++ b/pallets/fee_control/src/check_fee_wrapper.rs
@@ -3,7 +3,10 @@ const INVALID_TX_SPONSORED_FEE_TOO_HIGH: u8 = 1;
 use crate::pallet::{Config, Event, Pallet};
 use alloc::vec::Vec;
 use codec::EncodeLike;
-use frame_support::{dispatch::CheckIfFeeless, traits::InstanceFilter};
+use frame_support::{
+	dispatch::{CheckIfFeeless, DispatchInfo, PostDispatchInfo},
+	traits::InstanceFilter,
+};
 use pallet_prelude::{
 	argon_primitives::{
 		CallTxPoolKeyProvider, CallTxValidityProvider, FeelessCallTxPoolKeyProvider,
@@ -291,7 +294,10 @@ where
     T: Config + pallet_transaction_payment::Config + pallet_proxy::Config + pallet_utility::Config + Send + Sync,
     T: pallet_proxy::Config<RuntimeCall = RuntimeCallOf<T>>,
     T: pallet_utility::Config<RuntimeCall = RuntimeCallOf<T>>,
-    RuntimeCallOf<T>: CheckIfFeeless<Origin = OriginFor<T>> + IsSubType<pallet_proxy::Call<T>> + IsSubType<pallet_utility::Call<T>>,
+    RuntimeCallOf<T>: CheckIfFeeless<Origin = OriginFor<T>>
+        + Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>
+        + IsSubType<pallet_proxy::Call<T>>
+        + IsSubType<pallet_utility::Call<T>>,
     <<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<T>>::Balance:
         EncodeLike<T::Balance> + From<T::Balance> + Into<T::Balance>,
     S: TransactionExtension<RuntimeCallOf<T>, Pre = pallet_transaction_payment::Pre<T>, Val = pallet_transaction_payment::Val<T>>,
@@ -333,7 +339,17 @@ where
         Self::validate_freshness(call, signer.clone())?;
         let general_pool_keys = Self::collect_pool_keys(call, signer);
         if call.is_feeless(&origin) {
-            let mut validity = ValidTransaction::default();
+			let synthetic_fee =
+				pallet_transaction_payment::Pallet::<T>::compute_fee(len as u32, info, Zero::zero());
+				let mut validity = ValidTransaction {
+				priority: pallet_transaction_payment::ChargeTransactionPayment::<T>::get_priority(
+					info,
+					len,
+					Zero::zero(),
+					synthetic_fee,
+				),
+				..Default::default()
+			};
 
             for key in general_pool_keys.iter().cloned() {
                 Self::push_pool_key(&mut validity, key);

--- a/pallets/fee_control/src/mock.rs
+++ b/pallets/fee_control/src/mock.rs
@@ -302,6 +302,13 @@ pub mod pallet_dummy {
 			Ok(())
 		}
 
+		#[pallet::weight((Weight::zero(), DispatchClass::Operational))]
+		#[pallet::feeless_if(|_origin: &OriginFor<T>, _key: &u32| -> bool { true })]
+		pub fn stacked_operational(_origin: OriginFor<T>, _key: u32) -> DispatchResult {
+			let _who = ensure_signed(_origin)?;
+			Ok(())
+		}
+
 		pub fn pooled(_origin: OriginFor<T>, _key: u32) -> DispatchResult {
 			let _who = ensure_signed(_origin)?;
 			Ok(())
@@ -318,6 +325,8 @@ pub mod pallet_dummy {
 				RuntimeCall::DummyPallet(pallet_dummy::Call::aux { key, .. }) => Some(key.encode()),
 				RuntimeCall::DummyPallet(pallet_dummy::Call::stacked { key }) =>
 					Some((b"feeless", key).encode()),
+				RuntimeCall::DummyPallet(pallet_dummy::Call::stacked_operational { key }) =>
+					Some((b"feeless", key).encode()),
 				_ => None,
 			}
 		}
@@ -328,6 +337,8 @@ pub mod pallet_dummy {
 				RuntimeCall::DummyPallet(pallet_dummy::Call::pooled { key }) =>
 					Some((b"general", key).encode()),
 				RuntimeCall::DummyPallet(pallet_dummy::Call::stacked { key }) =>
+					Some((b"general", key).encode()),
+				RuntimeCall::DummyPallet(pallet_dummy::Call::stacked_operational { key }) =>
 					Some((b"general", key).encode()),
 				RuntimeCall::DummyPallet(pallet_dummy::Call::sponsored_pooled { key }) =>
 					Some((b"general", key).encode()),

--- a/pallets/fee_control/src/test.rs
+++ b/pallets/fee_control/src/test.rs
@@ -20,11 +20,13 @@ use crate::mock::{
 	Balances, FeeAmount, FeeControl, LastPayer, MockChargePaymentExtension, PrepareCount, Proxy,
 	ProxyType, RuntimeCall, Test, TipAmount, ValidateCount,
 };
-use frame_support::dispatch::DispatchInfo;
+use codec::Encode;
+use frame_support::dispatch::{DispatchInfo, GetDispatchInfo};
 use frame_system::RawOrigin;
 use pallet_prelude::{
 	argon_primitives::CurrentTransactionFeeProvider, frame_support::traits::Currency,
 };
+use pallet_transaction_payment::ChargeTransactionPayment;
 use sp_runtime::{
 	traits::{DispatchTransaction, Hash},
 	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidityError},
@@ -103,6 +105,87 @@ fn validate_works() {
 		assert_eq!(ValidateCount::get(), 2);
 		assert_eq!(PrepareCount::get(), 0);
 		assert_eq!(res3.provides[0], (b"general", 7u32).encode());
+	});
+}
+
+#[test]
+fn feeless_calls_get_a_non_zero_priority_floor() {
+	new_test_ext().execute_with(|| {
+		set_argons(0, 1_000_000_000_000u128);
+
+		let feeless_call = RuntimeCall::DummyPallet(Call::<Test>::stacked { key: 7 });
+
+		let (feeless, _, _) = CheckFeeWrapper::<Test, ChargeTransactionPayment<Test>>::from(
+			ChargeTransactionPayment::from(0u128),
+		)
+		.validate_only(
+			Some(0).into(),
+			&feeless_call,
+			&feeless_call.get_dispatch_info(),
+			feeless_call.encoded_size(),
+			TransactionSource::External,
+			0,
+		)
+		.unwrap();
+		let expected_priority = ChargeTransactionPayment::<Test>::get_priority(
+			&feeless_call.get_dispatch_info(),
+			feeless_call.encoded_size(),
+			0u128,
+			pallet_transaction_payment::Pallet::<Test>::compute_fee(
+				feeless_call.encoded_size() as u32,
+				&feeless_call.get_dispatch_info(),
+				0u128,
+			),
+		);
+
+		assert!(feeless.priority > 0);
+		assert_eq!(feeless.priority, expected_priority);
+	});
+}
+
+#[test]
+fn operational_feeless_calls_keep_operational_priority_bump() {
+	new_test_ext().execute_with(|| {
+		set_argons(0, 1_000_000_000_000u128);
+
+		let call = RuntimeCall::DummyPallet(Call::<Test>::stacked_operational { key: 7 });
+		let normal_call = RuntimeCall::DummyPallet(Call::<Test>::stacked { key: 7 });
+
+		let (feeless, _, _) = CheckFeeWrapper::<Test, ChargeTransactionPayment<Test>>::from(
+			ChargeTransactionPayment::from(0u128),
+		)
+		.validate_only(
+			Some(0).into(),
+			&call,
+			&call.get_dispatch_info(),
+			call.encoded_size(),
+			TransactionSource::External,
+			0,
+		)
+		.unwrap();
+		let expected_priority = ChargeTransactionPayment::<Test>::get_priority(
+			&call.get_dispatch_info(),
+			call.encoded_size(),
+			0u128,
+			pallet_transaction_payment::Pallet::<Test>::compute_fee(
+				call.encoded_size() as u32,
+				&call.get_dispatch_info(),
+				0u128,
+			),
+		);
+		let normal_priority = ChargeTransactionPayment::<Test>::get_priority(
+			&normal_call.get_dispatch_info(),
+			normal_call.encoded_size(),
+			0u128,
+			pallet_transaction_payment::Pallet::<Test>::compute_fee(
+				normal_call.encoded_size() as u32,
+				&normal_call.get_dispatch_info(),
+				0u128,
+			),
+		);
+
+		assert_eq!(feeless.priority, expected_priority);
+		assert!(feeless.priority > normal_priority);
 	});
 }
 


### PR DESCRIPTION
`feeless_if` calls were skipping transaction payment validation entirely, so they fell back to default tx-pool priority. That made important free transactions, including operational ones like price index submissions, look easy to drop under congestion.

Use a synthetic zero-tip fee only for priority calculation so feeless transactions keep the same class-based ordering a paid zero-tip transaction would have. The runtime still skips fee withdrawal and tip charging; this only fixes how the pool ranks those transactions.
