### PR TITLE
fix(nodejs): recover missing beacon sync committee from finality update

### DIFF
--- a/bitcoin/src/cosign_script.rs
+++ b/bitcoin/src/cosign_script.rs
@@ -821,6 +821,56 @@ mod test {
 		drop(bitcoind);
 	}
 
+	#[test]
+	fn vault_uploaded_xpub_root_can_sign_release_child() {
+		let network = Network::Regtest;
+		let secp = Secp256k1::new();
+		let amount: Satoshis = Amount::ONE_BTC.to_sat();
+		let (master_xpriv, _) = create_xpriv(network);
+		let uploaded_vault_xpub_path: bitcoin::bip32::DerivationPath = "m/0'".parse().unwrap();
+		let uploaded_vault_xpriv = master_xpriv
+			.derive_priv(&secp, &uploaded_vault_xpub_path)
+			.expect("uploaded vault xpub root");
+		let (vault_compressed_pubkey, _) = derive(&master_xpriv, "m/0'/1");
+		let vault_claim_pubkey = derive(&master_xpriv, "m/0'/2").0;
+		let owner_pubkey: CompressedBitcoinPubkey =
+			PrivateKey::generate(network).public_key(&secp).into();
+		let vault_pubkey: CompressedBitcoinPubkey = vault_compressed_pubkey.into();
+		let out_script_pubkey = vault_compressed_pubkey.p2wpkh_script_code();
+		let fee = Amount::from_sat(500);
+		let mut releaser = CosignReleaser::new(
+			CosignScriptArgs {
+				vault_pubkey,
+				vault_claim_pubkey: vault_claim_pubkey.into(),
+				owner_pubkey,
+				vault_claim_height: 120,
+				open_claim_height: 240,
+				created_at_height: 100,
+			},
+			amount,
+			"0000000000000000000000000000000000000000000000000000000000000001"
+				.parse()
+				.unwrap(),
+			0,
+			ReleaseStep::VaultCosign,
+			fee,
+			out_script_pubkey,
+			network,
+		)
+		.expect("unlocker");
+
+		let (vault_signature, signed_pubkey) = releaser
+			.sign_derived(
+				uploaded_vault_xpriv,
+				alloc::vec![bitcoin::bip32::ChildNumber::from_normal_idx(1).unwrap()].into(),
+			)
+			.expect("sign");
+
+		assert_eq!(signed_pubkey, vault_compressed_pubkey.into());
+		let vault_signature_api: BitcoinSignature = vault_signature.try_into().unwrap();
+		assert!(releaser.verify_signature_raw(vault_pubkey, &vault_signature_api).unwrap());
+	}
+
 	fn check_spent(
 		tx_hex: &str,
 		tracker: &UtxoSpendFilter,

--- a/client/nodejs/src/EthereumBeaconSync.ts
+++ b/client/nodejs/src/EthereumBeaconSync.ts
@@ -17,6 +17,7 @@ type BeaconNetworkParams = {
   epochsPerSyncCommitteePeriod: bigint;
   preset: BeaconPreset;
   slotsPerEpoch: bigint;
+  slotsPerHistoricalRoot: bigint;
 };
 type EthereumBeaconSyncState =
   | {
@@ -120,6 +121,8 @@ export async function getNextEthereumBeaconSyncTxs(
   const expectedPreset = await getExpectedBeaconPreset(client);
   const beaconNetworkParams = await getBeaconNetworkParams(beaconApiUrl, expectedPreset);
   const storedPeriod = computePeriod(state.latestFinalizedSlot, beaconNetworkParams);
+  const maxBridgeableFinalizedSlot =
+    state.latestFinalizedSlot + beaconNetworkParams.slotsPerHistoricalRoot;
   const txs: SubmittableExtrinsic[] = [];
   const startedAt = Date.now();
 
@@ -143,8 +146,9 @@ export async function getNextEthereumBeaconSyncTxs(
     }
 
     const missingNextSyncCommittee = !state.hasNextSyncCommittee;
+    const finalityFinalizedSlot = BigInt(finalityUpdate.finalized_header.beacon.slot);
     const finalityFinalizedPeriod = computePeriod(
-      BigInt(finalityUpdate.finalized_header.beacon.slot),
+      finalityFinalizedSlot,
       beaconNetworkParams,
     );
     const requiredCommitteePeriod = getRequiredCommitteePeriod({
@@ -159,18 +163,23 @@ export async function getNextEthereumBeaconSyncTxs(
       requiredCommitteePeriod,
       beaconNetworkParams,
     );
-    const needsCurrentPeriodUpdate =
-      requiredCommitteePeriod !== undefined &&
-      (missingNextSyncCommittee || !finalityCarriesRequiredCommittee);
-    let submitUpdate: EthereumLightClientUpdate | undefined = finalityUpdate;
+    const finalityIsBridgeable = finalityFinalizedSlot <= maxBridgeableFinalizedSlot;
+    const needsCurrentPeriodUpdate = needsCommitteeData && !finalityCarriesRequiredCommittee;
+    const needsPeriodUpdate = needsCurrentPeriodUpdate || !finalityIsBridgeable;
+    let submitUpdate: EthereumLightClientUpdate | undefined;
 
-    if (needsCommitteeData && needsCurrentPeriodUpdate) {
+    if (finalityIsBridgeable && !needsCurrentPeriodUpdate) {
+      submitUpdate = finalityUpdate;
+    }
+
+    if (needsPeriodUpdate) {
       let periodUpdates: EthereumLightClientUpdatesResponse;
+      const periodUpdateStartPeriod = requiredCommitteePeriod ?? storedPeriod;
 
       try {
         periodUpdates = await getBeaconJson<EthereumLightClientUpdatesResponse>(
           beaconApiUrl,
-          `/eth/v1/beacon/light_client/updates?count=1&start_period=${requiredCommitteePeriod}`,
+          `/eth/v1/beacon/light_client/updates?count=1&start_period=${periodUpdateStartPeriod}`,
         );
       } catch (error) {
         if (!isRetryableBeaconLightClientError(error)) {
@@ -181,22 +190,35 @@ export async function getNextEthereumBeaconSyncTxs(
         continue;
       }
 
-      const currentPeriodUpdate = periodUpdates[0]?.data;
-      if (
-        updateCarriesCommitteeForPeriod(
-          currentPeriodUpdate,
+      const periodUpdate = periodUpdates[0]?.data;
+      const periodUpdateFinalizedSlot = periodUpdate
+        ? BigInt(periodUpdate.finalized_header.beacon.slot)
+        : undefined;
+      const hasBridgeablePeriodUpdate =
+        periodUpdateFinalizedSlot !== undefined &&
+        periodUpdateFinalizedSlot <= maxBridgeableFinalizedSlot;
+      let periodUpdateHasRequiredCommittee = !needsCommitteeData;
+
+      if (periodUpdate && needsCommitteeData) {
+        periodUpdateHasRequiredCommittee = updateCarriesCommitteeForPeriod(
+          periodUpdate,
           requiredCommitteePeriod,
           beaconNetworkParams,
-        )
-      ) {
-        submitUpdate = currentPeriodUpdate;
-      } else {
-        submitUpdate = undefined;
+        );
+      }
+
+      if (periodUpdate && hasBridgeablePeriodUpdate && periodUpdateHasRequiredCommittee) {
+        submitUpdate = periodUpdate;
       }
     }
 
-    if (needsCommitteeData && needsCurrentPeriodUpdate && !submitUpdate) {
+    if (needsCurrentPeriodUpdate && !submitUpdate) {
       return [];
+    }
+
+    if (needsPeriodUpdate && !submitUpdate) {
+      await new Promise(resolve => setTimeout(resolve, lightClientUpdateRetryIntervalMs));
+      continue;
     }
 
     // make sure the update we choose has a supermajority of sync committee participants
@@ -396,12 +418,16 @@ function parseBeaconNetworkParams(
 ): BeaconNetworkParams {
   const slotsPerEpoch = spec.SLOTS_PER_EPOCH;
   const epochsPerSyncCommitteePeriod = spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
+  const slotsPerHistoricalRoot = spec.SLOTS_PER_HISTORICAL_ROOT;
 
   if (!slotsPerEpoch) {
     throw new Error('Missing beacon spec value for SLOTS_PER_EPOCH');
   }
   if (!epochsPerSyncCommitteePeriod) {
     throw new Error('Missing beacon spec value for EPOCHS_PER_SYNC_COMMITTEE_PERIOD');
+  }
+  if (!slotsPerHistoricalRoot) {
+    throw new Error('Missing beacon spec value for SLOTS_PER_HISTORICAL_ROOT');
   }
 
   const preset = detectBeaconPreset(spec);
@@ -416,6 +442,7 @@ function parseBeaconNetworkParams(
     preset,
     slotsPerEpoch: BigInt(slotsPerEpoch),
     epochsPerSyncCommitteePeriod: BigInt(epochsPerSyncCommitteePeriod),
+    slotsPerHistoricalRoot: BigInt(slotsPerHistoricalRoot),
   };
 }
 

--- a/client/nodejs/src/__test__/EthereumBeaconSync.test.ts
+++ b/client/nodejs/src/__test__/EthereumBeaconSync.test.ts
@@ -172,7 +172,7 @@ it('supports minimal beacon updates with execution header proofs embedded in sub
   ]);
 });
 
-it('prefers the current-period update when the next sync committee is missing', async () => {
+it('uses a bridgeable finality update when the next sync committee is missing and finality already carries it', async () => {
   globalThis.fetch = createFetch({
     'https://beacon.example/eth/v1/beacon/light_client/finality_update': {
       data: createLightClientUpdate(1600, {
@@ -182,6 +182,38 @@ it('prefers the current-period update when the next sync committee is missing', 
         },
         next_sync_committee_branch: ['0x9'],
       }),
+    },
+    'https://beacon.example/eth/v1/beacon/light_client/bootstrap/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa':
+      createBootstrapResponse(800, ['0xstored800']),
+    'https://beacon.example/eth/v1/config/spec': {
+      data: createBeaconSpec(),
+    },
+  });
+
+  const txs = await getNextEthereumBeaconSyncTxs(
+    createMockClient({ hasNextSyncCommittee: false }),
+    'https://beacon.example',
+  );
+
+  expect(txs[0]).toEqual({
+    method: 'submit',
+    update: expect.objectContaining({
+      finalizedHeader: expect.objectContaining({ slot: '1600' }),
+      nextSyncCommitteeUpdate: expect.objectContaining({
+        nextSyncCommittee: expect.anything(),
+        nextSyncCommitteeBranch: ['0x9'],
+      }),
+      executionHeaderProof: expect.objectContaining({
+        executionBranch: [],
+      }),
+    }),
+  });
+});
+
+it('fetches the current-period update when the next sync committee is missing and finality does not carry it', async () => {
+  globalThis.fetch = createFetch({
+    'https://beacon.example/eth/v1/beacon/light_client/finality_update': {
+      data: createLightClientUpdate(1600),
     },
     'https://beacon.example/eth/v1/beacon/light_client/updates?count=1&start_period=0': [
       createVersionedLightClientUpdate(800, {
@@ -215,7 +247,7 @@ it('prefers the current-period update when the next sync committee is missing', 
       finalizedHeader: expect.objectContaining({ slot: '800' }),
       nextSyncCommitteeUpdate: expect.objectContaining({
         nextSyncCommittee: expect.anything(),
-        nextSyncCommitteeBranch: expect.anything(),
+        nextSyncCommitteeBranch: ['0x6'],
       }),
       executionHeaderProof: expect.objectContaining({
         executionBranch: ['0xperiod0-execution'],
@@ -373,16 +405,210 @@ it('submits the current-period sync committee update before the next free header
   ]);
 });
 
+it('falls back to a bridgeable period update when the latest finality jump is too large', async () => {
+  const beaconApiUrl = 'https://minimal-beacon-bridgeable-gap.example';
+
+  globalThis.fetch = createFetch({
+    [`${beaconApiUrl}/eth/v1/beacon/light_client/finality_update`]: {
+      data: createLightClientUpdate(120, {
+        attested_header: {
+          beacon: createBeaconHeader(121),
+          execution: createExecutionHeader(121),
+          execution_branch: ['0xfinality121'],
+        },
+        signature_slot: '122',
+        next_sync_committee: {
+          pubkeys: ['0xfinality-period1'],
+          aggregate_pubkey: '0xfinality-period1-agg',
+        },
+        next_sync_committee_branch: ['0xfinality-period1-branch'],
+        finalized_header: {
+          beacon: createBeaconHeader(120),
+          execution: createExecutionHeader(120),
+          execution_branch: ['0xfinality120'],
+        },
+      }),
+    },
+    [`${beaconApiUrl}/eth/v1/beacon/light_client/updates?count=1&start_period=1`]: [
+      createVersionedLightClientUpdate(96, {
+        attested_header: {
+          beacon: createBeaconHeader(97),
+          execution: createExecutionHeader(97),
+          execution_branch: ['0xbridgeable97'],
+        },
+        signature_slot: '98',
+        next_sync_committee: {
+          pubkeys: ['0xbridgeable-period1'],
+          aggregate_pubkey: '0xbridgeable-period1-agg',
+        },
+        next_sync_committee_branch: ['0xbridgeable-period1-branch'],
+        finalized_header: {
+          beacon: createBeaconHeader(96),
+          execution: createExecutionHeader(96),
+          execution_branch: ['0xbridgeable96'],
+        },
+      }),
+    ],
+    [`${beaconApiUrl}/eth/v1/config/spec`]: {
+      data: createBeaconSpec({
+        slotsPerEpoch: '8',
+        epochsPerSyncCommitteePeriod: '8',
+        slotsPerHistoricalRoot: '64',
+      }),
+    },
+  });
+
+  const txs = await getNextEthereumBeaconSyncTxs(
+    createMockClient({
+      beaconPreset: 'minimal',
+      hasNextSyncCommittee: true,
+      latestFinalizedSlot: 40,
+      latestSyncCommitteeUpdatePeriod: 0,
+      headerInterval: 32,
+    }),
+    beaconApiUrl,
+  );
+
+  expect(txs).toEqual([
+    {
+      method: 'submit',
+      update: expect.objectContaining({
+        finalizedHeader: expect.objectContaining({ slot: '96' }),
+        signatureSlot: '98',
+        nextSyncCommitteeUpdate: expect.objectContaining({
+          nextSyncCommittee: expect.anything(),
+          nextSyncCommitteeBranch: ['0xbridgeable-period1-branch'],
+        }),
+        executionHeaderProof: expect.objectContaining({
+          executionBranch: ['0xbridgeable96'],
+        }),
+      }),
+    },
+  ]);
+});
+
+it('retries until a bridgeable period update is available when finality is not bridgeable', async () => {
+  const beaconApiUrl = 'https://minimal-beacon-bridgeable-gap-retry.example';
+  const periodUpdateUrl = `${beaconApiUrl}/eth/v1/beacon/light_client/updates?count=1&start_period=1`;
+  let periodUpdateRequests = 0;
+
+  globalThis.fetch = async (input: string | URL | Request) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url === `${beaconApiUrl}/eth/v1/beacon/light_client/finality_update`) {
+      return {
+        ok: true,
+        json: async () => ({
+          data: createLightClientUpdate(120, {
+            attested_header: {
+              beacon: createBeaconHeader(121),
+              execution: createExecutionHeader(121),
+              execution_branch: ['0xfinality121'],
+            },
+            signature_slot: '122',
+            next_sync_committee: {
+              pubkeys: ['0xfinality-period1'],
+              aggregate_pubkey: '0xfinality-period1-agg',
+            },
+            next_sync_committee_branch: ['0xfinality-period1-branch'],
+            finalized_header: {
+              beacon: createBeaconHeader(120),
+              execution: createExecutionHeader(120),
+              execution_branch: ['0xfinality120'],
+            },
+          }),
+        }),
+        status: 200,
+        statusText: 'OK',
+      } as Response;
+    }
+
+    if (url === periodUpdateUrl) {
+      periodUpdateRequests += 1;
+
+      return {
+        ok: true,
+        json: async () =>
+          periodUpdateRequests === 1
+            ? []
+            : [
+                createVersionedLightClientUpdate(96, {
+                  attested_header: {
+                    beacon: createBeaconHeader(97),
+                    execution: createExecutionHeader(97),
+                    execution_branch: ['0xbridgeable97'],
+                  },
+                  signature_slot: '98',
+                  next_sync_committee: {
+                    pubkeys: ['0xbridgeable-period1'],
+                    aggregate_pubkey: '0xbridgeable-period1-agg',
+                  },
+                  next_sync_committee_branch: ['0xbridgeable-period1-branch'],
+                  finalized_header: {
+                    beacon: createBeaconHeader(96),
+                    execution: createExecutionHeader(96),
+                    execution_branch: ['0xbridgeable96'],
+                  },
+                }),
+              ],
+        status: 200,
+        statusText: 'OK',
+      } as Response;
+    }
+
+    if (url === `${beaconApiUrl}/eth/v1/config/spec`) {
+      return {
+        ok: true,
+        json: async () => ({
+          data: createBeaconSpec({
+            slotsPerEpoch: '8',
+            epochsPerSyncCommitteePeriod: '8',
+            slotsPerHistoricalRoot: '64',
+          }),
+        }),
+        status: 200,
+        statusText: 'OK',
+      } as Response;
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  const txs = await getNextEthereumBeaconSyncTxs(
+    createMockClient({
+      beaconPreset: 'minimal',
+      hasNextSyncCommittee: true,
+      latestFinalizedSlot: 40,
+      latestSyncCommitteeUpdatePeriod: 0,
+      headerInterval: 32,
+    }),
+    beaconApiUrl,
+  );
+
+  expect(periodUpdateRequests).toBe(2);
+  expect(txs).toEqual([
+    {
+      method: 'submit',
+      update: expect.objectContaining({
+        finalizedHeader: expect.objectContaining({ slot: '96' }),
+        signatureSlot: '98',
+        nextSyncCommitteeUpdate: expect.objectContaining({
+          nextSyncCommittee: expect.anything(),
+          nextSyncCommitteeBranch: ['0xbridgeable-period1-branch'],
+        }),
+        executionHeaderProof: expect.objectContaining({
+          executionBranch: ['0xbridgeable96'],
+        }),
+      }),
+    },
+  ]);
+});
+
 it('returns nothing when the required current-period committee update is unavailable', async () => {
   globalThis.fetch = createFetch({
     'https://beacon.example/eth/v1/beacon/light_client/finality_update': {
-      data: createLightClientUpdate(1600, {
-        next_sync_committee: {
-          pubkeys: ['0x4'],
-          aggregate_pubkey: '0x5',
-        },
-        next_sync_committee_branch: ['0x6'],
-      }),
+      data: createLightClientUpdate(1600),
     },
     'https://beacon.example/eth/v1/beacon/light_client/updates?count=1&start_period=0': [{} as any],
     'https://beacon.example/eth/v1/config/spec': {

--- a/end-to-end/src/bitcoin.rs
+++ b/end-to-end/src/bitcoin.rs
@@ -881,8 +881,12 @@ async fn vault_cosigns_release(
 		.await?
 		.ok_or_else(|| anyhow!("No finalized lock found for utxo {utxo_id}"))?;
 	let mut releaser = load_cosign_releaser(client, *utxo_id, &lock, FetchAt::Finalized).await?;
-	let (signature, _) = releaser
-		.sign_derived(vault_xpriv.clone(), DerivationPath::from_str(uploaded_xpub_hd_path)?)?;
+	// The runtime derives each lock pubkey from the uploaded vault xpub, so we need to sign from
+	// that xpub root and then derive the per-lock child number stored on the lock.
+	let uploaded_vault_xpriv = vault_xpriv
+		.derive_priv(&Secp256k1::new(), &DerivationPath::from_str(uploaded_xpub_hd_path)?)?;
+	let vault_hd_path = DerivationPath::from(vec![ChildNumber::from(lock.vault_xpub_sources.1)]);
+	let (signature, _) = releaser.sign_derived(uploaded_vault_xpriv, vault_hd_path)?;
 	let signature: BitcoinSignature = signature
 		.try_into()
 		.map_err(|_| anyhow!("Unable to translate signature to bytes"))?;


### PR DESCRIPTION
## Summary
- allow a bridgeable finality update to fill a missing next sync committee when it already carries the required committee
- keep fetching a current-period light client update when finality does not carry the missing committee or when the latest finality update is not bridgeable
- cover both missing-committee recovery paths and the bridgeable-gap behavior in the beacon sync tests

## Random
- fix the bitcoin tests failing 