### PR TITLE
Rename MintingGatewayV2 to MintingGateway

### DIFF
--- a/chains/ethereum/contracts/README.md
+++ b/chains/ethereum/contracts/README.md
@@ -16,13 +16,13 @@ At a high level, the shape is:
 ## Visual Overview
 
 ```text
-Users ----------------------> MintingGatewayV2 proxy ----------------------> ArgonToken / ArgonotToken
+Users ----------------------> MintingGateway proxy ----------------------> ArgonToken / ArgonotToken
 Guardian Safe -------------> pause()
 Admin Safe ---------------> proxy upgrade / migrate / unpause
 Admin Safe ---------------> ProxyAdmin --------> upgrade gateway implementation
 
 The tokens only trust the proxy address.
-The proxy runs MintingGatewayV2 implementation code behind that stable address.
+The proxy runs MintingGateway implementation code behind that stable address.
 ```
 
 At the basic level, that is the whole shape:
@@ -37,7 +37,7 @@ At the basic level, that is the whole shape:
 
 - `ArgonToken.sol`
 - `ArgonotToken.sol`
-- `MintingGatewayV2.sol`
+- `MintingGateway.sol`
 
 The two token contracts are intentionally boring. They expose `mint(...)` and `burnFrom(...)`, but
 only the gateway can call them. They do not have their own role system, and they do not expose a
@@ -46,7 +46,7 @@ public self-burn path.
 The gateway is where the actual protocol behavior lives:
 
 - steady-state transfer amounts are expressed in 6-decimal Argon runtime base units
-- MintingGatewayV2 runtime-unit amount and collateral fields use `uint128` balances
+- MintingGateway runtime-unit amount and collateral fields use `uint128` balances
 - `startTransferToArgon(...)` is the primary user path: the caller supplies the runtime-unit amount
   Argon should credit plus an ERC-2612 permit signature, and the gateway scales that amount into
   exact token base units before it permits, burns, and emits the outbound proof event
@@ -83,7 +83,7 @@ There are only three things to keep in your head:
 2. The gateway address is stable. The tokens keep trusting that one proxy address. They do not have
    a `setGateway(...)` path.
 
-3. The gateway code is upgradeable. The proxy points at a `MintingGatewayV2` implementation, and that
+3. The gateway code is upgradeable. The proxy points at a `MintingGateway` implementation, and that
    implementation can be replaced later.
 
 Today the split is:
@@ -127,13 +127,13 @@ initial migration distribution in the same place as the long-term burn behavior.
 
 The deployment order still matters:
 
-1. Deploy a bootstrap `MintingGatewayV2` implementation with zero canonical-token immutables.
+1. Deploy a bootstrap `MintingGateway` implementation with zero canonical-token immutables.
 2. Deploy the gateway proxy with the admin Safe as its current `ProxyAdmin` owner and the bootstrap
    `initialize(...)` calldata already encoded into the proxy constructor. Token-bearing gateway
    entrypoints stay blocked in this bootstrap state until the final implementation is installed with
    canonical token addresses configured.
 3. Deploy `ArgonToken` and `ArgonotToken` with the proxy address in their constructors.
-4. Deploy the final `MintingGatewayV2` implementation with the Argon and Argonot token addresses baked
+4. Deploy the final `MintingGateway` implementation with the Argon and Argonot token addresses baked
    in as immutables.
 5. Have the admin Safe call `ProxyAdmin.upgradeAndCall(...)` once to move the proxy onto that final
    implementation.

--- a/chains/ethereum/contracts/contracts/MintingGateway.sol
+++ b/chains/ethereum/contracts/contracts/MintingGateway.sol
@@ -8,10 +8,10 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-/// @title MintingGatewayV2
+/// @title MintingGateway
 /// @author Argon Protocol
 /// @notice Gateway for transfers between this chain and Argon, plus council-managed minting authority updates.
