### PR TITLE
Fix sponsored mining bid fee refunds on success

### DIFF
--- a/pallets/fee_control/src/check_fee_wrapper.rs
+++ b/pallets/fee_control/src/check_fee_wrapper.rs
@@ -76,17 +76,17 @@ where
 	T: pallet_utility::Config<RuntimeCall = RuntimeCallOf<T>>,
 	RuntimeCallOf<T>: IsSubType<pallet_proxy::Call<T>> + IsSubType<pallet_utility::Call<T>>,
 {
-	// Determine the call to check for sponsorship. If the outer call is a proxy wrapper,
-	// unwrap to the inner call (recursing through nested proxy wrappers).
-	fn unwrap_proxy(call: &RuntimeCallOf<T>) -> &RuntimeCallOf<T> {
+	// If the outer call is a proxy wrapper, unwrap to the effective inner call (recursing through
+	// nested proxy wrappers). Non-proxy calls return `None`.
+	fn unwrap_proxy(call: &RuntimeCallOf<T>) -> Option<&RuntimeCallOf<T>> {
 		if let Some(
 			pallet_proxy::Call::proxy { call, .. } |
 			pallet_proxy::Call::proxy_announced { call, .. },
 		) = <RuntimeCallOf<T> as IsSubType<pallet_proxy::Call<T>>>::is_sub_type(call)
 		{
-			return Self::unwrap_proxy(call.as_ref());
+			return Some(Self::unwrap_proxy(call.as_ref()).unwrap_or(call.as_ref()));
 		}
-		call
+		None
 	}
 
 	fn validated_pool_key_context(
@@ -321,7 +321,7 @@ where
     type Pre = Intermediate<S::Pre, DispatchOriginOf<RuntimeCallOf<T>>, Option<TxSponsor<<T as frame_system::Config>::AccountId, T::Balance>>>;
 
     fn weight(&self, call: &RuntimeCallOf<T>) -> Weight {
-        self.0.weight(call)
+		self.0.weight(call)
     }
 
     fn validate(
@@ -333,11 +333,12 @@ where
         self_implicit: S::Implicit,
         inherited_implication: &impl Implication,
         source: TransactionSource,
-    ) -> ValidateResult<Self::Val, RuntimeCallOf<T>> {
-        let inner_call = Self::unwrap_proxy(call);
-        let signer = origin.as_signer().cloned();
-        Self::validate_freshness(call, signer.clone())?;
-        let general_pool_keys = Self::collect_pool_keys(call, signer);
+	) -> ValidateResult<Self::Val, RuntimeCallOf<T>> {
+		let unwrapped_proxy_call = Self::unwrap_proxy(call);
+		let inner_call = unwrapped_proxy_call.unwrap_or(call);
+		let signer = origin.as_signer().cloned();
+		Self::validate_freshness(call, signer.clone())?;
+		let general_pool_keys = Self::collect_pool_keys(call, signer);
 		if call.is_feeless(&origin) {
 			let synthetic_fee =
 				pallet_transaction_payment::Pallet::<T>::compute_fee(len as u32, info, Zero::zero());
@@ -351,53 +352,65 @@ where
 				..Default::default()
 			};
 
-            for key in general_pool_keys.iter().cloned() {
-                Self::push_pool_key(&mut validity, key);
-            }
-            if let Some(key) = T::FeelessCallTxPoolKeyProviders::key_for(call) {
-                Self::push_pool_key(&mut validity, key);
-            }
+			for key in general_pool_keys.iter().cloned() {
+				Self::push_pool_key(&mut validity, key);
+			}
+			if let Some(key) = T::FeelessCallTxPoolKeyProviders::key_for(call) {
+				Self::push_pool_key(&mut validity, key);
+			}
 
 			Ok((validity, Feeless(origin.clone()), origin))
 		} else {
 			let mut delegated_origin = origin.clone();
 			let mut tx_sponsor = None;
-			// Proxy wrappers should not affect whether a runtime-defined batch combination refunds
-			// on success, so we evaluate policy against the effective inner call.
-			let refund_fee_on_success = T::CallFeeRefundProviders::refund_fee_on_success(inner_call);
-			if let Some(signer) = origin.as_signer()
-				&& let Some(sponsor) =
-					T::TransactionSponsorProviders::get_transaction_sponsor(signer, inner_call)
-                {
-                    log::debug!("fee sponsor detected: payer={:?}", sponsor.payer);
-                    delegated_origin.set_caller_from_signed(sponsor.payer.clone());
-                    tx_sponsor = Some(sponsor);
-                };
+			// Runtime refund policies are evaluated on the effective call after proxy unwrapping.
+			// Proxy-specific sponsored refunds are carried separately by the sponsor itself.
+			let mut refund_fee_on_success =
+				T::CallFeeRefundProviders::refund_fee_on_success(inner_call);
 
-            let (mut validity, inner_val, origin_out) = self.0.validate(
-                delegated_origin.clone(),
-                call,
-                info,
-                len,
-                self_implicit,
-                inherited_implication,
-                source,
-            )?;
-            if let Some(max_fee_with_tip) = tx_sponsor.as_ref().and_then(|sp| sp.max_fee_with_tip)
-                && let pallet_transaction_payment::Val::<T>::Charge { fee_with_tip, .. } =
-                    &inner_val
-                {
-                    let total_fee: T::Balance = (*fee_with_tip).into();
-                    if total_fee > max_fee_with_tip {
-                        return Err(TransactionValidityError::Invalid(
-                            InvalidTransaction::Custom(INVALID_TX_SPONSORED_FEE_TOO_HIGH),
-                    ));
-                }
-            }
+			if let Some(signer) = origin.as_signer() {
+				let sponsor_for_outer_call =
+					T::TransactionSponsorProviders::get_transaction_sponsor(signer, call);
+				let sponsor = if let Some(sponsor) = sponsor_for_outer_call {
+					Some(sponsor)
+				} else {
+					unwrapped_proxy_call.and_then(|inner_call| {
+						T::TransactionSponsorProviders::get_transaction_sponsor(signer, inner_call)
+					})
+				};
 
-            for key in general_pool_keys {
-                Self::push_pool_key(&mut validity, key);
-            }
+				if let Some(sponsor) = sponsor {
+					log::debug!("fee sponsor detected: payer={:?}", sponsor.payer);
+					refund_fee_on_success |= sponsor.refund_fee_on_success;
+					delegated_origin.set_caller_from_signed(sponsor.payer.clone());
+					tx_sponsor = Some(sponsor);
+				}
+			}
+
+			let (mut validity, inner_val, origin_out) = self.0.validate(
+				delegated_origin.clone(),
+				call,
+				info,
+				len,
+				self_implicit,
+				inherited_implication,
+				source,
+			)?;
+			if let Some(max_fee_with_tip) = tx_sponsor.as_ref().and_then(|sp| sp.max_fee_with_tip)
+				&& let pallet_transaction_payment::Val::<T>::Charge { fee_with_tip, .. } =
+					&inner_val
+			{
+				let total_fee: T::Balance = (*fee_with_tip).into();
+				if total_fee > max_fee_with_tip {
+					return Err(TransactionValidityError::Invalid(
+						InvalidTransaction::Custom(INVALID_TX_SPONSORED_FEE_TOO_HIGH),
+					));
+				}
+			}
+
+			for key in general_pool_keys {
+				Self::push_pool_key(&mut validity, key);
+			}
 			if let Some(key) = tx_sponsor.as_ref().and_then(|sponsor| sponsor.unique_tx_key.clone())
 			{
 				Self::push_pool_key(&mut validity, key);
@@ -464,15 +477,17 @@ where
 				if let (Some(sponsor), Some(from)) = (tx_sponsor, origin.as_signer()) {
 					Pallet::<T>::deposit_event(Event::<T>::FeeDelegated {
 						origin: origin.clone().into_caller(),
-                        from: from.clone(),
-                        to: sponsor.payer
-                    });
-                }
-                Ok(result)
-            },
-            Feeless(origin) => {
-                Pallet::<T>::deposit_event(Event::<T>::FeeSkipped { origin: origin.into_caller() });
-                Ok(Weight::zero())
+						from: from.clone(),
+						to: sponsor.payer,
+					});
+				}
+				Ok(result)
+			},
+			Feeless(origin) => {
+				Pallet::<T>::deposit_event(Event::<T>::FeeSkipped {
+					origin: origin.into_caller(),
+				});
+				Ok(Weight::zero())
 			},
 		}
 	}

