### PR TITLE
fix(ethereum): harden beacon BLS public key deserialization

### DIFF
--- a/pallets/ethereum_verifier/src/tests.rs
+++ b/pallets/ethereum_verifier/src/tests.rs
@@ -10,7 +10,7 @@ use crate::{
 		load_next_sync_committee_update_fixture, load_sync_committee_update_fixture,
 	},
 	sync_committee_sum,
-	types::{CheckpointUpdate, ExecutionHeaderProof, Update},
+	types::{CheckpointUpdate, ExecutionHeaderProof, SyncCommittee, TypeError, Update},
 	verify_merkle_branch, BasicOperatingMode, BeaconHeader, Error, ExecutionHeaderAnchor,
 	ExecutionHeaderAnchors, ExecutionHeaderAnchorsByBlockNumber, ExecutionProof,
 	FinalizedBeaconHeaderState, FinalizedBeaconState, Fork, ForkVersionSchedule, ForkVersions,
@@ -42,7 +42,10 @@ use polkadot_sdk::{
 	sp_core::{hashing::blake2_256, H160, H256},
 	sp_runtime::{traits::ConstU32, DispatchError},
 };
-use snowbridge_beacon_primitives::merkle_proof::{generalized_index_length, subtree_index};
+use snowbridge_beacon_primitives::{
+	merkle_proof::{generalized_index_length, subtree_index},
+	PublicKey, PublicKeyPrepared,
+};
 use std::{fs::File, path::PathBuf};
 
 const MAINNET_SLOTS_PER_EPOCH: u64 = EthereumBeaconPreset::Mainnet.slots_per_epoch() as u64;
@@ -521,6 +524,22 @@ fn find_present_keys() {
 		assert_eq!(pubkeys[2], sync_committee_prepared.pubkeys[26]);
 		assert_eq!(pubkeys[3], sync_committee_prepared.pubkeys[30]);
 	});
+}
+
+#[test]
+fn sync_committee_prepare_rejects_infinity_public_keys() {
+	let infinity_pubkey = PublicKey::from(PublicKeyPrepared::default().as_bytes());
+	let committee = SyncCommittee {
+		pubkeys: vec![infinity_pubkey; MINIMAL_SYNC_COMMITTEE_SIZE]
+			.try_into()
+			.expect("minimal committee length is bounded"),
+		aggregate_pubkey: infinity_pubkey,
+	};
+
+	assert!(matches!(
+		committee.prepare(EthereumBeaconPreset::Minimal),
+		Err(TypeError::PreparePublicKeysFailed)
+	));
 }
 
 /* SYNC PROCESS TESTS */

--- a/pallets/ethereum_verifier/src/tests.rs
+++ b/pallets/ethereum_verifier/src/tests.rs
@@ -542,6 +542,26 @@ fn sync_committee_prepare_rejects_infinity_public_keys() {
 	));
 }
 
+#[test]
+fn sync_committee_prepare_rejects_non_subgroup_public_keys() {
+	// Mirrors the compressed `(0, 2)` G1 test vector from `snowbridge-milagro-bls`, which
+	// deserializes on the unchecked path but fails subgroup validation.
+	let mut non_subgroup_bytes = [0u8; 48];
+	non_subgroup_bytes[0] = 128;
+	let non_subgroup_pubkey = PublicKey::from(non_subgroup_bytes);
+	let committee = SyncCommittee {
+		pubkeys: vec![non_subgroup_pubkey; MINIMAL_SYNC_COMMITTEE_SIZE]
+			.try_into()
+			.expect("minimal committee length is bounded"),
+		aggregate_pubkey: non_subgroup_pubkey,
+	};
+
+	assert!(matches!(
+		committee.prepare(EthereumBeaconPreset::Minimal),
+		Err(TypeError::PreparePublicKeysFailed)
+	));
+}
+
 /* SYNC PROCESS TESTS */
 
 #[test]

--- a/pallets/ethereum_verifier/src/types.rs
+++ b/pallets/ethereum_verifier/src/types.rs
@@ -27,8 +27,6 @@ const MAINNET_SYNC_COMMITTEE_BITS_SIZE: usize =
 const MINIMAL_SYNC_COMMITTEE_SIZE: usize = EthereumBeaconPreset::Minimal.sync_committee_size();
 
 type RawSyncCommittee<const COMMITTEE_SIZE: usize> = snowbridge::SyncCommittee<COMMITTEE_SIZE>;
