### PR TITLE
Require operational upgrades for invite-only vault and mining entry

### DIFF
--- a/pallets/mining_slot/src/lib.rs
+++ b/pallets/mining_slot/src/lib.rs
@@ -357,7 +357,7 @@ pub mod pallet {
 		BidCannotBeReduced,
 		/// Bids must be in allowed increments
 		InvalidBidAmount,
-		/// Mining slot bidding currently requires prior operational-account registration.
+		/// Mining slot bidding currently requires a prior operational-account upgrade.
 		OperationalAccountRegistrationRequired,
 		/// The argonots on hold cannot be released
 		UnrecoverableHold,

--- a/pallets/mining_slot/src/mock.rs
+++ b/pallets/mining_slot/src/mock.rs
@@ -108,7 +108,7 @@ parameter_types! {
 	pub static GrandaRotations: Vec<FrameId> = vec![];
 	pub static MiningSeatsWon: Vec<u64> = vec![];
 	pub static OperationalAccountsInviteOnly: bool = false;
-	pub static RegisteredOperationalAccounts: BTreeSet<u64> = BTreeSet::new();
+	pub static UpgradedOperationalAccounts: BTreeSet<u64> = BTreeSet::new();
 
 	// set slot bidding active by default
 	pub static ElapsedTicks: u64 = 3;
@@ -182,7 +182,7 @@ impl OperationalAccountProvider<u64> for MockOperationalAccountProvider {
 
 	fn is_eligible(account_id: &u64) -> bool {
 		!OperationalAccountsInviteOnly::get() ||
-			RegisteredOperationalAccounts::get().contains(account_id)
+			UpgradedOperationalAccounts::get().contains(account_id)
 	}
 }
 
@@ -321,7 +321,7 @@ impl pallet_mining_slot::Config for Test {
 pub fn new_test_ext() -> TestState {
 	AverageMicrogonsPerArgonotByFrame::set(BTreeMap::new());
 	OperationalAccountsInviteOnly::set(false);
-	RegisteredOperationalAccounts::set(BTreeSet::new());
+	UpgradedOperationalAccounts::set(BTreeSet::new());
 	new_test_with_genesis::<Test>(|t: &mut Storage| {
 		let mining_config = MiningSlotConfig {
 			slot_bidding_start_after_ticks: SlotBiddingStartAfterTicks::get(),

--- a/pallets/mining_slot/src/tests.rs
+++ b/pallets/mining_slot/src/tests.rs
@@ -513,7 +513,7 @@ fn it_holds_ownership_tokens_for_a_slot() {
 }
 
 #[test]
-fn it_requires_operational_account_registration_when_invite_only() {
+fn it_requires_operational_account_upgrade_when_invite_only() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 		OperationalAccountsInviteOnly::set(true);
@@ -526,7 +526,7 @@ fn it_requires_operational_account_registration_when_invite_only() {
 			Error::<Test>::OperationalAccountRegistrationRequired
 		);
 
-		RegisteredOperationalAccounts::mutate(|accounts| {
+		UpgradedOperationalAccounts::mutate(|accounts| {
 			accounts.insert(1);
 		});
 		assert_ok!(MiningSlots::bid(RuntimeOrigin::signed(1), 0, 1.into(), None));

--- a/pallets/operational_accounts/src/lib.rs
+++ b/pallets/operational_accounts/src/lib.rs
@@ -1256,9 +1256,17 @@ pub mod pallet {
 		type Weights = weights::ProviderWeightAdapter<T>;
 
 		fn is_eligible(account_id: &T::AccountId) -> bool {
-			!IsOperationalAccountInviteOnly::<T>::get() ||
-				OperationalAccounts::<T>::contains_key(account_id) ||
-				OperationalAccountBySubAccount::<T>::contains_key(account_id)
+			if !IsOperationalAccountInviteOnly::<T>::get() {
+				return true;
+			}
+
+			let Some(owner) = Self::operational_owner_for(account_id) else {
+				return false;
+			};
+
+			OperationalAccounts::<T>::get(owner)
+				.map(|account| account.is_upgraded_to_operations)
+				.unwrap_or(false)
 		}
 	}
 }

--- a/pallets/operational_accounts/src/tests.rs
+++ b/pallets/operational_accounts/src/tests.rs
@@ -5,7 +5,10 @@ use crate::{
 	RegistrationV1, MINING_ACCOUNT_PROOF_MESSAGE_KEY, OPERATIONAL_ACCOUNT_PROOF_MESSAGE_KEY,
 	VAULT_ACCOUNT_PROOF_MESSAGE_KEY,
 };
-use argon_primitives::{OperationalAccountsHook, Signature, UtxoLockEvents, MICROGONS_PER_ARGON};
+use argon_primitives::{
+	OperationalAccountProvider, OperationalAccountsHook, Signature, UtxoLockEvents,
+	MICROGONS_PER_ARGON,
+};
 use frame_support::{assert_noop, assert_ok};
 use pallet_prelude::*;
 use sp_core::{sr25519, Pair};
@@ -82,6 +85,39 @@ fn test_register_allows_referrer_when_invite_only() {
 		let recruit_account =
 			OperationalAccounts::<Test>::get(&recruit_set.owner).expect("recruit account");
 		assert_eq!(recruit_account.referrer, Some(referrer_set.owner));
+	});
+}
+
+#[test]
+fn test_invite_only_eligibility_requires_operational_upgrade() {
+	new_test_ext().execute_with(|| {
+		let account_set = make_account_set(17, 18, 19);
+		register_account(&account_set, None);
+		IsOperationalAccountInviteOnly::<Test>::put(true);
+
+		assert!(
+			!<OperationalAccountsPallet as OperationalAccountProvider<TestAccountId>>::is_eligible(
+				&account_set.owner,
+			)
+		);
+		assert!(
+			!<OperationalAccountsPallet as OperationalAccountProvider<TestAccountId>>::is_eligible(
+				&account_set.vault,
+			)
+		);
+
+		mark_upgraded_to_operational(&account_set.owner);
+
+		assert!(
+			<OperationalAccountsPallet as OperationalAccountProvider<TestAccountId>>::is_eligible(
+				&account_set.owner,
+			)
+		);
+		assert!(
+			<OperationalAccountsPallet as OperationalAccountProvider<TestAccountId>>::is_eligible(
+				&account_set.vault,
+			)
+		);
 	});
 }
 

--- a/pallets/vaults/src/lib.rs
+++ b/pallets/vaults/src/lib.rs
@@ -134,8 +134,8 @@ pub mod pallet {
 
 		/// Hook to notify operational accounts about vault lifecycle events.
 		type OperationalAccountsHook: OperationalAccountsHook<Self::AccountId, Self::Balance>;
-		/// Provider for whether restricted vault creation requires operational-account
-		/// registration.
+		/// Provider for whether restricted vault creation requires an upgraded
+		/// operational account.
 		type OperationalAccountProvider: OperationalAccountProvider<Self::AccountId>;
 		/// External collect blockers that must be cleared before revenue can be collected.
 		type CollectBlockerProvider: CollectBlockerProvider<Self::AccountId>;
@@ -400,7 +400,7 @@ pub mod pallet {
 		OverdueCollectBlockersBeforeCollect,
 		/// An account may only be associated with a single vault
 		AccountAlreadyHasVault,
-		/// Vault creation currently requires prior operational-account registration.
+		/// Vault creation currently requires a prior operational-account upgrade.
 		OperationalAccountRegistrationRequired,
 		/// Committed Argonots cannot be reduced below the amount already crosschain-encumbered.
 		CommittedArgonotsBelowEncumberedBacking,

--- a/pallets/vaults/src/mock.rs
+++ b/pallets/vaults/src/mock.rs
@@ -106,7 +106,7 @@ parameter_types! {
 	pub static PercentForTreasuryReserves: Percent = Percent::from_percent(20);
 	pub static OverdueCollectBlockers: BTreeSet<u64> = BTreeSet::new();
 	pub static OperationalAccountsInviteOnly: bool = false;
-	pub static RegisteredOperationalAccounts: BTreeSet<u64> = BTreeSet::new();
+	pub static UpgradedOperationalAccounts: BTreeSet<u64> = BTreeSet::new();
 
 }
 pub struct StaticMiningFrameProvider;
@@ -176,7 +176,7 @@ impl OperationalAccountProvider<u64> for MockOperationalAccountProvider {
 
 	fn is_eligible(account_id: &u64) -> bool {
 		!OperationalAccountsInviteOnly::get() ||
-			RegisteredOperationalAccounts::get().contains(account_id)
+			UpgradedOperationalAccounts::get().contains(account_id)
 	}
 }
 
@@ -368,6 +368,6 @@ impl pallet_bitcoin_locks::Config for Test {
 pub fn new_test_ext() -> TestState {
 	OverdueCollectBlockers::set(BTreeSet::new());
 	OperationalAccountsInviteOnly::set(false);
-	RegisteredOperationalAccounts::set(BTreeSet::new());
+	UpgradedOperationalAccounts::set(BTreeSet::new());
 	new_test_with_genesis::<Test>(|_t| {})
 }

--- a/pallets/vaults/src/tests.rs
+++ b/pallets/vaults/src/tests.rs
@@ -116,7 +116,7 @@ fn it_can_create_a_vault() {
 }
 
 #[test]
-fn it_requires_operational_account_registration_when_invite_only() {
+fn it_requires_operational_account_upgrade_when_invite_only() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 		OperationalAccountsInviteOnly::set(true);
@@ -127,7 +127,7 @@ fn it_requires_operational_account_registration_when_invite_only() {
 			Error::<Test>::OperationalAccountRegistrationRequired
 		);
 
-		RegisteredOperationalAccounts::mutate(|accounts| {
+		UpgradedOperationalAccounts::mutate(|accounts| {
 			accounts.insert(1);
 		});
 		assert_ok!(Vaults::create(RuntimeOrigin::signed(1), default_vault()));


### PR DESCRIPTION
When operational-account gating is enabled, vault creation and mining bids should stay blocked until the account has actually been upgraded to operations.

This updates the shared eligibility check so registered-but-not-upgraded accounts no longer pass the gate, while unrestricted environments keep the existing behavior.