### PR TITLE
Refund successful vault admin maintenance batches

### DIFF
--- a/pallets/fee_control/src/check_fee_wrapper.rs
+++ b/pallets/fee_control/src/check_fee_wrapper.rs
@@ -9,8 +9,8 @@ use frame_support::{
 };
 use pallet_prelude::{
 	argon_primitives::{
-		CallTxPoolKeyProvider, CallTxValidityProvider, FeelessCallTxPoolKeyProvider,
-		TransactionSponsorProvider, TxSponsor,
+		CallFeeRefundProvider, CallTxPoolKeyProvider, CallTxValidityProvider,
+		FeelessCallTxPoolKeyProvider, TransactionSponsorProvider, TxSponsor,
 	},
 	sp_runtime::traits::{
 		DispatchOriginOf, Implication, PostDispatchInfoOf, StaticLookup, TransactionExtension, Zero,
@@ -56,7 +56,7 @@ impl<T, S> From<S> for CheckFeeWrapper<T, S> {
 
 pub enum Intermediate<T, O, A> {
 	/// The wrapped extension should be applied.
-	RequiresFee(T, O, A),
+	RequiresFee { inner: T, delegated_origin: O, tx_sponsor: A, refund_fee_on_success: bool },
 	/// The wrapped extension should be skipped.
 	Feeless(O),
 }
@@ -338,10 +338,10 @@ where
         let signer = origin.as_signer().cloned();
         Self::validate_freshness(call, signer.clone())?;
         let general_pool_keys = Self::collect_pool_keys(call, signer);
-        if call.is_feeless(&origin) {
+		if call.is_feeless(&origin) {
 			let synthetic_fee =
 				pallet_transaction_payment::Pallet::<T>::compute_fee(len as u32, info, Zero::zero());
-				let mut validity = ValidTransaction {
+			let mut validity = ValidTransaction {
 				priority: pallet_transaction_payment::ChargeTransactionPayment::<T>::get_priority(
 					info,
 					len,
@@ -358,13 +358,16 @@ where
                 Self::push_pool_key(&mut validity, key);
             }
 
-            Ok((validity, Feeless(origin.clone()), origin))
-        } else {
-            let mut delegated_origin = origin.clone();
-            let mut tx_sponsor = None;
-            if let Some(signer) = origin.as_signer()
-                && let Some(sponsor) =
-                    T::TransactionSponsorProviders::get_transaction_sponsor(signer, inner_call)
+			Ok((validity, Feeless(origin.clone()), origin))
+		} else {
+			let mut delegated_origin = origin.clone();
+			let mut tx_sponsor = None;
+			// Proxy wrappers should not affect whether a runtime-defined batch combination refunds
+			// on success, so we evaluate policy against the effective inner call.
+			let refund_fee_on_success = T::CallFeeRefundProviders::refund_fee_on_success(inner_call);
+			if let Some(signer) = origin.as_signer()
+				&& let Some(sponsor) =
+					T::TransactionSponsorProviders::get_transaction_sponsor(signer, inner_call)
                 {
                     log::debug!("fee sponsor detected: payer={:?}", sponsor.payer);
                     delegated_origin.set_caller_from_signed(sponsor.payer.clone());
@@ -395,14 +398,23 @@ where
             for key in general_pool_keys {
                 Self::push_pool_key(&mut validity, key);
             }
-            if let Some(key) = tx_sponsor.as_ref().and_then(|sponsor| sponsor.unique_tx_key.clone())
-            {
-                Self::push_pool_key(&mut validity, key);
-            }
+			if let Some(key) = tx_sponsor.as_ref().and_then(|sponsor| sponsor.unique_tx_key.clone())
+			{
+				Self::push_pool_key(&mut validity, key);
+			}
 
-            Ok((validity, RequiresFee(inner_val, delegated_origin, tx_sponsor), origin_out))
-        }
-    }
+			Ok((
+				validity,
+				RequiresFee {
+					inner: inner_val,
+					delegated_origin,
+					tx_sponsor,
+					refund_fee_on_success,
+				},
+				origin_out,
+			))
+		}
+	}
 
     fn prepare(
         self,
@@ -412,15 +424,20 @@ where
         info: &DispatchInfoOf<RuntimeCallOf<T>>,
         len: usize,
     ) -> Result<Self::Pre, TransactionValidityError> {
-        Self::validate_freshness(call, origin.as_signer().cloned())?;
+		Self::validate_freshness(call, origin.as_signer().cloned())?;
 
-        match val {
-            RequiresFee(inner, delegated_origin, sponsor) => {
-                let res = self.0.prepare(inner, &delegated_origin, call, info, len)?;
-                Ok(RequiresFee(res, delegated_origin, sponsor))
-            },
-            Feeless(origin) => Ok(Feeless(origin)),
-        }
+		match val {
+			RequiresFee { inner, delegated_origin, tx_sponsor, refund_fee_on_success } => {
+				let res = self.0.prepare(inner, &delegated_origin, call, info, len)?;
+				Ok(RequiresFee {
+					inner: res,
+					delegated_origin,
+					tx_sponsor,
+					refund_fee_on_success,
+				})
+			},
+			Feeless(origin) => Ok(Feeless(origin)),
+		}
     }
 
     fn post_dispatch_details(
@@ -428,14 +445,25 @@ where
         info: &DispatchInfoOf<RuntimeCallOf<T>>,
         post_info: &PostDispatchInfoOf<RuntimeCallOf<T>>,
         len: usize,
-        result: &DispatchResult,
-    ) -> Result<Weight, TransactionValidityError> {
-        match pre {
-            RequiresFee(pre, origin, tx_sponsor) => {
-                let result = S::post_dispatch_details(pre, info, post_info, len, result)?;
-                if let (Some(sponsor), Some(from)) = (tx_sponsor, origin.as_signer()) {
-                    Pallet::<T>::deposit_event(Event::<T>::FeeDelegated {
-                        origin: origin.clone().into_caller(),
+		result: &DispatchResult,
+	) -> Result<Weight, TransactionValidityError> {
+		match pre {
+			RequiresFee { inner: pre, delegated_origin: origin, tx_sponsor, refund_fee_on_success } => {
+				let adjusted_post_info;
+				let post_info = if refund_fee_on_success && result.is_ok() && post_info.pays_fee == Pays::Yes
+				{
+					adjusted_post_info = PostDispatchInfo {
+						actual_weight: post_info.actual_weight,
+						pays_fee: Pays::No,
+					};
+					&adjusted_post_info
+				} else {
+					post_info
+				};
+				let result = S::post_dispatch_details(pre, info, post_info, len, result)?;
+				if let (Some(sponsor), Some(from)) = (tx_sponsor, origin.as_signer()) {
+					Pallet::<T>::deposit_event(Event::<T>::FeeDelegated {
+						origin: origin.clone().into_caller(),
                         from: from.clone(),
                         to: sponsor.payer
                     });
@@ -445,7 +473,7 @@ where
             Feeless(origin) => {
                 Pallet::<T>::deposit_event(Event::<T>::FeeSkipped { origin: origin.into_caller() });
                 Ok(Weight::zero())
-            },
-        }
-    }
+			},
+		}
+	}
 }

--- a/pallets/fee_control/src/lib.rs
+++ b/pallets/fee_control/src/lib.rs
@@ -19,9 +19,9 @@ use pallet_prelude::*;
 pub mod pallet {
 	use super::*;
 	use pallet_prelude::argon_primitives::{
-		CallTxPoolKeyProvider, CallTxValidityProvider, CurrentTransactionFeeProvider,
-		CurrentTransactionFeeProviderWeightInfo, FeelessCallTxPoolKeyProvider,
-		TransactionSponsorProvider,
+		CallFeeRefundProvider, CallTxPoolKeyProvider, CallTxValidityProvider,
+		CurrentTransactionFeeProvider, CurrentTransactionFeeProviderWeightInfo,
+		FeelessCallTxPoolKeyProvider, TransactionSponsorProvider,
 	};
 
 	#[pallet::config]
@@ -56,6 +56,10 @@ pub mod pallet {
 			Self::RuntimeCall,
 			Self::Balance,
 		>;
+
+		/// Provides runtime-owned call combinations that should refund their fee after successful
+		/// dispatch.
+		type CallFeeRefundProviders: CallFeeRefundProvider<Self::RuntimeCall>;
 	}
 
 	#[pallet::pallet]

--- a/pallets/fee_control/src/mock.rs
+++ b/pallets/fee_control/src/mock.rs
@@ -2,7 +2,7 @@ use pallet_prelude::*;
 
 use super::*;
 use crate as pallet_fee_control;
-use frame_support::{derive_impl, parameter_types, traits::InstanceFilter};
+use frame_support::{derive_impl, dispatch::Pays, parameter_types, traits::InstanceFilter};
 use pallet_prelude::{
 	frame_support::traits::{Imbalance, OnUnbalanced},
 	pallet_balances::AccountData,
@@ -13,7 +13,7 @@ use polkadot_sdk::{
 	sp_core::{ConstU128, ConstU8},
 };
 use sp_runtime::{
-	traits::{DispatchOriginOf, TransactionExtension},
+	traits::{DispatchOriginOf, PostDispatchInfoOf, TransactionExtension},
 	transaction_validity::ValidTransaction,
 };
 
@@ -46,6 +46,7 @@ impl pallet_fee_control::Config for Test {
 	type FeelessCallTxPoolKeyProviders = DummyPallet;
 	type CallTxPoolKeyProviders = DummyPallet;
 	type CallTxValidityProviders = DummyPallet;
+	type CallFeeRefundProviders = DummyPallet;
 }
 parameter_types! {
 	pub(crate) static TipUnbalancedAmount: Balance = 0;
@@ -179,6 +180,7 @@ parameter_types! {
 	pub static TipAmount: Balance = 500;
 	pub static FeeAmount: Balance = 1000;
 	pub static LastPayer: Option<u64> = None;
+	pub static LastPostDispatchPaysFee: Option<Pays> = None;
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo)]
@@ -257,6 +259,17 @@ impl TransactionExtension<RuntimeCall> for MockChargePaymentExtension {
 			},
 		}
 	}
+
+	fn post_dispatch_details(
+		_pre: Self::Pre,
+		_info: &DispatchInfoOf<RuntimeCall>,
+		post_info: &PostDispatchInfoOf<RuntimeCall>,
+		_len: usize,
+		_result: &DispatchResult,
+	) -> Result<Weight, TransactionValidityError> {
+		LastPostDispatchPaysFee::set(Some(post_info.pays_fee));
+		Ok(Weight::zero())
+	}
 }
 
 #[frame_support::pallet(dev_mode)]
@@ -264,8 +277,8 @@ pub mod pallet_dummy {
 	use crate::mock::{pallet_dummy, RuntimeCall};
 	use pallet_prelude::{
 		argon_primitives::{
-			CallTxPoolKeyProvider, CallTxValidityProvider, FeelessCallTxPoolKeyProvider,
-			TransactionSponsorProvider, TxSponsor,
+			CallFeeRefundProvider, CallTxPoolKeyProvider, CallTxValidityProvider,
+			FeelessCallTxPoolKeyProvider, TransactionSponsorProvider, TxSponsor,
 		},
 		*,
 	};
@@ -316,6 +329,12 @@ pub mod pallet_dummy {
 
 		pub fn sponsored_pooled(_origin: OriginFor<T>, _key: u32) -> DispatchResult {
 			let _who = ensure_signed(_origin)?;
+			Ok(())
+		}
+
+		pub fn combo_paid(_origin: OriginFor<T>, should_fail: bool) -> DispatchResult {
+			let _who = ensure_signed(_origin)?;
+			ensure!(!should_fail, DispatchError::Other("combo failed"));
 			Ok(())
 		}
 	}
@@ -379,6 +398,21 @@ pub mod pallet_dummy {
 				});
 			}
 			None
+		}
+	}
+	impl<T: Config> CallFeeRefundProvider<RuntimeCall> for Pallet<T> {
+		fn refund_fee_on_success(call: &RuntimeCall) -> bool {
+			matches!(
+				call,
+				RuntimeCall::Utility(pallet_utility::Call::batch_all { calls })
+					if matches!(
+						calls.as_slice(),
+						[
+							RuntimeCall::DummyPallet(pallet_dummy::Call::stacked { .. }),
+							RuntimeCall::DummyPallet(pallet_dummy::Call::combo_paid { should_fail: false })
+						]
+					)
+			)
 		}
 	}
 }

--- a/pallets/fee_control/src/test.rs
+++ b/pallets/fee_control/src/test.rs
@@ -17,11 +17,12 @@ use super::*;
 use crate::mock::{
 	new_test_ext,
 	pallet_dummy::{Call, ConsumedPoolKeys, OneUseCodes},
-	Balances, FeeAmount, FeeControl, LastPayer, MockChargePaymentExtension, PrepareCount, Proxy,
-	ProxyType, RuntimeCall, Test, TipAmount, ValidateCount,
+	Balances, FeeAmount, FeeControl, LastPayer, LastPostDispatchPaysFee,
+	MockChargePaymentExtension, PrepareCount, Proxy, ProxyType, RuntimeCall, Test, TipAmount,
+	ValidateCount,
 };
 use codec::Encode;
-use frame_support::dispatch::{DispatchInfo, GetDispatchInfo};
+use frame_support::dispatch::{DispatchInfo, GetDispatchInfo, Pays};
 use frame_system::RawOrigin;
 use pallet_prelude::{
 	argon_primitives::CurrentTransactionFeeProvider, frame_support::traits::Currency,
@@ -350,6 +351,100 @@ fn validate_rejects_stale_batched_calls() {
 			result,
 			Err(TransactionValidityError::Invalid(InvalidTransaction::Stale))
 		));
+	});
+}
+
+#[test]
+fn post_dispatch_refunds_configured_batch_all_combinations_on_success() {
+	new_test_ext().execute_with(|| {
+		set_argons(0, 1_000_000u128);
+		LastPostDispatchPaysFee::set(None);
+
+		let call = RuntimeCall::Utility(pallet_utility::Call::<Test>::batch_all {
+			calls: vec![
+				RuntimeCall::DummyPallet(Call::<Test>::stacked { key: 7 }),
+				RuntimeCall::DummyPallet(Call::<Test>::combo_paid { should_fail: false }),
+			],
+		});
+		let info = call.get_dispatch_info();
+		let len = call.encoded_size();
+		let wrapper =
+			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension);
+		let (_, val, validated_origin) = wrapper
+			.validate_only(Some(0).into(), &call, &info, len, TransactionSource::External, 0)
+			.unwrap();
+		let pre =
+			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension)
+				.prepare(val, &validated_origin, &call, &info, len)
+				.unwrap();
+
+		let dispatch_result = call.dispatch(validated_origin);
+		let dispatch_outcome = match &dispatch_result {
+			Ok(_) => Ok(()),
+			Err(err) => Err(err.error.clone()),
+		};
+		let post_info = match &dispatch_result {
+			Ok(post_info) => post_info,
+			Err(err) => &err.post_info,
+		};
+
+		CheckFeeWrapper::<Test, MockChargePaymentExtension>::post_dispatch_details(
+			pre,
+			&info,
+			post_info,
+			len,
+			&dispatch_outcome,
+		)
+		.unwrap();
+
+		assert_eq!(LastPostDispatchPaysFee::get(), Some(Pays::No));
+	});
+}
+
+#[test]
+fn post_dispatch_keeps_fees_for_failed_configured_batch_all_combinations() {
+	new_test_ext().execute_with(|| {
+		set_argons(0, 1_000_000u128);
+		LastPostDispatchPaysFee::set(None);
+
+		let call = RuntimeCall::Utility(pallet_utility::Call::<Test>::batch_all {
+			calls: vec![
+				RuntimeCall::DummyPallet(Call::<Test>::stacked { key: 7 }),
+				RuntimeCall::DummyPallet(Call::<Test>::combo_paid { should_fail: true }),
+			],
+		});
+		let info = call.get_dispatch_info();
+		let len = call.encoded_size();
+		let wrapper =
+			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension);
+		let (_, val, validated_origin) = wrapper
+			.validate_only(Some(0).into(), &call, &info, len, TransactionSource::External, 0)
+			.unwrap();
+		let pre =
+			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension)
+				.prepare(val, &validated_origin, &call, &info, len)
+				.unwrap();
+
+		let dispatch_result = call.dispatch(validated_origin);
+		let dispatch_outcome = match &dispatch_result {
+			Ok(_) => Ok(()),
+			Err(err) => Err(err.error.clone()),
+		};
+		let post_info = match &dispatch_result {
+			Ok(post_info) => post_info,
+			Err(err) => &err.post_info,
+		};
+
+		CheckFeeWrapper::<Test, MockChargePaymentExtension>::post_dispatch_details(
+			pre,
+			&info,
+			post_info,
+			len,
+			&dispatch_outcome,
+		)
+		.unwrap();
+
+		assert_eq!(LastPostDispatchPaysFee::get(), Some(Pays::Yes));
 	});
 }
 

