### PR TITLE
fix(nodejs): keep test aliases out of package builds

### DIFF
--- a/client/nodejs/package.json
+++ b/client/nodejs/package.json
@@ -19,7 +19,7 @@
     "test": "vitest --run --config vitest.config.ts",
     "tsc": "yarn workspace @argonprotocol/ethereum-contracts build && tsup",
     "watch": "tsup --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit -p tsconfig.test.json"
   },
   "files": [
     "lib/",

--- a/client/nodejs/src/__test__/EthereumGatewayQueue.test.ts
+++ b/client/nodejs/src/__test__/EthereumGatewayQueue.test.ts
@@ -5,7 +5,7 @@ import {
   hashMintingGatewayActivateMintingAuthorityApproval,
   type MintingGatewayMintingAuthorityActivationTarget,
 } from '../EvmContracts';
-import { getReadyEthereumGatewayUpdates } from '../../../../testing/nodejs/src/index';
+import { getReadyEthereumGatewayUpdates } from '@argonprotocol/testing';
 import type { Hex } from 'viem';
 
 const ZERO_HASH: Hex = `0x${'00'.repeat(32)}`;

--- a/client/nodejs/src/__test__/ethereum.e2e.test.ts
+++ b/client/nodejs/src/__test__/ethereum.e2e.test.ts
@@ -9,7 +9,7 @@ import {
   SKIP_E2E,
   teardown,
   TestEthereum,
-} from '../../../../testing/nodejs/src/index';
+} from '@argonprotocol/testing';
 import { repeatByteHex, waitForExecutionBlockAtOrAbove } from './ethereumE2eTestUtils';
 import { toHex, type Hex } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';

--- a/client/nodejs/src/__test__/ethereumE2eTestUtils.ts
+++ b/client/nodejs/src/__test__/ethereumE2eTestUtils.ts
@@ -15,7 +15,7 @@ import type {
 import { privateKeyToAccount } from 'viem/accounts';
 import type { Hex, RpcTransactionReceipt } from 'viem';
 import { createPublicClient, createWalletClient, defineChain, parseSignature } from 'viem';
-import { TestEthereum } from '../../../../testing/nodejs/src/index';
+import { TestEthereum } from '@argonprotocol/testing';
 
 export async function signGatewayPermit(args: {
   account: ReturnType<typeof privateKeyToAccount>;

--- a/client/nodejs/tsconfig.json
+++ b/client/nodejs/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "paths": {
       "@argonprotocol/mainchain": ["src/index.ts"],
-      "@argonprotocol/testing": ["../../testing/nodejs/src/index.ts"],
       "@polkadot/api/augment": ["src/interfaces/augment-api.ts"],
       "@polkadot/types/lookup": ["src/interfaces/types-lookup.ts"],
       "@polkadot/types/augment": ["src/interfaces/augment-types.ts"],
@@ -24,7 +23,7 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
-    "rootDir": "../..",
+    "rootDir": "./src",
     "sourceMap": true,
     "importHelpers": true,
     "skipDefaultLibCheck": true,

--- a/client/nodejs/tsconfig.test.json
+++ b/client/nodejs/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@argonprotocol/mainchain": ["src/index.ts"],
+      "@argonprotocol/testing": ["../../testing/nodejs/src/index.ts"],
+      "@polkadot/api/augment": ["src/interfaces/augment-api.ts"],
+      "@polkadot/types/lookup": ["src/interfaces/types-lookup.ts"],
+      "@polkadot/types/augment": ["src/interfaces/augment-types.ts"],
+      "@argonprotocol/mainchain/interfaces/*": ["src/interfaces/*/index.ts", "src/interfaces/*.ts"]
+    },
+    "module": "esnext",
+    "rootDir": "../.."
+  }
+}

--- a/testing/nodejs/package.json
+++ b/testing/nodejs/package.json
@@ -16,7 +16,7 @@
     "build": "yarn workspace @argonprotocol/ethereum-contracts run build && tsup",
     "tsc": "yarn workspace @argonprotocol/ethereum-contracts run build && tsup",
     "watch": "tsup --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit -p tsconfig.test.json"
   },
   "files": [
     "lib/"

--- a/testing/nodejs/tsconfig.json
+++ b/testing/nodejs/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "paths": {
-      "@argonprotocol/mainchain": ["../../client/nodejs/src/index.ts"],
-      "@argonprotocol/testing": ["src/index.ts"]
-    },
     "target": "es2022",
-    "module": "esnext",
+    "module": "es2022",
     "declaration": true,
     "noImplicitAny": true,
     "noUnusedLocals": false,
@@ -19,7 +15,7 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
-    "rootDir": "../..",
+    "rootDir": "./src",
     "sourceMap": true,
     "importHelpers": true,
     "skipDefaultLibCheck": true,

--- a/testing/nodejs/tsconfig.test.json
+++ b/testing/nodejs/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@argonprotocol/mainchain": ["../../client/nodejs/src/index.ts"],
+      "@polkadot/api/augment": ["../../client/nodejs/src/interfaces/augment-api.ts"],
+      "@polkadot/types/lookup": ["../../client/nodejs/src/interfaces/types-lookup.ts"],
+      "@polkadot/types/augment": ["../../client/nodejs/src/interfaces/augment-types.ts"],
+      "@argonprotocol/mainchain/interfaces/*": [
+        "../../client/nodejs/src/interfaces/*/index.ts",
+        "../../client/nodejs/src/interfaces/*.ts"
+      ]
+    },
+    "module": "esnext",
+    "resolveJsonModule": true,
+    "rootDir": "../.."
+  }
+}

--- a/testing/nodejs/tsup.config.ts
+++ b/testing/nodejs/tsup.config.ts
@@ -3,7 +3,23 @@ import { promises as fs } from 'node:fs';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  dts: true,
+  dts: {
+    compilerOptions: {
+      paths: {
+        '@argonprotocol/mainchain': ['../../client/nodejs/src/index.ts'],
+        '@polkadot/api/augment': ['../../client/nodejs/src/interfaces/augment-api.ts'],
+        '@polkadot/types/lookup': ['../../client/nodejs/src/interfaces/types-lookup.ts'],
+        '@polkadot/types/augment': ['../../client/nodejs/src/interfaces/augment-types.ts'],
+        '@argonprotocol/mainchain/interfaces/*': [
+          '../../client/nodejs/src/interfaces/*/index.ts',
+          '../../client/nodejs/src/interfaces/*.ts',
+        ],
+      },
+      module: 'esnext',
+      resolveJsonModule: true,
+      rootDir: '../..',
+    },
+  },
   format: ['esm', 'cjs'],
   clean: true,
   splitting: false,


### PR DESCRIPTION
## Summary
Root workspace builds no longer inline client source through `@argonprotocol/testing`, so the Node.js packages resolve Polkadot types from their package boundaries again.
The local source-alias shortcut still works for client tests by moving it into a dedicated test tsconfig instead of the package build config.

## Testing
- `yarn typecheck`
- `yarn tsc`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
