### PR TITLE
Use built bitcoin bindings in CosignScript test

### DIFF
--- a/bitcoin/nodejs/ts/__test__/CosignScript.test.ts
+++ b/bitcoin/nodejs/ts/__test__/CosignScript.test.ts
@@ -31,7 +31,7 @@ import {
   getXpubFromXpriv,
   HDKey,
   p2wshScriptHexToAddress,
-} from '..';
+} from '../../lib/index.js';
 import { wordlist as english } from '@scure/bip39/wordlists/english';
 
 const { generateMnemonic, mnemonicToSeedSync } = bip39;


### PR DESCRIPTION
## Summary
- switch `CosignScript.test.ts` to import the built bitcoin Node entry instead of the source entry
- avoid the `vite-plugin-wasm` helper path that was failing on Windows after the Vitest lockfile bump

## Validation
- `yarn exec vitest --run --project bitcoin bitcoin/nodejs/ts/__test__/CosignScript.test.ts`
- GitHub Actions run `26924374017`: Windows `Test bindings on x86_64-pc-windows-msvc - node@22` and `node@24` passed
- the branch workflow was still running Linux jobs when this PR was opened