--- a/primitives/src/providers.rs
+++ b/primitives/src/providers.rs
@@ -1105,3 +1105,26 @@ impl<AccountId, RuntimeCall, Balance> TransactionSponsorProvider<AccountId, Runt
 		None
 	}
 }
+
+/// Provides runtime-defined call combinations that should be refunded after successful dispatch.
+///
+/// This is evaluated against the effective call after proxy unwrapping, allowing the runtime to
+/// keep fee-refund policy close to its own call-shape and proxy rules instead of hard-coding
+/// pallet-specific combinations inside `pallet_fee_control`.
+pub trait CallFeeRefundProvider<RuntimeCall> {
+	fn refund_fee_on_success(call: &RuntimeCall) -> bool;
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(5)]
+impl<RuntimeCall> CallFeeRefundProvider<RuntimeCall> for Tuple {
+	fn refund_fee_on_success(call: &RuntimeCall) -> bool {
+		for_tuples!(
+			#(
+			if Tuple::refund_fee_on_success(call) {
+				return true;
+			}
+			)*
+		);
+		false
+	}
+}

--- a/runtime/argon/src/lib.rs
+++ b/runtime/argon/src/lib.rs
@@ -130,6 +130,7 @@ mod runtime {
 }
 
 argon_runtime_common::call_filters!();
