### PR TITLE
fix(nodejs): don’t blow up if a block number can’t be looked up

### DIFF
--- a/client/nodejs/src/TxResult.ts
+++ b/client/nodejs/src/TxResult.ts
@@ -1,4 +1,4 @@
-import { ArgonClient, GenericEvent, SpRuntimeDispatchError } from './index';
+import { ArgonClient, GenericEvent, SpRuntimeDispatchError, u8aEq } from './index';
 import {
   dispatchErrorToExtrinsicError,
   ExtrinsicError,
@@ -10,9 +10,19 @@ import { DispatchError } from '@polkadot/types/interfaces';
 
 export type ITxProgressCallback = (progressToInBlock: number, result?: TxResult) => void;
 
+type IBlockInclusion = {
+  blockHash: Uint8Array;
+  blockNumber?: number;
+  extrinsicIndex: number;
+  events: GenericEvent[];
+};
+
+type IPendingInBlock = Omit<IBlockInclusion, 'blockNumber'>;
+
 export class TxResult {
   #isBroadcast = false;
   #submissionError?: Error;
+  #pendingInBlock?: IPendingInBlock;
 
   set isBroadcast(value: boolean) {
     this.#isBroadcast = value;
@@ -91,30 +101,55 @@ export class TxResult {
     this.waitForInFirstBlock.catch(() => null);
   }
 
-  public async setSeenInBlock(block: {
-    blockHash: Uint8Array;
-    blockNumber?: number;
-    extrinsicIndex: number;
-    events: GenericEvent[];
-  }): Promise<void> {
-    const { blockHash, blockNumber, events } = block;
-    if (blockHash !== this.blockHash) {
-      this.parseEvents(events);
-      this.blockHash = blockHash;
-      this.blockNumber =
-        blockNumber ??
-        (await this.client.rpc.chain.getHeader(blockHash).then(h => h.number.toNumber()));
-      this.extrinsicIndex = block.extrinsicIndex;
-      this.updateProgress();
-      if (this.extrinsicError) {
-        this.inBlockReject(this.extrinsicError);
-      } else {
-        this.inBlockResolve(blockHash);
-      }
+  public async setSeenInBlock(block: IBlockInclusion): Promise<void> {
+    if (block.blockNumber === undefined) {
+      this.#pendingInBlock = {
+        blockHash: block.blockHash,
+        extrinsicIndex: block.extrinsicIndex,
+        events: block.events,
+      };
+      return;
+    }
+
+    if (
+      this.blockHash &&
+      this.blockNumber === block.blockNumber &&
+      this.extrinsicIndex === block.extrinsicIndex &&
+      u8aEq(this.blockHash, block.blockHash)
+    ) {
+      this.#pendingInBlock = undefined;
+      return;
+    }
+
+    this.#pendingInBlock = undefined;
+    this.parseEvents(block.events);
+    this.blockHash = block.blockHash;
+    this.blockNumber = block.blockNumber;
+    this.extrinsicIndex = block.extrinsicIndex;
+    this.updateProgress();
+    if (this.extrinsicError) {
+      this.inBlockReject(this.extrinsicError);
+    } else {
+      this.inBlockResolve(block.blockHash);
     }
   }
 
-  public setFinalized() {
+  public async setFinalized() {
+    const pendingInBlock = this.#pendingInBlock;
+    if (pendingInBlock) {
+      await this.publishSeenInBlock(pendingInBlock);
+    } else if (this.blockHash && this.blockNumber === undefined) {
+      if (this.extrinsicIndex === undefined) {
+        throw new Error('Cannot finalize transaction before extrinsic index is known');
+      }
+
+      await this.publishSeenInBlock({
+        blockHash: this.blockHash,
+        extrinsicIndex: this.extrinsicIndex,
+        events: this.events,
+      });
+    }
+
     this.isFinalized = true;
     this.updateProgress();
 
@@ -141,33 +176,87 @@ export class TxResult {
       if (result.internalError) this.submissionError = result.internalError;
     }
     if (status.isInBlock) {
-      void this.setSeenInBlock({
-        blockHash: Uint8Array.from(status.asInBlock),
-        events: extrinsicEvents,
-        extrinsicIndex: txIndex!,
-      });
+      try {
+        const pendingInBlock = createPendingInBlock(
+          Uint8Array.from(status.asInBlock),
+          txIndex,
+          extrinsicEvents,
+        );
+        this.#pendingInBlock = pendingInBlock;
+
+        void this.publishSeenInBlock(pendingInBlock).catch(error => {
+          if (!isMissingBlockHeaderError(error)) {
+            this.submissionError = error as Error;
+          }
+        });
+      } catch (error) {
+        this.submissionError = error as Error;
+      }
     }
     if (status.isUsurped) {
+      this.#pendingInBlock = undefined;
       this.submissionError = new TxSubmissionError(
         TxSubmissionErrorCode.Usurped,
         `Transaction was usurped by ${status.asUsurped.toHex()}.`,
       );
     }
     if (status.isDropped) {
+      this.#pendingInBlock = undefined;
       this.submissionError = new TxSubmissionError(
         TxSubmissionErrorCode.Dropped,
         'Transaction was dropped before it was included in a block.',
       );
     }
     if (status.isInvalid) {
+      this.#pendingInBlock = undefined;
       this.submissionError = new TxSubmissionError(
         TxSubmissionErrorCode.Invalid,
         'Transaction was rejected as invalid by the node.',
       );
     }
     if (isFinalized) {
-      this.setFinalized();
+      try {
+        this.#pendingInBlock = createPendingInBlock(
+          Uint8Array.from(status.asFinalized),
+          txIndex ?? this.#pendingInBlock?.extrinsicIndex ?? this.extrinsicIndex,
+          extrinsicEvents.length ? extrinsicEvents : this.events,
+        );
+      } catch (error) {
+        this.submissionError = error as Error;
+        return;
+      }
+
+      void this.setFinalized().catch(error => {
+        this.submissionError = error as Error;
+      });
     }
+  }
+
+  private async publishSeenInBlock(block: IPendingInBlock) {
+    const pendingInBlock = this.#pendingInBlock;
+    if (
+      !pendingInBlock ||
+      pendingInBlock.extrinsicIndex !== block.extrinsicIndex ||
+      !u8aEq(pendingInBlock.blockHash, block.blockHash)
+    ) {
+      return;
+    }
+
+    const blockNumber = await this.client.rpc.chain.getHeader(block.blockHash).then(h => h.number.toNumber());
+
+    const currentPendingInBlock = this.#pendingInBlock;
+    if (
+      !currentPendingInBlock ||
+      currentPendingInBlock.extrinsicIndex !== block.extrinsicIndex ||
+      !u8aEq(currentPendingInBlock.blockHash, block.blockHash)
+    ) {
+      return;
+    }
+
+    await this.setSeenInBlock({
+      ...block,
+      blockNumber,
+    });
   }
 
   private updateProgress() {
@@ -215,4 +304,24 @@ export class TxResult {
     }
     this.events = events;
   }
+}
+
+function createPendingInBlock(
+  blockHash: Uint8Array,
+  extrinsicIndex: number | undefined,
+  events: GenericEvent[],
+): IPendingInBlock {
+  if (extrinsicIndex === undefined) {
+    throw new Error('Cannot publish transaction block state before extrinsic index is known');
+  }
+
+  return {
+    blockHash,
+    extrinsicIndex,
+    events,
+  };
+}
+
+function isMissingBlockHeaderError(error: unknown) {
+  return String(error).includes('Unable to retrieve header and parent from supplied hash');
 }

--- a/client/nodejs/src/__test__/TxResult.test.ts
+++ b/client/nodejs/src/__test__/TxResult.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { u8aEq } from '@polkadot/util';
+import { describe, expect, it, vi } from 'vitest';
 import { TxResult } from '../TxResult';
 import { TxSubmissionErrorCode } from '../utils';
 
@@ -55,10 +56,160 @@ describe('TxResult', () => {
       message: expect.stringContaining('0xreplacement'),
     });
   });
+
+  it('waits to publish in-block until it can resolve a real finalized block', async () => {
+    const getHeader = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Unable to retrieve header and parent from supplied hash'))
+      .mockResolvedValue({
+        number: {
+          toNumber: () => 145,
+        },
+      });
+    const result = createTxResult({
+      rpc: {
+        chain: {
+          getHeader,
+        },
+      },
+    } as any);
+
+    let inBlockHash: Uint8Array | undefined;
+    void result.waitForInFirstBlock.then(hash => {
+      inBlockHash = hash;
+    });
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: true,
+        asInBlock: Uint8Array.from([1, 2, 3]),
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await Promise.resolve();
+
+    expect(getHeader).toHaveBeenCalledTimes(1);
+    expect(inBlockHash).toBeUndefined();
+    expect(result.blockHash).toBeUndefined();
+    expect(result.blockNumber).toBeUndefined();
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: true,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isFinalized: true,
+        asFinalized: Uint8Array.from([4, 5, 6]),
+        isInBlock: false,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await expect(result.waitForInFirstBlock).resolves.toEqual(Uint8Array.from([4, 5, 6]));
+    await expect(result.waitForFinalizedBlock).resolves.toEqual(Uint8Array.from([4, 5, 6]));
+    expect(result.blockHash).toEqual(Uint8Array.from([4, 5, 6]));
+    expect(result.blockNumber).toBe(145);
+    expect(result.extrinsicIndex).toBe(4);
+  });
+
+  it('ignores a stale in-block lookup after finalized wins', async () => {
+    const inBlockHash = Uint8Array.from([1, 2, 3]);
+    const finalizedHash = Uint8Array.from([4, 5, 6]);
+    let resolveInBlockHeader!: (value: unknown) => void;
+    let resolveFinalizedHeader!: (value: unknown) => void;
+    const getHeader = vi.fn().mockImplementation((hash: Uint8Array) => {
+      if (u8aEq(hash, inBlockHash)) {
+        return new Promise(resolve => {
+          resolveInBlockHeader = resolve;
+        });
+      }
+
+      if (u8aEq(hash, finalizedHash)) {
+        return new Promise(resolve => {
+          resolveFinalizedHeader = resolve;
+        });
+      }
+
+      throw new Error('Unexpected hash');
+    });
+    const result = createTxResult({
+      rpc: {
+        chain: {
+          getHeader,
+        },
+      },
+    } as any);
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: true,
+        asInBlock: inBlockHash,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await Promise.resolve();
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: true,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isFinalized: true,
+        asFinalized: finalizedHash,
+        isInBlock: false,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await Promise.resolve();
+
+    resolveFinalizedHeader({
+      number: {
+        toNumber: () => 145,
+      },
+    });
+
+    await expect(result.waitForInFirstBlock).resolves.toEqual(finalizedHash);
+    await expect(result.waitForFinalizedBlock).resolves.toEqual(finalizedHash);
+    expect(result.blockHash).toEqual(finalizedHash);
+    expect(result.blockNumber).toBe(145);
+
+    resolveInBlockHeader({
+      number: {
+        toNumber: () => 144,
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(result.blockHash).toEqual(finalizedHash);
+    expect(result.blockNumber).toBe(145);
+  });
 });
 
-function createTxResult(): TxResult {
-  return new TxResult({} as any, {
+function createTxResult(client: Partial<ConstructorParameters<typeof TxResult>[0]> = {}): TxResult {
+  return new TxResult(client as any, {
     signedHash: '0xtx',
     method: {},
     accountAddress: '5Submitter',


### PR DESCRIPTION
The tx result class can explode if the chain re-orgs. This catches those errors.