### PR TITLE
fix: recover notary notebook processing after db interruptions

### DIFF
--- a/notary/src/main.rs
+++ b/notary/src/main.rs
@@ -14,6 +14,7 @@ use argon_notary::{
 	},
 	NotaryServer,
 };
+use argon_notary_apis::error::Error as NotaryApiError;
 use argon_primitives::{tick::Ticker, AccountId, CryptoType, KeystoreParams, NotaryId};
 use clap::{Parser, Subcommand};
 use futures::StreamExt;
@@ -22,6 +23,7 @@ use prometheus::Registry;
 use sp_core::{crypto::Ss58Codec, sr25519, ByteArray, Pair};
 use sqlx::{migrate, postgres::PgPoolOptions};
 use std::{env, time::Duration};
+use tokio::task::JoinHandle;
 use tracing::warn;
 
 #[derive(Parser, Debug)]
@@ -277,6 +279,9 @@ async fn main() -> anyhow::Result<()> {
 					});
 				});
 			}
+			// print to stdout - ignore log filters
+			println!("Listening on ws://{}", server.addr);
+
 			if finalize_notebooks {
 				let handles = spawn_notebook_closer(
 					pool.clone(),
@@ -289,25 +294,10 @@ async fn main() -> anyhow::Result<()> {
 					server.notary_metrics.clone(),
 				)?;
 
-				let mut subscription = server.audit_failure_stream.subscribe(10);
-				let mut server_handle = server.clone();
-				tokio::spawn(async move {
-					if let Some(failure) = subscription.next().await {
-						warn!("Audit failure detected in {}. Shutting down...", failure);
-						// stop notebook close processes immediately
-						handles.0.abort();
-						handles.1.abort();
-						// wait one second to clean up
-						tokio::time::sleep(Duration::from_secs(1)).await;
-						server_handle.stop().await;
-					}
-				});
+				wait_for_notebook_processing_shutdown(&server, handles).await?;
+			} else {
+				server.wait_for_close().await;
 			}
-
-			// print to stdout - ignore log filters
-			println!("Listening on ws://{}", server.addr);
-			let watching_server = server.clone();
-			let _ = tokio::spawn(async move { watching_server.wait_for_close().await }).await;
 
 			tracing::info!("Notary server closed");
 		},
@@ -342,6 +332,79 @@ async fn main() -> anyhow::Result<()> {
 			migrate!().run(&pool).await?;
 		},
 	};
+
+	Ok(())
+}
+
+async fn wait_for_notebook_processing_shutdown(
+	server: &NotaryServer,
+	handles: (JoinHandle<anyhow::Result<()>>, JoinHandle<anyhow::Result<()>>),
+) -> anyhow::Result<()> {
+	let (mut notebook_closer_handle, mut finalized_header_listener_handle) = handles;
+	let mut subscription = server.audit_failure_stream.subscribe(10);
+	let mut shutdown_server = server.clone();
+	let watching_server = server.clone();
+
+	tokio::select! {
+		failure = subscription.next() => {
+			match failure {
+				Some(failure) => {
+					warn!("Audit failure detected in {}. Shutting down...", failure);
+					notebook_closer_handle.abort();
+					finalized_header_listener_handle.abort();
+					tokio::time::sleep(Duration::from_secs(1)).await;
+					shutdown_server.stop().await;
+				},
+				None => {
+					return Err(anyhow::anyhow!("Audit failure stream closed unexpectedly"));
+				},
+			}
+		},
+		result = &mut notebook_closer_handle => {
+			match result {
+				Ok(Ok(())) => {
+					return Err(anyhow::anyhow!("Notebook closer exited unexpectedly"));
+				},
+				Ok(Err(e)) => {
+					if matches!(
+						e.downcast_ref::<NotaryApiError>(),
+						Some(NotaryApiError::NotaryFailedAudit(_))
+					) {
+						shutdown_server.stop().await;
+					} else {
+						return Err(anyhow::anyhow!(
+							"Notebook closer failed unexpectedly: {e:?}"
+						));
+					}
+				},
+				Err(e) => {
+					return Err(anyhow::anyhow!(
+						"Notebook closer panicked or was cancelled unexpectedly: {e}"
+					));
+				},
+			}
+		},
+		result = &mut finalized_header_listener_handle => {
+			match result {
+				Ok(Ok(())) => {
+					return Err(anyhow::anyhow!(
+						"Finalized notebook header listener exited unexpectedly"
+					));
+				},
+				Ok(Err(e)) => {
+					return Err(anyhow::anyhow!(
+						"Finalized notebook header listener failed unexpectedly: {e:?}"
+					));
+				},
+				Err(e) => {
+					return Err(anyhow::anyhow!(
+						"Finalized notebook header listener panicked or was cancelled unexpectedly: {e}"
+					));
+				},
+			}
+		},
+		_ = watching_server.wait_for_close() => {},
+	}
 
 	Ok(())
 }