--- a/pallets/fee_control/src/mock.rs
+++ b/pallets/fee_control/src/mock.rs
@@ -97,8 +97,12 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::DummyWrapper =>
-				matches!(c, RuntimeCall::DummyPallet(pallet_dummy::Call::sponsored { .. })),
+			ProxyType::DummyWrapper => matches!(
+				c,
+				RuntimeCall::DummyPallet(
+					pallet_dummy::Call::sponsored { .. } | pallet_dummy::Call::pooled { .. }
+				)
+			),
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {
@@ -386,6 +390,21 @@ pub mod pallet_dummy {
 			_signer: &u64,
 			call: &RuntimeCall,
 		) -> Option<TxSponsor<u64, Balance>> {
+			if let RuntimeCall::Proxy(pallet_proxy::Call::proxy {
+				real,
+				force_proxy_type: Some(crate::mock::ProxyType::DummyWrapper),
+				call,
+			}) = call && let RuntimeCall::DummyPallet(pallet_dummy::Call::pooled { key }) =
+				call.as_ref()
+			{
+				return Some(TxSponsor {
+					payer: *real,
+					max_fee_with_tip: Some(5_000),
+					unique_tx_key: Some((b"proxy", key).encode()),
+					refund_fee_on_success: true,
+				});
+			}
+
 			if let RuntimeCall::DummyPallet(
 				pallet_dummy::Call::sponsored { key } |
 				pallet_dummy::Call::sponsored_pooled { key },
@@ -395,6 +414,7 @@ pub mod pallet_dummy {
 					payer: sponsor,
 					max_fee_with_tip: Some(max_fee_with_tip),
 					unique_tx_key: Some(key.encode()),
+					refund_fee_on_success: false,
 				});
 			}
 			None

--- a/pallets/fee_control/src/test.rs
+++ b/pallets/fee_control/src/test.rs
@@ -777,6 +777,64 @@ fn delegation_changes_fee_payer_seen_by_payment_ext_with_proxy() {
 	});
 }
 