-contract MintingGatewayV2 is Initializable, OwnableUpgradeable, PausableUpgradeable {
+contract MintingGateway is Initializable, OwnableUpgradeable, PausableUpgradeable {
 	using MessageHashUtils for bytes32;
 
 	/// @notice Decimal precision used by Argon runtime balances.

--- a/chains/ethereum/contracts/deployments/mainnet/bootstrap/README.md
+++ b/chains/ethereum/contracts/deployments/mainnet/bootstrap/README.md
@@ -8,18 +8,18 @@ Expected generated artifacts:
 - `deployment-manifest.json` from
   `yarn workspace @argonprotocol/ethereum-contracts bootstrap:deploy`
 - deployment transaction hashes and constructor arguments
-- MintingGatewayV2 bootstrap implementation address, final implementation address, proxy address, and
+- MintingGateway bootstrap implementation address, final implementation address, proxy address, and
   proxy admin address
-- Safe calldata to upgrade the MintingGatewayV2 proxy to the final implementation with fixed Argon and
+- Safe calldata to upgrade the MintingGateway proxy to the final implementation with fixed Argon and
   Argonot token addresses
-- the Ethereum `chainId`, `MintingGatewayV2` address, and canonical token addresses that the future
+- the Ethereum `chainId`, `MintingGateway` address, and canonical token addresses that the future
   Argon-side runtime seeding step will need
 
 The current bootstrap slice is intentionally narrow:
 
 - `ArgonToken`
 - `ArgonotToken`
-- `MintingGatewayV2` with the user transfer-start path, first-council initialization, and one-time
+- `MintingGateway` with the user transfer-start path, first-council initialization, and one-time
   `migrate(...)`
 
 The bootstrap implementation only stores the first council summary. Token-bearing gateway

--- a/chains/ethereum/contracts/index.ts
+++ b/chains/ethereum/contracts/index.ts
@@ -1,6 +1,6 @@
 import argonTokenArtifact from './artifacts/contracts/ArgonToken.sol/ArgonToken.json' with { type: 'json' };
 import argonotTokenArtifact from './artifacts/contracts/ArgonotToken.sol/ArgonotToken.json' with { type: 'json' };
-import mintingGatewayArtifact from './artifacts/contracts/MintingGatewayV2.sol/MintingGatewayV2.json' with { type: 'json' };
+import mintingGatewayArtifact from './artifacts/contracts/MintingGateway.sol/MintingGateway.json' with { type: 'json' };
 import proxyAdminArtifact from './artifacts/contracts/ProxyArtifacts.sol/ProxyAdmin.json' with { type: 'json' };
 import transparentUpgradeableProxyArtifact from './artifacts/contracts/ProxyArtifacts.sol/TransparentUpgradeableProxy.json' with { type: 'json' };
 

--- a/chains/ethereum/contracts/script/bootstrap/deploy.ts
+++ b/chains/ethereum/contracts/script/bootstrap/deploy.ts
@@ -65,7 +65,7 @@ async function main() {
       ),
     );
 
-    const gatewayImplementationFactory = await ethers.getContractFactory('MintingGatewayV2');
+    const gatewayImplementationFactory = await ethers.getContractFactory('MintingGateway');
     const gatewayBootstrapImplementation = await gatewayImplementationFactory.deploy(
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -177,7 +177,7 @@ async function main() {
       safeTransactions: [
         {
           description:
-            'Upgrade MintingGatewayV2 proxy to final implementation with fixed canonical tokens',
+            'Upgrade MintingGateway proxy to final implementation with fixed canonical tokens',
           target: proxyAdminAddress,
           value: '0',
           data: proxyAdminInterface.encodeFunctionData('upgradeAndCall', [
@@ -188,12 +188,12 @@ async function main() {
         },
       ],
       notes: [
-        'Canonical tokens are deployed with the MintingGatewayV2 proxy address fixed in their constructors.',
-        'The proxy is first deployed against a bootstrap MintingGatewayV2 implementation with zero canonical token immutables.',
+        'Canonical tokens are deployed with the MintingGateway proxy address fixed in their constructors.',
+        'The proxy is first deployed against a bootstrap MintingGateway implementation with zero canonical token immutables.',
         'That proxy initialization stores the first council summary.',
         'Token-bearing gateway entrypoints reject until the proxy is upgraded to the final implementation with canonical token addresses configured.',
-        'After the token contracts exist, the admin Safe upgrades the proxy through ProxyAdmin to the final MintingGatewayV2 implementation that has the Argon and Argonot token addresses baked in as immutables.',
-        'MintingGatewayV2 business ownership starts under the admin Safe.',
+        'After the token contracts exist, the admin Safe upgrades the proxy through ProxyAdmin to the final MintingGateway implementation that has the Argon and Argonot token addresses baked in as immutables.',
+        'MintingGateway business ownership starts under the admin Safe.',
         'The guardian Safe can pause immediately, while unpause remains on the admin Safe owner path.',
         'The proxy admin is initially owned by the admin Safe.',
         'A later hardening step can transfer ProxyAdmin ownership to a TimelockController once the governance flow is ready.',

--- a/chains/ethereum/contracts/script/gas/measure.ts
+++ b/chains/ethereum/contracts/script/gas/measure.ts
@@ -366,14 +366,14 @@ async function deployGatewayStack(council: Council) {
     (await ethers.getSigners()) as AccountSigner[];
 
   const gatewayFactory = (await ethers.getContractFactory(
-    'MintingGatewayV2',
+    'MintingGateway',
   )) as unknown as ContractFactory<ContractWithDeployment>;
   const gatewayBootstrapImplementation = await gatewayFactory.deploy(
     ethers.ZeroAddress,
     ethers.ZeroAddress,
   );
   const gatewayBootstrapImplementationTx = requireDeploymentTransaction(
-    'MintingGatewayV2 bootstrap implementation',
+    'MintingGateway bootstrap implementation',
     gatewayBootstrapImplementation.deploymentTransaction(),
   );
   await gatewayBootstrapImplementation.waitForDeployment();
@@ -402,7 +402,7 @@ async function deployGatewayStack(council: Council) {
   await gatewayProxy.waitForDeployment();
 
   const gateway = (await ethers.getContractAt(
-    'MintingGatewayV2',
+    'MintingGateway',
     await gatewayProxy.getAddress(),
   )) as unknown as GatewayContract;
 

--- a/chains/ethereum/contracts/test/ArgonToken.test.ts
+++ b/chains/ethereum/contracts/test/ArgonToken.test.ts
@@ -17,7 +17,7 @@ describe('ArgonToken', () => {
     const councilTotalWeight = 1n;
     const initialMicrogonsPerArgonot = 1_000_000n;
 
-    const gatewayImplementationFactory = await ethers.getContractFactory('MintingGatewayV2');
+    const gatewayImplementationFactory = await ethers.getContractFactory('MintingGateway');
     const gatewayImplementation = (await gatewayImplementationFactory.deploy(
       ethers.ZeroAddress,
       ethers.ZeroAddress,

--- a/chains/ethereum/contracts/test/MintingGateway.test.ts
+++ b/chains/ethereum/contracts/test/MintingGateway.test.ts
@@ -71,7 +71,7 @@ afterAll(async () => {
   await connection.close();
 });
 
-describe('MintingGatewayV2', () => {
+describe('MintingGateway', () => {
   async function getGatewayHashContext(gateway: {
     getAddress(): Promise<string>;
   }): Promise<MintingGatewayHashContext> {
@@ -221,7 +221,7 @@ describe('MintingGatewayV2', () => {
       mintingAuthoritySigner,
     ] = await ethers.getSigners();
 
-    const gatewayFactory = await ethers.getContractFactory('MintingGatewayV2');
+    const gatewayFactory = await ethers.getContractFactory('MintingGateway');
     const gatewayBootstrapImplementation = await gatewayFactory.deploy(
       ethers.ZeroAddress,
       ethers.ZeroAddress,
@@ -253,7 +253,7 @@ describe('MintingGatewayV2', () => {
     await gatewayProxy.waitForDeployment();
 
     const gateway = (await ethers.getContractAt(
-      'MintingGatewayV2',
+      'MintingGateway',
       await gatewayProxy.getAddress(),
     )) as any;
 

--- a/client/nodejs/src/__test__/ethereum.e2e.test.ts
+++ b/client/nodejs/src/__test__/ethereum.e2e.test.ts
@@ -86,7 +86,7 @@ async function signGatewayPermit(args: {
 }
 
 describe.skipIf(SKIP_E2E || !TestEthereum.isInstalled())('Ethereum proof e2e', () => {
-  it('boots a real ethereum devnet and proves two MintingGatewayV2 burns in one proof batch', async () => {
+  it('boots a real ethereum devnet and proves two MintingGateway burns in one proof batch', async () => {
     const ethereum = new TestEthereum();
     const endpoints = await ethereum.launch({
       consensusClient: 'lodestar',

--- a/testing/nodejs/src/ethereumContracts.ts
+++ b/testing/nodejs/src/ethereumContracts.ts
@@ -14,7 +14,7 @@ function loadArtifact(fileName: string) {
 
 const argonTokenArtifact = loadArtifact('ArgonToken.json');
 const argonotTokenArtifact = loadArtifact('ArgonotToken.json');
-const mintingGatewayArtifact = loadArtifact('MintingGatewayV2.json');
+const mintingGatewayArtifact = loadArtifact('MintingGateway.json');
 const proxyAdminArtifact = loadArtifact('ProxyAdmin.json');
 const transparentUpgradeableProxyArtifact = loadArtifact('TransparentUpgradeableProxy.json');
 

--- a/testing/nodejs/tsup.config.ts
+++ b/testing/nodejs/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     const contractArtifacts = [
       ['artifacts/contracts/ArgonToken.sol/ArgonToken.json', 'ArgonToken.json'],
       ['artifacts/contracts/ArgonotToken.sol/ArgonotToken.json', 'ArgonotToken.json'],
-      ['artifacts/contracts/MintingGatewayV2.sol/MintingGatewayV2.json', 'MintingGatewayV2.json'],
+      ['artifacts/contracts/MintingGateway.sol/MintingGateway.json', 'MintingGateway.json'],
       ['artifacts/contracts/ProxyArtifacts.sol/ProxyAdmin.json', 'ProxyAdmin.json'],
       [
         'artifacts/contracts/ProxyArtifacts.sol/TransparentUpgradeableProxy.json',


### PR DESCRIPTION
## Summary
- rename the Ethereum gateway contract surface from MintingGatewayV2 to MintingGateway
- update contract tests, artifact packaging, and bootstrap/gas scripts to use the new contract name
- align the contract docs and related node test text with the unversioned gateway name