+argon_runtime_common::vault_admin_fee_refund_policy!();
 argon_runtime_common::deal_with_fees!();
 argon_runtime_common::inject_runtime_vars!();
 argon_runtime_common::inject_common_apis!();
@@ -750,4 +751,5 @@ impl pallet_fee_control::Config for Runtime {
 	type CallTxPoolKeyProviders = (BitcoinLocks, EthereumVerifier, CrosschainTransfer);
 	type CallTxValidityProviders = (EthereumVerifier, CrosschainTransfer);
 	type TransactionSponsorProviders = ProxyFeeDelegate<Runtime>;
+	type CallFeeRefundProviders = VaultAdminFeeRefundPolicy;
 }

--- a/runtime/canary/src/lib.rs
+++ b/runtime/canary/src/lib.rs
@@ -133,6 +133,7 @@ mod runtime {
 argon_runtime_common::inject_runtime_vars!();
 argon_runtime_common::inject_common_apis!();
 argon_runtime_common::call_filters!();
+argon_runtime_common::vault_admin_fee_refund_policy!();
 argon_runtime_common::deal_with_fees!();
 
 #[derive_impl(frame_system::config_preludes::SolochainDefaultConfig)]
@@ -752,4 +753,5 @@ impl pallet_fee_control::Config for Runtime {
 	type CallTxPoolKeyProviders = (BitcoinLocks, EthereumVerifier, CrosschainTransfer);
 	type CallTxValidityProviders = (EthereumVerifier, CrosschainTransfer);
 	type TransactionSponsorProviders = ProxyFeeDelegate<Runtime>;
+	type CallFeeRefundProviders = VaultAdminFeeRefundPolicy;
 }

--- a/runtime/common/src/call_filters.rs
+++ b/runtime/common/src/call_filters.rs
@@ -25,6 +25,38 @@ macro_rules! call_filters {
 			}
 		}
 