+#[test]
+fn delegation_refunds_fees_for_proxy_specific_sponsors() {
+	new_test_ext().execute_with(|| {
+		LastPayer::set(None);
+		LastPostDispatchPaysFee::set(None);
+
+		let real = 7u64;
+		let delegate = 1u64;
+		let key = 33u32;
+		let sponsor_balance: Balance = 2_000_000u128;
+
+		assert_eq!(Balances::free_balance(delegate), 0u128);
+		set_argons(real, sponsor_balance);
+		assert_ok!(Proxy::add_proxy(Some(real).into(), delegate, ProxyType::DummyWrapper, 0,));
+
+		let call = RuntimeCall::Proxy(pallet_proxy::Call::<Test>::proxy {
+			real,
+			force_proxy_type: Some(ProxyType::DummyWrapper),
+			call: Box::new(RuntimeCall::DummyPallet(Call::<Test>::pooled { key })),
+		});
+		let info = call.get_dispatch_info();
+		let len = call.encoded_size();
+		let origin = crate::mock::RuntimeOrigin::signed(delegate);
+		let wrapper =
+			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension);
+		let (_, val, _) = wrapper
+			.validate_only(origin.clone(), &call, &info, len, TransactionSource::External, 0)
+			.unwrap();
+		let pre =
+			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension)
+				.prepare(val, &origin, &call, &info, len)
+				.unwrap();
+
+		let dispatch_result = call.dispatch(origin);
+		let dispatch_outcome = match &dispatch_result {
+			Ok(_) => Ok(()),
+			Err(err) => Err(err.error.clone()),
+		};
+		let post_info = match &dispatch_result {
+			Ok(post_info) => post_info,
+			Err(err) => &err.post_info,
+		};
+
+		CheckFeeWrapper::<Test, MockChargePaymentExtension>::post_dispatch_details(
+			pre,
+			&info,
+			post_info,
+			len,
+			&dispatch_outcome,
+		)
+		.unwrap();
+
+		assert!(dispatch_outcome.is_ok());
+		assert_eq!(LastPayer::get(), Some(real));
+		assert_eq!(LastPostDispatchPaysFee::get(), Some(Pays::No));
+	});
+}
+
 fn set_argons(account_id: u64, amount: Balance) {
 	let _ = Balances::make_free_balance_be(&account_id, amount);
 	drop(Balances::issue(amount));

--- a/primitives/src/providers.rs
+++ b/primitives/src/providers.rs
@@ -1305,6 +1305,8 @@ pub struct TxSponsor<AccountId, Balance> {
 	/// A unique key to identify this sponsored transaction in the tx pool to prevent dos
 	/// attacks
 	pub unique_tx_key: Option<Vec<u8>>,
+	/// Whether the charged fee should be refunded when the transaction succeeds.
+	pub refund_fee_on_success: bool,
 }
 
 /// A configurable hook that can recognize calls where one account should reimburse another

--- a/runtime/common/src/deal_with_fees.rs
+++ b/runtime/common/src/deal_with_fees.rs
@@ -119,6 +119,7 @@ macro_rules! deal_with_fees {
 								.using_encoded(sp_crypto_hashing::blake2_256)
 								.to_vec(),
 						),
+						refund_fee_on_success: true,
 					});
 				}
 				None


### PR DESCRIPTION
## Summary

`miningbidrefundsfee` was not refunding sponsored fees correctly for the mining bid proxy flow.

This changes `CheckFeeWrapper` so runtime refund policy is evaluated against the effective inner call after proxy unwrapping, and lets transaction sponsors explicitly opt into refunding fees on successful dispatch.

The runtime mining bid sponsor now marks that path as refund-on-success, which restores the expected behavior for sponsored mining bid proxy calls without broadening refund behavior for unrelated calls.
