### PR TITLE
Add argon-rpc gateway to dev docker stack

### DIFF
--- a/.github/templates/docker/action.yml
+++ b/.github/templates/docker/action.yml
@@ -61,9 +61,7 @@ runs:
         platforms: linux/amd64,linux/arm64
         context: .
         file: ${{ inputs.dockerfile }}
-        build-args: |
-          BIN=${{ inputs.bin }}
-          VCS_REF=${{ github.sha }}
+        build-args: BIN=${{ inputs.bin }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/templates/docker/action.yml
+++ b/.github/templates/docker/action.yml
@@ -61,7 +61,9 @@ runs:
         platforms: linux/amd64,linux/arm64
         context: .
         file: ${{ inputs.dockerfile }}
-        build-args: BIN=${{ inputs.bin }}
+        build-args: |
+          BIN=${{ inputs.bin }}
+          VCS_REF=${{ github.sha }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-argon-rpc.yml
+++ b/.github/workflows/publish-argon-rpc.yml
@@ -1,0 +1,58 @@
+name: Publish Argon RPC Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Immutable image tag to publish (for example: v0.1.2-argon.2)'
+        required: true
+        type: string
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Require main branch workflow
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ "$GITHUB_REF_NAME" != "${{ github.event.repository.default_branch }}" ]]; then
+            echo "Run this workflow from ${{ github.event.repository.default_branch }} only." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v5
+
+      - name: Choose tags
+        id: tags
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ ! "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-argon\.[0-9]+$ ]]; then
+              echo "Invalid argon-rpc image tag: $IMAGE_TAG" >&2
+              exit 1
+            fi
+
+            tags="type=raw,value=$IMAGE_TAG"
+          else
+            tags=$'type=raw,dev\ntype=sha'
+          fi
+
+          printf 'tags<<EOF\n%s\nEOF\n' "$tags" >> "$GITHUB_OUTPUT"
+
+      - name: Argon RPC
+        uses: ./.github/templates/docker
+        with:
+          image: ghcr.io/argonprotocol/argon-rpc
+          dockerfile: docker/argon-rpc/Containerfile
+          bin: argon-rpc
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tags: ${{ steps.tags.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -223,22 +223,33 @@ VERSION=v1.3.0 RPC_PORT=9944 docker compose -f dev.docker-compose.yml up
 The docker compose file has several profiles that can be used to run different parts of the network.
 
 - `Default (no profile)`: If you don't use a profile, it will run the entire network with an argon
-  node, bitcoin node, notary and bitcoin oracle.
+  node, bitcoin node, notary, bitcoin oracle, and the RPC gateway in front of the archive node.
 - `miners`: Adds 2 compute miners.
 - `price-oracle`: Adds a price oracle to the network. You must supply an `Infura` and `BLS` key in
   the `.env` file for this to work (see below).
 - `all`: Run the entire network: 1 archive node, 2 miners, 1 bitcoin node, 1 notary, 1 bitcoin
-  oracle and 1 price oracle.
+  oracle, 1 RPC gateway, and 1 price oracle.
 
 Profiles must be specified with the `--profile` flag in the `docker compose` command. Omitting will
 use the default profile.
 
-To run multiple compose instances, you need to set `RPC_PORT=0`, otherwise, each will bind an rpc
-port on 9944.
+To run multiple compose instances, you need to set `RPC_PORT=0`.
 
 ```sh
 VERSION=v1.3.0 RPC_PORT=0 docker compose -f dev.docker-compose.yml --profile all up
 ```
+
+The RPC gateway listens on `RPC_PORT` (default `9944`). The raw archive node can also be exposed on
+`ARCHIVE_NODE_RPC_PORT`, which defaults to `0` so Docker assigns an ephemeral host port. Set it to
+something like `9946` when you want a stable direct node RPC port for lower-level debugging or
+admin flows. The gateway
+builds locally as `ghcr.io/argonprotocol/argon-rpc:${VERSION:-dev}` from the pinned upstream Acala
+Subway release in `docker/argon-rpc/Containerfile`, bakes in its checked-in config template from
+`docker/argon-rpc/config.yml`, and loads its RPC allowlist/cache tuning from
+`docker/argon-rpc/rpcs.yml`. Runtime tuning is passed through with `ARGON_RPC_*` environment
+variables. By default it proxies to `ws://archive-node:9944`, and optional backup upstreams can be
+supplied with `ARGON_RPC_ENDPOINTS='["ws://archive-node:9944", "ws://backup-node:9944"]'`. See
+[`docker/argon-rpc/README.md`](./docker/argon-rpc/README.md) for the full config reference.
 
 NOTE: You must get a [BLS key](https://data.bls.gov/registrationEngine/) and an
 [Infura](https://docs.metamask.io/services/get-started/infura/) key to run the price oracle. They

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -235,9 +235,6 @@ services:
     build:
       context: .
       dockerfile: docker/argon-rpc/Containerfile
-      args:
-        ARGON_RPC_VERSION: ${VERSION:-dev}
-        VCS_REF: ${VCS_REF:-unknown}
     restart: on-failure
     depends_on:
       archive-node:
@@ -268,9 +265,10 @@ services:
       test:
         - CMD-SHELL
         - >
-          bash -lc "exec 3<>/dev/tcp/127.0.0.1/9944 &&
-          printf 'GET /liveness HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n' >&3 &&
-          grep -q '200 OK' <&3"
+          bash -lc 'exec 3<>/dev/tcp/127.0.0.1/9944 &&
+          printf "GET /liveness HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n" >&3 &&
+          IFS= read -r status <&3 &&
+          [[ $$status == *"200 OK"* ]]'
       interval: 5s
       timeout: 5s
       start_period: 10s

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -1,6 +1,6 @@
 ## Shared configs
 x-oracle-config: &oracle
-  image: ghcr.io/argonprotocol/argon-oracle:${VERSION:-latest}
+  image: ghcr.io/argonprotocol/argon-oracle:${VERSION:-dev}
   user: root
   build:
     context: .
@@ -8,7 +8,7 @@ x-oracle-config: &oracle
     target: oracle
   restart: on-failure
 x-notary-config: &notary
-  image: ghcr.io/argonprotocol/argon-notary:${VERSION:-latest}
+  image: ghcr.io/argonprotocol/argon-notary:${VERSION:-dev}
   user: root
   build:
     context: .
@@ -16,7 +16,7 @@ x-notary-config: &notary
     target: argon-notary
   restart: on-failure
 x-node-config: &node
-  image: ghcr.io/argonprotocol/argon-miner:${VERSION:-latest}
+  image: ghcr.io/argonprotocol/argon-miner:${VERSION:-dev}
   build:
     context: .
     dockerfile: dev.Dockerfile
@@ -212,7 +212,7 @@ services:
       --validator
       --pruning=archive
     ports:
-      - "${RPC_PORT:-9944}:9944"
+      - "${ARCHIVE_NODE_RPC_PORT:-0}:9944"
       - "0:30334"
     volumes:
       - archive-data:/data
@@ -228,6 +228,52 @@ services:
       interval: 5s
       timeout: 5s
       start_period: 30s
+      retries: 12
+
+  archive-rpc:
+    image: ghcr.io/argonprotocol/argon-rpc:${VERSION:-dev}
+    build:
+      context: .
+      dockerfile: docker/argon-rpc/Containerfile
+      args:
+        ARGON_RPC_VERSION: ${VERSION:-dev}
+        VCS_REF: ${VCS_REF:-unknown}
+    restart: on-failure
+    depends_on:
+      archive-node:
+        condition: service_healthy
+    # Forward optional host overrides; config.yml defaults still apply when values are unset or blank.
+    environment:
+      - RUST_LOG=${ARGON_RPC_RUST_LOG:-info,subway=debug}
+      - LOG_FORMAT=${ARGON_RPC_LOG_FORMAT:-compact}
+      - ARGON_RPC_ENDPOINTS
+      - ARGON_RPC_UPSTREAM_REQUEST_TIMEOUT_SECONDS
+      - ARGON_RPC_UPSTREAM_CONNECTION_TIMEOUT_SECONDS
+      - ARGON_RPC_UPSTREAM_RETRIES
+      - ARGON_RPC_STALE_TIMEOUT_SECONDS
+      - ARGON_RPC_CACHE_TTL_SECONDS
+      - ARGON_RPC_CACHE_SIZE
+      - ARGON_RPC_KEEP_ALIVE_SECONDS
+      - ARGON_RPC_MAX_CONNECTIONS
+      - ARGON_RPC_MAX_BATCH_SIZE
+      - ARGON_RPC_CONNECTION_BURST
+      - ARGON_RPC_CONNECTION_PERIOD_SECS
+      - ARGON_RPC_IP_BURST
+      - ARGON_RPC_IP_PERIOD_SECS
+      - ARGON_RPC_USE_XFF
+      - ARGON_RPC_PROMETHEUS_LABEL
+    ports:
+      - "${RPC_PORT:-9944}:9944"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          bash -lc "exec 3<>/dev/tcp/127.0.0.1/9944 &&
+          printf 'GET /liveness HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n' >&3 &&
+          grep -q '200 OK' <&3"
+      interval: 5s
+      timeout: 5s
+      start_period: 10s
       retries: 12
 
   miner-1:
@@ -357,7 +403,7 @@ services:
         condition: service_completed_successfully
       notary-migrate:
         condition: service_completed_successfully
-      archive-node:
+      archive-rpc:
         condition: service_healthy
       minio:
         condition: service_healthy
@@ -380,7 +426,7 @@ services:
         aliases:
           - notary.localhost
     environment:
-      - TRUSTED_RPC_URL=ws://archive-node:9944
+      - TRUSTED_RPC_URL=ws://archive-rpc:9944
 
   oracle-btc-insert-key:
     <<: *oracle
@@ -397,7 +443,7 @@ services:
     depends_on:
       oracle-btc-insert-key:
         condition: service_completed_successfully
-      archive-node:
+      archive-rpc:
         condition: service_healthy
     command:
       - bitcoin
@@ -408,7 +454,7 @@ services:
     volumes:
       - oracle-btc-keystore:/keystore
     environment:
-      - TRUSTED_RPC_URL=ws://archive-node:9944
+      - TRUSTED_RPC_URL=ws://archive-rpc:9944
 
   oracle-price-insert-key:
     <<: *oracle
@@ -428,7 +474,7 @@ services:
     depends_on:
       oracle-price-insert-key:
         condition: service_completed_successfully
-      archive-node:
+      archive-rpc:
         condition: service_healthy
     command: >
       price-index
@@ -441,7 +487,7 @@ services:
       - /tmp/oracle/data/:/tmp/oracle/data/
       - ${PRICE_INDEX_FILE_PATH:-./oracle/test-price-index.json}:/price_index.json:ro
     environment:
-      - TRUSTED_RPC_URL=ws://archive-node:9944
+      - TRUSTED_RPC_URL=ws://archive-rpc:9944
     profiles:
       - price-oracle
       - all
@@ -453,7 +499,7 @@ services:
     depends_on:
       oracle-price-insert-key:
         condition: service_completed_successfully
-      archive-node:
+      archive-rpc:
         condition: service_healthy
     command: >
       price-index
@@ -464,7 +510,7 @@ services:
       - oracle-price-keystore:/keystore
       - /tmp/oracle/data/:/tmp/oracle/data/
     environment:
-      - TRUSTED_RPC_URL=ws://archive-node:9944
+      - TRUSTED_RPC_URL=ws://archive-rpc:9944
       - ARGON_TOKEN_ADDRESS=${ARGON_TOKEN_ADDRESS:-3e622317f8C93f7328350cF0B56d9eD4C620C5d6}
       - ARGONOT_TOKEN_ADDRESS=${ARGONOT_TOKEN_ADDRESS:-3e622317f8C93f7328350cF0B56d9eD4C620C5d6}
       - BLS_API_KEY=${BLS_API_KEY}

--- a/docker/argon-rpc/Containerfile
+++ b/docker/argon-rpc/Containerfile
@@ -1,0 +1,50 @@
+ARG UPSTREAM_SUBWAY_REF=v0.1.2
+ARG ARGON_RPC_VERSION=dev
+ARG VCS_REF=unknown
+
+FROM docker.io/library/rust:1.86 AS builder
+
+# Keep this pinned to upstream Acala releases unless we intentionally need a newer Subway tag.
+ARG UPSTREAM_SUBWAY_REF
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      ca-certificates clang git libssl-dev pkg-config protobuf-compiler && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cargo install \
+    --locked \
+    --git https://github.com/AcalaNetwork/subway.git \
+    --tag ${UPSTREAM_SUBWAY_REF} \
+    subway
+
+FROM docker.io/library/ubuntu:22.04
+
+ARG UPSTREAM_SUBWAY_REF
+ARG ARGON_RPC_VERSION
+ARG VCS_REF
+
+LABEL org.opencontainers.image.title="Argon RPC" \
+      org.opencontainers.image.description="Argon RPC gateway packaging Acala Subway with Argon defaults" \
+      org.opencontainers.image.source="https://github.com/argonprotocol/mainchain" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Argon Foundation" \
+      org.opencontainers.image.version="${ARGON_RPC_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      io.argonprotocol.upstream-subway.repository="https://github.com/AcalaNetwork/subway" \
+      io.argonprotocol.upstream-subway.ref="${UPSTREAM_SUBWAY_REF}"
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      bash ca-certificates libssl3 tini && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/cargo/bin/subway /usr/local/bin/subway
+COPY docker/argon-rpc/config.yml /config/argon-rpc.yml
+COPY docker/argon-rpc/rpcs.yml /config/rpcs.yml
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/subway", "--config", "/config/argon-rpc.yml"]

--- a/docker/argon-rpc/Containerfile
+++ b/docker/argon-rpc/Containerfile
@@ -1,6 +1,4 @@
 ARG UPSTREAM_SUBWAY_REF=v0.1.2
-ARG ARGON_RPC_VERSION=dev
-ARG VCS_REF=unknown
 
 FROM docker.io/library/rust:1.86 AS builder
 
@@ -23,17 +21,8 @@ RUN cargo install \
 FROM docker.io/library/ubuntu:22.04
 
 ARG UPSTREAM_SUBWAY_REF
-ARG ARGON_RPC_VERSION
-ARG VCS_REF
 
-LABEL org.opencontainers.image.title="Argon RPC" \
-      org.opencontainers.image.description="Argon RPC gateway packaging Acala Subway with Argon defaults" \
-      org.opencontainers.image.source="https://github.com/argonprotocol/mainchain" \
-      org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.vendor="Argon Foundation" \
-      org.opencontainers.image.version="${ARGON_RPC_VERSION}" \
-      org.opencontainers.image.revision="${VCS_REF}" \
-      io.argonprotocol.upstream-subway.repository="https://github.com/AcalaNetwork/subway" \
+LABEL io.argonprotocol.upstream-subway.repository="https://github.com/AcalaNetwork/subway" \
       io.argonprotocol.upstream-subway.ref="${UPSTREAM_SUBWAY_REF}"
 
 RUN apt-get update && \

--- a/docker/argon-rpc/README.md
+++ b/docker/argon-rpc/README.md
@@ -127,17 +127,14 @@ JSON-style array examples above work well in `.env` files.
 
 ## OCI metadata
 
-The image carries both Argon-owned and upstream provenance labels:
+The image adds custom upstream provenance labels:
 
-- `org.opencontainers.image.version`: Argon image version
-- `org.opencontainers.image.revision`: Argon git revision when supplied at build time
 - `io.argonprotocol.upstream-subway.repository`: upstream Subway repository
 - `io.argonprotocol.upstream-subway.ref`: pinned upstream Subway tag or ref
 
-Local compose builds currently set the Argon image version label from `${VERSION:-dev}`. The git
-revision label comes from `VCS_REF` when supplied and otherwise defaults to `unknown`. The shared
-GitHub Docker publish template passes `VCS_REF=${github.sha}` and already emits a build provenance
-attestation for published images.
+Published images already inherit the standard OCI labels and build metadata from the shared GitHub
+Docker metadata workflow, and the shared publish template already emits a build provenance
+attestation. The Dockerfile only adds the Argon-specific upstream Subway labels above.
 
 ## RPC surface
 
@@ -159,6 +156,18 @@ If you need to change the exposed RPC surface, edit [`rpcs.yml`](./rpcs.yml) and
 
 ## Publishing status
 
-The repo already publishes other runtime images through GitHub Actions, but `argon-rpc` is not wired
-into those workflows yet. Today the dev stack builds this image locally from source, but the image
-itself no longer depends on bind-mounted config files from the repo.
+The repo now has one workflow for this image at
+[`publish-argon-rpc.yml`](../../.github/workflows/publish-argon-rpc.yml):
+
+- pushes to `main` build the rolling edge image tags
+- `workflow_dispatch` with `image_tag` publishes an immutable `vX.Y.Z-argon.N` tag from `main`
+
+The manual tag path is intentionally narrow:
+
+- it only accepts the full immutable Argon tag, such as `v0.1.2-argon.2`
+- it does not allow overriding the pinned upstream Subway ref
+- it always publishes current `main`
+- it publishes `ghcr.io/argonprotocol/argon-rpc` only
+
+The dev stack still builds this image locally from source, but the image itself no longer depends on
+bind-mounted config files from the repo.

--- a/docker/argon-rpc/README.md
+++ b/docker/argon-rpc/README.md
@@ -1,0 +1,164 @@
+# Argon RPC
+
+This image wraps the upstream Acala `subway` binary with Argon's checked-in RPC config and method
+allowlist.
+
+## How it works
+
+1. [`Containerfile`](./Containerfile) builds `subway` from the pinned upstream Acala release in
+   `UPSTREAM_SUBWAY_REF`.
+2. The runtime image copies [`config.yml`](./config.yml) into `/config/argon-rpc.yml`.
+3. The runtime image copies [`rpcs.yml`](./rpcs.yml) into `/config/rpcs.yml`.
+4. The image starts with:
+
+   ```sh
+   subway --config /config/argon-rpc.yml
+   ```
+
+5. Subway expands `${...}` placeholders inside the YAML before parsing it, so we can keep one
+   checked-in config template and tune it with container environment variables.
+6. By default the gateway proxies to `ws://archive-node:9944`. Backup upstreams can be added with
+   `ARGON_RPC_ENDPOINTS`.
+
+## Files
+
+- [`Containerfile`](./Containerfile): builds the pinned upstream `subway` binary and packages the
+  checked-in RPC config and allowlist.
+- [`config.yml`](./config.yml): the main Subway config template with env-driven defaults.
+- [`rpcs.yml`](./rpcs.yml): the allowed RPC surface, cache settings, and subscription middleware
+  behavior.
+
+## Compose behavior
+
+In [`dev.docker-compose.yml`](../../dev.docker-compose.yml), the `archive-rpc` service:
+
+- builds locally as `ghcr.io/argonprotocol/argon-rpc:${VERSION:-dev}`
+- listens on container port `9944`
+- publishes that port to `${RPC_PORT:-9944}` on the host
+- uses the baked-in `/config/argon-rpc.yml` and `/config/rpcs.yml`
+- passes through optional host overrides with `ARGON_RPC_*`
+
+The raw archive node RPC host port is controlled separately with `ARCHIVE_NODE_RPC_PORT`. Its
+default is `0`, so Docker assigns an ephemeral host port and the main developer entrypoint stays on
+the gateway.
+
+## Versioning
+
+For published images, the immutable tag should be Argon-owned while still showing the upstream
+Subway base:
+
+- `v0.1.2-argon.1`
+- `v0.1.2-argon.2`
+- `v0.1.3-argon.1`
+
+That means:
+
+- bump `argon.N` when we change Argon packaging, config, or RPC policy on top of the same upstream
+  Subway release
+- reset to `.1` when we move to a new upstream Acala Subway tag
+
+The current dev compose stack still builds and tags locally with `${VERSION:-dev}` because it is not
+consuming a published `argon-rpc` image yet.
+
+## Environment variables
+
+The compose file forwards these variable names so you can override them from your shell or `.env`
+file. If a value is unset or blank, the `${...:-default}` expression in the baked-in
+[`config.yml`](./config.yml) falls back to the checked-in default.
+
+### Compose-level variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `VERSION` | `dev` | Image tag used for the local build tag in compose. |
+| `RPC_PORT` | `9944` | Host port for the gateway itself. |
+| `ARCHIVE_NODE_RPC_PORT` | `0` | Optional direct host port for the raw archive node RPC. |
+
+### Logging variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ARGON_RPC_RUST_LOG` | `info,subway=debug` | Rust log filter passed as `RUST_LOG`. |
+| `ARGON_RPC_LOG_FORMAT` | `compact` | Subway log formatter passed as `LOG_FORMAT`. |
+
+### Gateway variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ARGON_RPC_ENDPOINTS` | `["ws://archive-node:9944"]` | YAML/JSON list of upstream websocket endpoints. Order matters. Put the preferred endpoint first. |
+| `ARGON_RPC_UPSTREAM_REQUEST_TIMEOUT_SECONDS` | `20` | Per-request timeout for upstream RPC calls. |
+| `ARGON_RPC_UPSTREAM_CONNECTION_TIMEOUT_SECONDS` | `5` | Timeout when opening an upstream websocket connection. |
+| `ARGON_RPC_UPSTREAM_RETRIES` | `1` | Number of retry attempts for upstream requests. |
+| `ARGON_RPC_STALE_TIMEOUT_SECONDS` | `180` | How long the substrate API extension tolerates stale head data. |
+| `ARGON_RPC_CACHE_TTL_SECONDS` | `60` | Default cache TTL for methods that use the shared cache. |
+| `ARGON_RPC_CACHE_SIZE` | `500` | Default cache entry limit for methods that use the shared cache. |
+| `ARGON_RPC_KEEP_ALIVE_SECONDS` | `60` | Subscription keepalive interval for merged subscriptions. |
+| `ARGON_RPC_MAX_CONNECTIONS` | `2000` | Maximum concurrent client connections accepted by the server. |
+| `ARGON_RPC_MAX_BATCH_SIZE` | `10` | Maximum JSON-RPC batch size accepted by the server. |
+| `ARGON_RPC_CONNECTION_BURST` | `20` | Burst limit for the connection-level rate limiter. |
+| `ARGON_RPC_CONNECTION_PERIOD_SECS` | `1` | Window size for the connection-level rate limiter. |
+| `ARGON_RPC_IP_BURST` | `500` | Burst limit for the IP-level rate limiter. |
+| `ARGON_RPC_IP_PERIOD_SECS` | `10` | Window size for the IP-level rate limiter. |
+| `ARGON_RPC_USE_XFF` | `true` | Whether to trust `X-Forwarded-For` when applying IP rate limits. |
+| `ARGON_RPC_PROMETHEUS_LABEL` | `argon-rpc` | Label prefix exported by the Prometheus metrics endpoint. |
+
+## Endpoint examples
+
+Single upstream:
+
+```dotenv
+ARGON_RPC_ENDPOINTS=["ws://archive-node:9944"]
+```
+
+Primary plus backup upstream:
+
+```dotenv
+ARGON_RPC_ENDPOINTS=["ws://archive-node:9944", "ws://backup-node:9944"]
+```
+
+Because the value is substituted directly into YAML, it needs to stay a valid YAML list literal. The
+JSON-style array examples above work well in `.env` files.
+
+## Health and metrics
+
+- `GET /health` maps to `system_health`
+- `GET /liveness` maps to `chain_getBlockHash`
+- Prometheus metrics are exposed on container port `9616`
+
+## OCI metadata
+
+The image carries both Argon-owned and upstream provenance labels:
+
+- `org.opencontainers.image.version`: Argon image version
+- `org.opencontainers.image.revision`: Argon git revision when supplied at build time
+- `io.argonprotocol.upstream-subway.repository`: upstream Subway repository
+- `io.argonprotocol.upstream-subway.ref`: pinned upstream Subway tag or ref
+
+Local compose builds currently set the Argon image version label from `${VERSION:-dev}`. The git
+revision label comes from `VCS_REF` when supplied and otherwise defaults to `unknown`. The shared
+GitHub Docker publish template passes `VCS_REF=${github.sha}` and already emits a build provenance
+attestation for published images.
+
+## RPC surface
+
+[`rpcs.yml`](./rpcs.yml) is the checked-in allowlist for exposed methods and their cache settings.
+Right now it is intentionally scoped to the methods our local network and clients need, including:
+
+- author methods for extrinsic submission
+- common chain and state lookups
+- payment fee queries
+- selected `chainSpec_v1_*`, `transaction_v1_*`, and `archive_v1_body`
+
+Two intentional exclusions are worth calling out:
+
+- `rpc_methods` is not listed because Subway auto-registers it after loading the RPC config.
+- `chainHead_v1_*` is omitted for now because Subway does not rewrite follow IDs for those
+  downstream-follow subscriptions.
+
+If you need to change the exposed RPC surface, edit [`rpcs.yml`](./rpcs.yml) and rebuild the image.
+
+## Publishing status
+
+The repo already publishes other runtime images through GitHub Actions, but `argon-rpc` is not wired
+into those workflows yet. Today the dev stack builds this image locally from source, but the image
+itself no longer depends on bind-mounted config files from the repo.

--- a/docker/argon-rpc/config.yml
+++ b/docker/argon-rpc/config.yml
@@ -1,0 +1,52 @@
+extensions:
+  client:
+    endpoints: ${ARGON_RPC_ENDPOINTS:-["ws://archive-node:9944"]}
+    request_timeout_seconds: ${ARGON_RPC_UPSTREAM_REQUEST_TIMEOUT_SECONDS:-20}
+    connection_timeout_seconds: ${ARGON_RPC_UPSTREAM_CONNECTION_TIMEOUT_SECONDS:-5}
+    retries: ${ARGON_RPC_UPSTREAM_RETRIES:-1}
+  event_bus:
+  substrate_api:
+    stale_timeout_seconds: ${ARGON_RPC_STALE_TIMEOUT_SECONDS:-180}
+  telemetry:
+    provider: none
+  cache:
+    default_ttl_seconds: ${ARGON_RPC_CACHE_TTL_SECONDS:-60}
+    default_size: ${ARGON_RPC_CACHE_SIZE:-500}
+  merge_subscription:
+    keep_alive_seconds: ${ARGON_RPC_KEEP_ALIVE_SECONDS:-60}
+  server:
+    port: 9944
+    listen_address: "0.0.0.0"
+    max_connections: ${ARGON_RPC_MAX_CONNECTIONS:-2000}
+    max_batch_size: ${ARGON_RPC_MAX_BATCH_SIZE:-10}
+    http_methods:
+      - path: /health
+        method: system_health
+      - path: /liveness
+        method: chain_getBlockHash
+    cors: all
+  rate_limit:
+    connection:
+      burst: ${ARGON_RPC_CONNECTION_BURST:-20}
+      period_secs: ${ARGON_RPC_CONNECTION_PERIOD_SECS:-1}
+    ip:
+      burst: ${ARGON_RPC_IP_BURST:-500}
+      period_secs: ${ARGON_RPC_IP_PERIOD_SECS:-10}
+    use_xff: ${ARGON_RPC_USE_XFF:-true}
+  prometheus:
+    port: 9616
+    listen_address: "0.0.0.0"
+    label: "${ARGON_RPC_PROMETHEUS_LABEL:-argon-rpc}"
+
+middlewares:
+  methods:
+    - delay
+    - response
+    - inject_params
+    - cache
+    - upstream
+  subscriptions:
+    - merge_subscription
+    - upstream
+
+rpcs: /config/rpcs.yml

--- a/docker/argon-rpc/rpcs.yml
+++ b/docker/argon-rpc/rpcs.yml
@@ -286,10 +286,13 @@ methods:
       size: 1
 
   - method: system_name
-    response: Subway
+    cache:
+      size: 1
 
   - method: system_version
-    response: 1.0.0-dev
+    cache:
+      size: 1
+      ttl_seconds: 300
 
   - method: system_chainType
     cache:
@@ -300,7 +303,8 @@ methods:
       size: 1
 
   - method: system_nodeRoles
-    response: [ 'Full' ]
+    cache:
+      size: 1
 
   - method: system_localListenAddresses
     cache:

--- a/docker/argon-rpc/rpcs.yml
+++ b/docker/argon-rpc/rpcs.yml
@@ -1,0 +1,371 @@
+methods:
+  - method: author_submitExtrinsic
+    cache:
+      size: 0
+    params:
+      - name: extrinsic
+        ty: Bytes
+
+  - method: author_pendingExtrinsics
+    cache:
+      size: 1
+      ttl_seconds: 3
+    rate_limit_weight: 5
+
+  - method: chain_getBlockHash
+    cache:
+      size: 2000
+      ttl_seconds: 300
+    params:
+      - name: blockNumber
+        ty: BlockNumber
+        optional: true
+        inject: true
+
+  - method: chain_getHeader
+    cache:
+      size: 1000
+      ttl_seconds: 300
+    params:
+      - name: hash
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: chain_getBlock
+    cache:
+      size: 200
+      ttl_seconds: 300
+    params:
+      - name: hash
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: chain_getFinalizedHead
+    cache:
+      size: 1
+      ttl_seconds: 6
+
+  # Subway auto-registers `rpc_methods` after loading this RPC config.
+  - method: state_getRuntimeVersion
+    cache:
+      size: 32
+      ttl_seconds: 300
+    params:
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: state_getMetadata
+    params:
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: state_getStorage
+    params:
+      - name: key
+        ty: StorageKey
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: state_getKeysPaged
+    params:
+      - name: key
+        ty: StorageKey
+      - name: count
+        ty: u32
+      - name: startKey
+        ty: StorageKey
+        optional: true
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: state_queryStorageAt
+    params:
+      - name: keys
+        ty: 'Vec<StorageKey>'
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: state_call
+    cache:
+      size: 200
+      ttl_seconds: 30
+    rate_limit_weight: 5
+    params:
+      - name: method
+        ty: String
+      - name: data
+        ty: Bytes
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: state_getReadProof
+    params:
+      - name: keys
+        ty: 'Vec<StorageKey>'
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: state_getStorageHash
+    cache:
+      size: 2000
+      ttl_seconds: 300
+    params:
+      - name: key
+        ty: StorageKey
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: state_getStorageSize
+    cache:
+      size: 1000
+      ttl_seconds: 300
+    params:
+      - name: key
+        ty: StorageKey
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: childstate_getKeysPaged
+    params:
+      - name: childStorageKey
+        ty: StorageKey
+      - name: prefix
+        ty: StorageKey
+      - name: count
+        ty: u32
+      - name: startKey
+        ty: StorageKey
+        optional: true
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: childstate_getStorage
+    params:
+      - name: childStorageKey
+        ty: StorageKey
+      - name: key
+        ty: StorageKey
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: payment_queryInfo
+    cache:
+      size: 200
+      ttl_seconds: 30
+    rate_limit_weight: 5
+    params:
+      - name: extrinsic
+        ty: Bytes
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  - method: payment_queryFeeDetails
+    cache:
+      size: 200
+      ttl_seconds: 30
+    rate_limit_weight: 5
+    params:
+      - name: extrinsic
+        ty: Bytes
+      - name: at
+        ty: BlockHash
+        optional: true
+        inject: true
+
+  # `chainHead_v1_*` is intentionally omitted for now. Subway does not rewrite
+  # downstream follow IDs for the follow-bound spec-v2 methods.
+  - method: chainSpec_v1_chainName
+    cache:
+      size: 1
+      ttl_seconds: 300
+
+  - method: chainSpec_v1_genesisHash
+    cache:
+      size: 1
+      ttl_seconds: 300
+
+  - method: chainSpec_v1_properties
+    cache:
+      size: 1
+      ttl_seconds: 300
+
+  - method: transaction_v1_broadcast
+    cache:
+      size: 0
+    rate_limit_weight: 5
+    params:
+      - name: extrinsic
+        ty: Bytes
+
+  - method: transaction_v1_stop
+    cache:
+      size: 0
+    params:
+      - name: operationId
+        ty: String
+
+  - method: archive_v1_body
+    cache:
+      size: 200
+      ttl_seconds: 300
+    params:
+      - name: hash
+        ty: BlockHash
+
+  - method: archive_v1_call
+    cache:
+      size: 200
+      ttl_seconds: 30
+    rate_limit_weight: 5
+    params:
+      - name: hash
+        ty: BlockHash
+      - name: function
+        ty: String
+      - name: callParameters
+        ty: Bytes
+
+  - method: archive_v1_finalizedHeight
+    cache:
+      size: 1
+      ttl_seconds: 6
+
+  - method: archive_v1_genesisHash
+    cache:
+      size: 1
+      ttl_seconds: 300
+
+  - method: archive_v1_hashByHeight
+    cache:
+      size: 1000
+      ttl_seconds: 300
+    params:
+      - name: height
+        ty: u32
+
+  - method: archive_v1_header
+    cache:
+      size: 1000
+      ttl_seconds: 300
+    params:
+      - name: hash
+        ty: BlockHash
+
+  - method: system_chain
+    cache:
+      size: 1
+
+  - method: system_properties
+    cache:
+      size: 1
+
+  - method: system_name
+    response: Subway
+
+  - method: system_version
+    response: 1.0.0-dev
+
+  - method: system_chainType
+    cache:
+      size: 1
+
+  - method: system_localPeerId
+    cache:
+      size: 1
+
+  - method: system_nodeRoles
+    response: [ 'Full' ]
+
+  - method: system_localListenAddresses
+    cache:
+      size: 1
+
+  - method: system_health
+    cache:
+      size: 1
+      ttl_seconds: 5
+
+  - method: system_accountNextIndex
+    cache:
+      size: 0
+    params:
+      - name: accountId
+        ty: AccountId
+
+  - method: system_peers
+    cache:
+      size: 1
+      ttl_seconds: 5
+
+subscriptions:
+  - subscribe: author_submitAndWatchExtrinsic
+    unsubscribe: author_unwatchExtrinsic
+    name: author_extrinsicUpdate
+
+  - subscribe: transactionWatch_v1_submitAndWatch
+    unsubscribe: transactionWatch_v1_unwatch
+    name: transactionWatch_v1_watchEvent
+
+  - subscribe: chain_subscribeNewHeads
+    unsubscribe: chain_unsubscribeNewHeads
+    name: chain_newHead
+    merge_strategy: replace
+
+  - subscribe: chain_subscribeFinalizedHeads
+    unsubscribe: chain_unsubscribeFinalizedHeads
+    name: chain_finalizedHead
+    merge_strategy: replace
+
+  - subscribe: chain_subscribeAllHeads
+    unsubscribe: chain_unsubscribeAllHeads
+    name: chain_allHead
+    merge_strategy: replace
+
+  - subscribe: state_subscribeRuntimeVersion
+    unsubscribe: state_unsubscribeRuntimeVersion
+    name: state_runtimeVersion
+    merge_strategy: replace
+
+  - subscribe: state_subscribeStorage
+    unsubscribe: state_unsubscribeStorage
+    name: state_storage
+    merge_strategy: merge_storage_changes
+
+  - subscribe: archive_v1_storage
+    unsubscribe: archive_v1_stopStorage
+    name: archive_v1_storageEvent
+
+aliases:
+  - [ chain_subscribeNewHeads, chain_subscribeNewHead ]
+  - [ chain_unsubscribeNewHeads, chain_unsubscribeNewHead ]
+  - [ chain_getBlockHash, chain_getHead ]
+  - [ state_getKeysPaged, state_getKeysPagedAt ]
+  - [ state_getStorage, state_getStorageAt ]
+  - [ state_getRuntimeVersion, chain_getRuntimeVersion ]
+  - [ childstate_getKeysPaged, childstate_getKeysPagedAt ]


### PR DESCRIPTION
## Summary
- add an argon-rpc gateway service in front of the archive node in dev docker compose
- route notary and oracle services through the gateway while leaving direct archive-node RPC as an optional separate host port
- package the pinned Acala Subway config and RPC allowlist inside the argon-rpc image with env-driven overrides and provenance metadata