--- a/notary/src/notebook_closer.rs
+++ b/notary/src/notebook_closer.rs
@@ -186,23 +186,33 @@ pub fn spawn_notebook_closer(
 impl NotebookCloser {
 	pub async fn create_task(&'_ mut self) -> anyhow::Result<(), Error> {
 		loop {
-			if let Some(has_failed_audit) =
-				NotebookAuditFailureStore::has_unresolved_audit_failure(&self.pool).await?
-			{
+			let has_failed_audit =
+				match NotebookAuditFailureStore::has_unresolved_audit_failure(&self.pool).await {
+					Ok(has_failed_audit) => has_failed_audit,
+					Err(e) => {
+						tracing::error!("Error checking for unresolved audit failure {:?}", e);
+						if is_closed_database_error(&e) {
+							return Err(e);
+						}
+						tokio::time::sleep(Duration::from_secs(1)).await;
+						continue;
+					},
+				};
+
+			if let Some(has_failed_audit) = has_failed_audit {
 				tracing::error!(
 					"This notary has a failed audit. Need to shut down processing. Notebook={}, Reason={}",
 					has_failed_audit.notebook_number,
 					has_failed_audit.failure_reason
 				);
-				return Ok(());
+				return Err(Error::NotaryFailedAudit(has_failed_audit.notebook_number as _));
 			}
-			let _ = self.iterate_notebook_close_loop().await;
+			self.iterate_notebook_close_loop().await;
 			let tick = self.ticker.current();
 			let next_tick = self.ticker.time_for_tick(tick + 1);
 			let loop_millis = if self.ticker.tick_duration_millis <= 2000 { 200 } else { 1000 };
 			let sleep = next_tick.min(loop_millis) + 1;
-			// wait before resuming
-			tokio::time::sleep(tokio::time::Duration::from_millis(sleep)).await;
+			tokio::time::sleep(Duration::from_millis(sleep)).await;
 		}
 	}
 
@@ -285,6 +295,10 @@ impl NotebookCloser {
 		}
 		.boxed()
 	}
+}
+
+fn is_closed_database_error(error: &Error) -> bool {
+	matches!(error, Error::Database(message) if message.contains("pool closed"))
 }
 
 pub fn notary_sign(

--- a/notary/src/server.rs
+++ b/notary/src/server.rs
@@ -308,9 +308,24 @@ impl NotaryServer {
 		let audit_failure_number_copy = audit_failure_number.clone();
 		let handle = tokio::spawn(async move {
 			loop {
-				while let Ok(notebook_number) = audit_failure_listener.next().await {
-					tracing::error!("Audit failure for notebook {}", notebook_number);
-					*audit_failure_number_copy.lock().await = Some(notebook_number);
+				match audit_failure_listener.next().await {
+					Ok(notebook_number) => {
+						tracing::error!("Audit failure for notebook {}", notebook_number);
+						*audit_failure_number_copy.lock().await = Some(notebook_number);
+					},
+					Err(e) => {
+						tracing::error!("Error listening for audit failures {:?}", e);
+						match audit_failure_listener.reconnect(Duration::from_secs(1)).await {
+							Ok(Some(notebook_number)) => {
+								*audit_failure_number_copy.lock().await = Some(notebook_number);
+							},
+							Ok(None) => {},
+							Err(e) => {
+								tracing::error!("Audit failure listener exiting {:?}", e);
+								return;
+							},
+						}
+					},
 				}
 			}
 		});

--- a/notary/src/stores/notebook_audit_failure.rs
+++ b/notary/src/stores/notebook_audit_failure.rs
@@ -5,7 +5,8 @@ use chrono::{DateTime, Utc};
 use polkadot_sdk::*;
 use sc_utils::notification::{NotificationSender, NotificationStream, TracingKeyStr};
 use sp_core::H256;
-use sqlx::{postgres::PgListener, FromRow, PgConnection, PgPool};
+use sqlx::{postgres::PgListener, Error as SqlxError, FromRow, PgConnection, PgPool};
+use std::time::Duration;
 pub type AuditFailureStream = NotificationStream<NotebookNumber, AuditFailureTracingKey>;
 
 #[derive(Clone)]
@@ -15,6 +16,7 @@ impl TracingKeyStr for AuditFailureTracingKey {
 }
 
 pub struct AuditFailureListener {
+	pool: PgPool,
 	failed_audits_notification: NotificationSender<NotebookNumber>,
 	listener: PgListener,
 }
@@ -23,24 +25,74 @@ impl AuditFailureListener {
 		pool: PgPool,
 		failed_audits_notification: NotificationSender<NotebookNumber>,
 	) -> anyhow::Result<Self> {
-		let mut listener = PgListener::connect_with(&pool).await?;
+		let listener = Self::connect_listener(&pool).await?;
+		Ok(Self { pool, failed_audits_notification, listener })
+	}
+
+	async fn connect_listener(pool: &PgPool) -> anyhow::Result<PgListener> {
+		let mut listener = PgListener::connect_with(pool).await?;
 		listener.listen("audit_failure").await?;
-		Ok(Self { failed_audits_notification, listener })
+		Ok(listener)
 	}
 
 	pub async fn next(&mut self) -> anyhow::Result<NotebookNumber> {
-		let notification = &self.listener.recv().await?;
-		let notebook_number = match notification.payload().parse() {
-			Ok(notebook_number) => notebook_number,
-			Err(e) => {
-				return Err(anyhow::anyhow!("Error parsing notified notebook number {e:?}"));
-			},
-		};
+		loop {
+			let notification = self.listener.recv().await?;
+			let notebook_number = match notification.payload().parse() {
+				Ok(notebook_number) => notebook_number,
+				Err(e) => {
+					tracing::error!(
+						"Ignoring malformed audit failure notification payload {:?}: {:?}",
+						notification.payload(),
+						e
+					);
+					continue;
+				},
+			};
 
+			self.notify_failed_audit(notebook_number)?;
+			return Ok(notebook_number);
+		}
+	}
+
+	pub(crate) async fn reconnect(
+		&mut self,
+		delay: Duration,
+	) -> anyhow::Result<Option<NotebookNumber>> {
+		loop {
+			match self.try_reconnect().await {
+				Ok(notebook_number) => return Ok(notebook_number),
+				Err(e) => {
+					tracing::error!("Error reconnecting audit failure listener {:?}", e);
+					if is_closed_pool_error(&e) {
+						return Err(e);
+					}
+
+					tokio::time::sleep(delay).await;
+				},
+			}
+		}
+	}
+
+	async fn try_reconnect(&mut self) -> anyhow::Result<Option<NotebookNumber>> {
+		self.listener = Self::connect_listener(&self.pool).await?;
+
+		if let Some(failure) =
+			NotebookAuditFailureStore::has_unresolved_audit_failure(&self.pool).await?
+		{
+			let notebook_number = failure.notebook_number as NotebookNumber;
+			self.notify_failed_audit(notebook_number)?;
+			return Ok(Some(notebook_number));
+		}
+
+		Ok(None)
+	}
+
+	fn notify_failed_audit(&self, notebook_number: NotebookNumber) -> anyhow::Result<()> {
 		self.failed_audits_notification.notify(|| Ok(notebook_number)).map_err(
 			|e: anyhow::Error| anyhow::anyhow!("Error sending failed audits notification {e:?}"),
 		)?;
-		Ok(notebook_number)
+		Ok(())
 	}
 }
 
@@ -100,5 +152,53 @@ impl NotebookAuditFailureStore {
 		.fetch_optional(db)
 		.await?;
 		Ok(result)
+	}
+}
+
+fn is_closed_pool_error(error: &anyhow::Error) -> bool {
+	error
+		.chain()
+		.filter_map(|source| source.downcast_ref::<SqlxError>())
+		.any(|source| matches!(source, SqlxError::PoolClosed))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::stores::notebook_header::NotebookHeaderStore;
+	use futures::StreamExt;
+
+	#[sqlx::test]
+	async fn test_reconnect_publishes_existing_audit_failure(pool: PgPool) -> anyhow::Result<()> {
+		let (sender, stream) = AuditFailureStream::channel();
+		let mut listener = AuditFailureListener::connect(pool.clone(), sender).await?;
+		let mut subscription = stream.subscribe(10);
+
+		let mut tx = pool.begin().await?;
+		NotebookHeaderStore::create(&mut tx, 1, 1, 1, 1).await?;
+		tx.commit().await?;
+
+		let mut db = pool.acquire().await?;
+		NotebookAuditFailureStore::record(
+			&mut db,
+			1,
+			H256::from([1u8; 32]),
+			"failure".to_string(),
+			1,
+		)
+		.await?;
+
+		let notebook_number = listener.reconnect(Duration::ZERO).await?;
+		assert_eq!(notebook_number, Some(1));
+
+		let published_notebook = tokio::time::timeout(Duration::from_secs(1), subscription.next())
+			.await?
+			.expect("should publish the unresolved audit failure");
+		assert_eq!(published_notebook, 1);
+		assert!(tokio::time::timeout(Duration::from_millis(100), subscription.next())
+			.await
+			.is_err());
+
+		Ok(())
 	}
 }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -113,7 +113,7 @@ macro_rules! inject_runtime_vars {
 			// `spec_name`,   `spec_version`, and `authoring_version` are the same between Wasm and
 			// native. This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 			//   the compatible custom types.
-			spec_version: 151,
+			spec_version: 152,
 			impl_version: 10,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 5,


### PR DESCRIPTION
## Summary
- keep notebook closing alive across transient Postgres interruptions instead of silently losing the closer loop
- reconnect audit-failure listening and replay unresolved audit failures after database reconnects
- supervise notebook finalization tasks so unexpected task death fails fast while real audit failures still shut the notary down cleanly