+		pub struct VaultAdminCallFilter;
+
+		impl VaultAdminCallFilter {
+			fn is_crosschain_vault_admin_call(call: &RuntimeCall) -> bool {
+				matches!(
+					call,
+					RuntimeCall::CrosschainTransfer(
+						pallet_crosschain_transfer::Call::register_council_signer { .. } |
+							pallet_crosschain_transfer::Call::register_minting_authority { .. } |
+							pallet_crosschain_transfer::Call::approve_queue_entries { .. } |
+							pallet_crosschain_transfer::Call::collateralize_transfer { .. } |
+							pallet_crosschain_transfer::Call::deactivate_minting_authority { .. }
+					)
+				)
+			}
+
+			fn is_single_vault_admin_call(call: &RuntimeCall) -> bool {
+				matches!(
+					call,
+					RuntimeCall::Vaults(..) |
+						RuntimeCall::Treasury(pallet_treasury::Call::buy_bonds { .. }) |
+						RuntimeCall::Treasury(pallet_treasury::Call::liquidate_bond_lot { .. }) |
+						RuntimeCall::BitcoinLocks(pallet_bitcoin_locks::Call::initialize { .. }) |
+						RuntimeCall::BitcoinLocks(
+							pallet_bitcoin_locks::Call::cosign_release { .. }
+						) | RuntimeCall::BitcoinLocks(
+						pallet_bitcoin_locks::Call::cosign_orphaned_utxo_release { .. }
+					)
+				) || Self::is_crosschain_vault_admin_call(call)
+			}
+		}
+
 		/// The type used to represent the kinds of proxying allowed.
 		#[derive(
 			Copy,
