### PR TITLE
fix(mining-slot): keep seat argonots above the initial floor

### DIFF
--- a/bitcoin/nodejs/ts/__test__/CosignScript.test.ts
+++ b/bitcoin/nodejs/ts/__test__/CosignScript.test.ts
@@ -128,7 +128,7 @@ describe.skipIf(SKIP_E2E)('Bitcoin Bindings test', { retry: 0, timeout: 60e3 }, 
       baseFee: 500_000n,
       bitcoinXpub: vaultMasterXpub,
       treasuryProfitSharing: 0.5,
-      bonusSharingPercent: 0,
+      treasuryBonusProfitSharing: 0,
     });
     vault = await vaultResult.getVault();
 

--- a/client/nodejs/src/Vault.ts
+++ b/client/nodejs/src/Vault.ts
@@ -105,7 +105,7 @@ export class Vault {
     const currentBonusSharingPercent =
       'treasuryBonusProfitSharing' in vault.terms
         ? vault.terms.treasuryBonusProfitSharing
-        : (vault.terms as { bonusSharingPercent?: { toBigInt(): bigint } }).bonusSharingPercent;
+        : undefined;
     this.terms = {
       bitcoinAnnualPercentRate: fromFixedNumber(
         vault.terms.bitcoinAnnualPercentRate.toBigInt(),
@@ -116,7 +116,7 @@ export class Vault {
         vault.terms.treasuryProfitSharing.toBigInt(),
         PERMILL_DECIMALS,
       ),
-      bonusSharingPercent: fromFixedNumber(
+      treasuryBonusProfitSharing: fromFixedNumber(
         currentBonusSharingPercent?.toBigInt() ?? 0n,
         PERMILL_DECIMALS,
       ),
@@ -139,9 +139,7 @@ export class Vault {
     if (vault.pendingTerms.isSome) {
       const [tickApply, terms] = vault.pendingTerms.value;
       const pendingBonusSharingPercent =
-        'treasuryBonusProfitSharing' in terms
-          ? terms.treasuryBonusProfitSharing
-          : (terms as { bonusSharingPercent?: { toBigInt(): bigint } }).bonusSharingPercent;
+        'treasuryBonusProfitSharing' in terms ? terms.treasuryBonusProfitSharing : undefined;
       this.pendingTermsChangeTick = tickApply.toNumber();
       this.pendingTerms = {
         bitcoinAnnualPercentRate: fromFixedNumber(
@@ -153,7 +151,7 @@ export class Vault {
           terms.treasuryProfitSharing.toBigInt(),
           PERMILL_DECIMALS,
         ),
-        bonusSharingPercent: fromFixedNumber(
+        treasuryBonusProfitSharing: fromFixedNumber(
           pendingBonusSharingPercent?.toBigInt() ?? 0n,
           PERMILL_DECIMALS,
         ),
@@ -266,7 +264,7 @@ export class Vault {
       delegateAccountId?: string;
       name?: string;
       treasuryProfitSharing: number;
-      bonusSharingPercent: number;
+      treasuryBonusProfitSharing: number;
       doNotExceedBalance?: bigint;
     } & ISubmittableOptions,
     config: { tickDurationMillis?: number } = {},
@@ -306,7 +304,10 @@ export class Vault {
         bitcoinAnnualPercentRate: toFixedNumber(annualPercentRate, FIXED_U128_DECIMALS),
         bitcoinBaseFee: BigInt(baseFee),
         treasuryProfitSharing: toFixedNumber(args.treasuryProfitSharing, PERMILL_DECIMALS),
-        treasuryBonusProfitSharing: toFixedNumber(args.bonusSharingPercent, PERMILL_DECIMALS),
+        treasuryBonusProfitSharing: toFixedNumber(
+          args.treasuryBonusProfitSharing,
+          PERMILL_DECIMALS,
+        ),
       },
       securitizationRatio: toFixedNumber(securitizationRatio, FIXED_U128_DECIMALS),
       securitization: BigInt(securitization),
@@ -377,7 +378,7 @@ export interface ITerms {
   readonly bitcoinAnnualPercentRate: BigNumber;
   readonly bitcoinBaseFee: bigint;
   readonly treasuryProfitSharing: BigNumber;
-  readonly bonusSharingPercent: BigNumber;
+  readonly treasuryBonusProfitSharing: BigNumber;
 }
 function bigNumberToBigInt(bn: BigNumber): bigint {
   return BigInt(bn.integerValue(BigNumber.ROUND_DOWN).toString());

--- a/client/nodejs/src/utils.ts
+++ b/client/nodejs/src/utils.ts
@@ -79,7 +79,8 @@ export const TxSubmissionErrorCode = {
   Usurped: 'TxSubmission.Usurped',
 } as const;
 
-export type TxSubmissionErrorCode = (typeof TxSubmissionErrorCode)[keyof typeof TxSubmissionErrorCode];
+export type TxSubmissionErrorCode =
+  (typeof TxSubmissionErrorCode)[keyof typeof TxSubmissionErrorCode];
 
 export class TxSubmissionError extends Error {
   constructor(

--- a/pallets/mining_slot/src/lib.rs
+++ b/pallets/mining_slot/src/lib.rs
@@ -1083,8 +1083,9 @@ impl<T: Config> Pallet<T> {
 			.saturating_add(price_of_one_whole_argonot_in_microgons.saturating_sub(1))
 			.checked_div(price_of_one_whole_argonot_in_microgons)
 			.unwrap_or_default();
+		let argonots_needed = T::Balance::from(micronots_needed);
 
-		ArgonotsPerMiningSeat::<T>::put(T::Balance::from(micronots_needed));
+		ArgonotsPerMiningSeat::<T>::put(argonots_needed.max(T::InitialArgonotsPerSeat::get()));
 	}
 
 	/// Adjust the number of seats in the next cohort based on the average price per seat vs the

--- a/pallets/mining_slot/src/tests.rs
+++ b/pallets/mining_slot/src/tests.rs
@@ -1755,6 +1755,32 @@ fn it_keeps_argonots_per_seat_unchanged_when_there_are_no_winning_bids() {
 }
 
 #[test]
+fn it_floors_argonots_per_seat_to_the_initial_value() {
+	new_test_ext().execute_with(|| {
+		let original_initial_argonots_per_seat = InitialArgonotsPerSeat::get();
+		InitialArgonotsPerSeat::set(10 * MICROGONS_PER_ARGON);
+		ArgonotsPerMiningSeat::<Test>::set(77);
+		NextFrameId::<Test>::set(5);
+		set_average_microgons_per_argonot(4, 4 * MICROGONS_PER_ARGON);
+
+		BidsForNextSlotCohort::<Test>::set(bounded_vec![MiningRegistration {
+			account_id: 1,
+			argonots: 0,
+			bid: MICROGONS_PER_ARGON,
+			authority_keys: 1.into(),
+			starting_frame_id: 5,
+			external_funding_account: None,
+			bid_at_tick: 1,
+		}]);
+
+		MiningSlots::update_argonots_per_seat(5);
+
+		assert_eq!(ArgonotsPerMiningSeat::<Test>::get(), 10 * MICROGONS_PER_ARGON);
+		InitialArgonotsPerSeat::set(original_initial_argonots_per_seat);
+	});
+}
+
+#[test]
 fn it_defaults_argonots_per_seat_to_the_initial_value() {
 	new_test_ext().execute_with(|| {
 		ArgonotsPerMiningSeat::<Test>::kill();

--- a/testing/nodejs/src/TestEthereumProofActors.ts
+++ b/testing/nodejs/src/TestEthereumProofActors.ts
@@ -545,7 +545,7 @@ export class TestMintingAuthorityActor {
       baseFee: 0n,
       bitcoinXpub: args.bitcoinXpub,
       treasuryProfitSharing: 0,
-      bonusSharingPercent: 0,
+      treasuryBonusProfitSharing: 0,
     });
     await vault.getVault();
 


### PR DESCRIPTION
## Summary

Low winning bids could drive `ArgonotsPerMiningSeat` below the configured starting floor, which left miners with a seat requirement that was lower than the runtime minimum after a frame transition.

This keeps the recalculated seat collateral clamped to `InitialArgonotsPerSeat` while still using the bid-derived value whenever it is higher. It also adds a regression covering the low-bid case so the floor stays enforced.

----

Tweak name of var in nodejs lib for bond bonusSharingPercent