-type RawSyncCommitteePrepared<const COMMITTEE_SIZE: usize> =
-	snowbridge::SyncCommitteePrepared<COMMITTEE_SIZE>;
 type RawSyncAggregate<const COMMITTEE_SIZE: usize, const BITS_SIZE: usize> =
 	snowbridge::SyncAggregate<COMMITTEE_SIZE, BITS_SIZE>;
 type RawNextSyncCommitteeUpdate<const COMMITTEE_SIZE: usize> =
@@ -80,18 +78,10 @@ impl SyncCommittee {
 		preset: EthereumBeaconPreset,
 	) -> Result<SyncCommitteePrepared, TypeError> {
 		match preset {
-			EthereumBeaconPreset::Mainnet => {
-				let committee = self.to_raw::<{ MAINNET_SYNC_COMMITTEE_SIZE }>()?;
-				RawSyncCommitteePrepared::<{ MAINNET_SYNC_COMMITTEE_SIZE }>::try_from(&committee)
-					.map_err(|_| TypeError::PreparePublicKeysFailed)?
-					.try_into()
-			},
-			EthereumBeaconPreset::Minimal => {
-				let committee = self.to_raw::<{ MINIMAL_SYNC_COMMITTEE_SIZE }>()?;
-				RawSyncCommitteePrepared::<{ MINIMAL_SYNC_COMMITTEE_SIZE }>::try_from(&committee)
-					.map_err(|_| TypeError::PreparePublicKeysFailed)?
-					.try_into()
-			},
+			EthereumBeaconPreset::Mainnet =>
+				self.prepare_committee::<{ MAINNET_SYNC_COMMITTEE_SIZE }>(),
+			EthereumBeaconPreset::Minimal =>
+				self.prepare_committee::<{ MINIMAL_SYNC_COMMITTEE_SIZE }>(),
 		}
 	}
 
@@ -106,6 +96,28 @@ impl SyncCommittee {
 				.map_err(|_| TypeError::InvalidBoundedLength)?,
 			aggregate_pubkey: self.aggregate_pubkey,
 		})
+	}
+
+	fn prepare_committee<const COMMITTEE_SIZE: usize>(
+		&self,
+	) -> Result<SyncCommitteePrepared, TypeError> {
+		let committee = self.to_raw::<COMMITTEE_SIZE>()?;
+		let root = committee.hash_tree_root().map_err(|_| TypeError::HashTreeRootFailed)?;
+		let mut pubkeys = BoundedVec::new();
+
+		for pubkey in committee.pubkeys.iter() {
+			pubkeys
+				.try_push(
+					PublicKeyPrepared::from_bytes(&pubkey.0)
+						.map_err(|_| TypeError::PreparePublicKeysFailed)?,
+				)
+				.map_err(|_| TypeError::InvalidBoundedLength)?;
+		}
+
+		let aggregate_pubkey = PublicKeyPrepared::from_bytes(&committee.aggregate_pubkey.0)
+			.map_err(|_| TypeError::PreparePublicKeysFailed)?;
+
+		Ok(SyncCommitteePrepared { root, pubkeys, aggregate_pubkey })
 	}
 }
 
@@ -132,27 +144,6 @@ pub struct SyncCommitteePrepared {
 }
 
 impl DecodeWithMemTracking for SyncCommitteePrepared {}
-
-impl<const COMMITTEE_SIZE: usize> TryFrom<RawSyncCommitteePrepared<COMMITTEE_SIZE>>
-	for SyncCommitteePrepared
-{
-	type Error = TypeError;
-
-	fn try_from(
-		sync_committee: RawSyncCommitteePrepared<COMMITTEE_SIZE>,
-	) -> Result<Self, Self::Error> {
-		Ok(Self {
-			root: sync_committee.root,
-			pubkeys: sync_committee
-				.pubkeys
-				.as_ref()
-				.to_vec()
-				.try_into()
-				.map_err(|_| TypeError::InvalidBoundedLength)?,
-			aggregate_pubkey: sync_committee.aggregate_pubkey,
-		})
-	}
-}
 
 #[derive(Default, Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, Debug, TypeInfo)]
 pub struct SyncAggregate {


### PR DESCRIPTION
## Summary

This is a defense-in-depth security patch for the Ethereum verifier. Sync committee preparation now rejects malformed BLS public keys before they reach verifier storage, so a compromised proof path cannot smuggle infinity or non-subgroup points into state.

This also aligns our local verifier path with the checked public-key decoding used on Snowbridge's `polkadot-stable2603-4` line and adds regression coverage for encoded infinity keys.

## Validation

- `cargo test -p pallet-ethereum-verifier --lib sync_committee_prepare_rejects_infinity_public_keys`
- `cargo test -p pallet-ethereum-verifier --lib submit_update_with_invalid_sync_committee_update`