@@ -88,36 +120,11 @@ macro_rules! call_filters {
 						_ => false,
 					},
 					ProxyType::VaultAdmin => match c {
-						RuntimeCall::Vaults(..) |
-						RuntimeCall::Treasury(pallet_treasury::Call::buy_bonds { .. }) |
-						RuntimeCall::Treasury(pallet_treasury::Call::liquidate_bond_lot {
-							..
-						}) |
-						RuntimeCall::BitcoinLocks(pallet_bitcoin_locks::Call::initialize {
-							..
-						}) => true,
-						RuntimeCall::BitcoinLocks(pallet_bitcoin_locks::Call::cosign_release {
-							..
-						}) => true,
 						RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
 						RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
 						RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-							calls.iter().all(|sc| {
-								matches!(
-									sc,
-									RuntimeCall::Vaults(..) |
-										RuntimeCall::Treasury(
-											pallet_treasury::Call::buy_bonds { .. }
-										) | RuntimeCall::Treasury(
-										pallet_treasury::Call::liquidate_bond_lot { .. }
-									) | RuntimeCall::BitcoinLocks(
-										pallet_bitcoin_locks::Call::initialize { .. }
-									) | RuntimeCall::BitcoinLocks(
-										pallet_bitcoin_locks::Call::cosign_release { .. }
-									)
-								)
-							}),
-						_ => false,
+							calls.iter().all(VaultAdminCallFilter::is_single_vault_admin_call),
+						_ => VaultAdminCallFilter::is_single_vault_admin_call(c),
 					},
 					ProxyType::BitcoinInitializeFor => match c {
 						RuntimeCall::BitcoinLocks(pallet_bitcoin_locks::Call::initialize_for {

--- a/runtime/common/src/fee_control.rs
+++ b/runtime/common/src/fee_control.rs
@@ -1,0 +1,50 @@
+#[macro_export]
+macro_rules! vault_admin_fee_refund_policy {
+	() => {
+		pub struct VaultAdminFeeRefundPolicy;
+
+		impl VaultAdminFeeRefundPolicy {
+			fn is_collect_call(call: &RuntimeCall) -> bool {
+				matches!(call, RuntimeCall::Vaults(pallet_vaults::Call::collect { .. }))
+			}
+
+			fn is_collect_prerequisite_call(call: &RuntimeCall) -> bool {
+				matches!(
+					call,
+					RuntimeCall::CrosschainTransfer(
+						pallet_crosschain_transfer::Call::approve_queue_entries { .. }
+					) | RuntimeCall::BitcoinLocks(
+						pallet_bitcoin_locks::Call::cosign_release { .. }
+					) | RuntimeCall::BitcoinLocks(
+						pallet_bitcoin_locks::Call::cosign_orphaned_utxo_release { .. }
+					)
+				)
+			}
+		}
+
+		impl CallFeeRefundProvider<RuntimeCall> for VaultAdminFeeRefundPolicy {
+			fn refund_fee_on_success(call: &RuntimeCall) -> bool {
+				let RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) = call else {
+					return false;
+				};
+
+				let mut has_collect = false;
+				let mut has_prerequisite = false;
+
+				for call in calls.iter() {
+					if Self::is_collect_call(call) {
+						has_collect = true;
+						continue;
+					}
+					if Self::is_collect_prerequisite_call(call) {
+						has_prerequisite = true;
+						continue;
+					}
+					return false;
+				}
+
+				has_collect && has_prerequisite
+			}
+		}
+	};
+}

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod benchmarking;
 mod call_filters;
 pub mod config;
 mod deal_with_fees;
+mod fee_control;
 
 pub mod prelude {
 	pub use crate::config::*;


### PR DESCRIPTION
## Summary
- add a runtime-owned fee refund provider hook to fee control so successful approved batch_all calls can refund their outer fee
- move the vault admin maintenance refund policy out of call filters into dedicated runtime fee-control wiring
- expand the vault admin proxy allowlist to cover the crosschain and bitcoin maintenance calls used in these bundles

## Testing
- cargo make fmt
- cargo test -p pallet-fee-control
- cargo check -p argon-runtime -p argon-canary-runtime