### PR TITLE
fix: allow force_set_progress to mark operational accounts upgraded

### DIFF
--- a/client/nodejs/src/interfaces/augment-api-tx.ts
+++ b/client/nodejs/src/interfaces/augment-api-tx.ts
@@ -1157,6 +1157,7 @@ declare module '@polkadot/api-base/types/submittable' {
                 accountBitcoinAmount?: any;
                 accountVaultBondAmount?: any;
                 vaultCreated?: any;
+                isUpgradedToOperations?: any;
                 vaultBitcoinAmount?: any;
                 miningSeatCount?: any;
               }

--- a/client/nodejs/src/interfaces/lookup.ts
+++ b/client/nodejs/src/interfaces/lookup.ts
@@ -2758,6 +2758,7 @@ export default {
     accountBitcoinAmount: 'Option<u128>',
     accountVaultBondAmount: 'Option<u128>',
     vaultCreated: 'Option<bool>',
+    isUpgradedToOperations: 'Option<bool>',
     vaultBitcoinAmount: 'Option<u128>',
     miningSeatCount: 'Option<u32>',
   },

--- a/client/nodejs/src/interfaces/types-lookup.ts
+++ b/client/nodejs/src/interfaces/types-lookup.ts
@@ -3265,6 +3265,7 @@ declare module '@polkadot/types/lookup' {
     readonly accountBitcoinAmount: Option<u128>;
     readonly accountVaultBondAmount: Option<u128>;
     readonly vaultCreated: Option<bool>;
+    readonly isUpgradedToOperations: Option<bool>;
     readonly vaultBitcoinAmount: Option<u128>;
     readonly miningSeatCount: Option<u32>;
   }

--- a/pallets/operational_accounts/src/benchmarking.rs
+++ b/pallets/operational_accounts/src/benchmarking.rs
@@ -423,6 +423,7 @@ mod benchmarks {
 			account_bitcoin_amount: Some(T::TreasuryMinimumBitcoin::get()),
 			account_vault_bond_amount: Some(T::TreasuryMinimumBonds::get()),
 			vault_created: Some(true),
+			is_upgraded_to_operations: Some(true),
 			vault_bitcoin_amount: Some(T::TreasuryMinimumBitcoin::get()),
 			mining_seat_count: Some(T::MiningSeatsForOperational::get()),
 		};
@@ -434,6 +435,7 @@ mod benchmarks {
 
 		let account = OperationalAccounts::<T>::get(&linked.owner).expect("account exists");
 		assert!(account.is_treasury_certified);
+		assert!(account.is_upgraded_to_operations);
 		assert!(!account.is_operationally_certified);
 	}
 

--- a/pallets/operational_accounts/src/lib.rs
+++ b/pallets/operational_accounts/src/lib.rs
@@ -297,6 +297,8 @@ pub mod pallet {
 		pub account_vault_bond_amount: Option<Balance>,
 		/// Override for whether the vault has been created.
 		pub vault_created: Option<bool>,
+		/// Override for whether the account has been upgraded to operations.
+		pub is_upgraded_to_operations: Option<bool>,
 		/// Requested minimum for the operator vault bitcoin amount.
 		///
 		/// This is treated as a monotonic applied-total override: the effective stored
@@ -319,6 +321,7 @@ pub mod pallet {
 				self.account_bitcoin_amount.is_some() ||
 				self.account_vault_bond_amount.is_some() ||
 				self.vault_created.is_some() ||
+				self.is_upgraded_to_operations.is_some() ||
 				self.vault_bitcoin_amount.is_some() ||
 				self.mining_seat_count.is_some()
 		}
@@ -740,6 +743,13 @@ pub mod pallet {
 					}
 					if let Some(value) = patch.vault_created {
 						account.vault_created = value;
+					}
+					if let Some(value) = patch.is_upgraded_to_operations {
+						ensure!(
+							value || !account.is_operationally_certified,
+							Error::<T>::AlreadyOperational
+						);
+						account.is_upgraded_to_operations = value;
 					}
 					if let Some(value) = patch.vault_bitcoin_amount {
 						Self::recalculate_vault_bitcoin_accrual(account, value);

--- a/pallets/operational_accounts/src/tests.rs
+++ b/pallets/operational_accounts/src/tests.rs
@@ -390,6 +390,7 @@ fn test_force_set_progress_guardrails() {
 					account_bitcoin_amount: None,
 					account_vault_bond_amount: None,
 					vault_created: None,
+					is_upgraded_to_operations: None,
 					vault_bitcoin_amount: None,
 					mining_seat_count: None,
 				},
@@ -422,6 +423,7 @@ fn test_force_set_progress_applies_patch_and_reconciles_totals() {
 				account_bitcoin_amount: Some(TreasuryMinimumBitcoin::get()),
 				account_vault_bond_amount: Some(TreasuryMinimumBonds::get()),
 				vault_created: Some(true),
+				is_upgraded_to_operations: Some(true),
 				vault_bitcoin_amount: Some(BitcoinLockSizeForUpgradeCode::get()),
 				mining_seat_count: Some(2),
 			},
@@ -436,8 +438,65 @@ fn test_force_set_progress_applies_patch_and_reconciles_totals() {
 		);
 		assert_eq!(account.account_bitcoin_amount, TreasuryMinimumBitcoin::get());
 		assert_eq!(account.account_vault_bond_amount, TreasuryMinimumBonds::get());
+		assert!(account.is_upgraded_to_operations);
 		assert_eq!(current_vault_bitcoin_amount(&account), BitcoinLockSizeForUpgradeCode::get(),);
 		assert_eq!(mining_seat_count(&account), 2);
+
+		assert_ok!(OperationalAccountsPallet::force_set_progress(
+			RuntimeOrigin::root(),
+			account_set.owner.clone(),
+			OperationalProgressPatch {
+				uniswap_argon_transfers_in_amount: None,
+				account_bitcoin_amount: None,
+				account_vault_bond_amount: None,
+				vault_created: None,
+				is_upgraded_to_operations: Some(false),
+				vault_bitcoin_amount: None,
+				mining_seat_count: None,
+			},
+			false,
+		));
+		assert!(
+			!OperationalAccounts::<Test>::get(&account_set.owner)
+				.expect("account")
+				.is_upgraded_to_operations
+		);
+
+		assert_ok!(OperationalAccountsPallet::force_set_progress(
+			RuntimeOrigin::root(),
+			account_set.owner.clone(),
+			OperationalProgressPatch {
+				uniswap_argon_transfers_in_amount: None,
+				account_bitcoin_amount: None,
+				account_vault_bond_amount: None,
+				vault_created: None,
+				is_upgraded_to_operations: Some(true),
+				vault_bitcoin_amount: None,
+				mining_seat_count: None,
+			},
+			false,
+		));
+		assert_ok!(OperationalAccountsPallet::activate(RuntimeOrigin::signed(
+			account_set.owner.clone(),
+		)));
+
+		assert_noop!(
+			OperationalAccountsPallet::force_set_progress(
+				RuntimeOrigin::root(),
+				account_set.owner.clone(),
+				OperationalProgressPatch {
+					uniswap_argon_transfers_in_amount: None,
+					account_bitcoin_amount: None,
+					account_vault_bond_amount: None,
+					vault_created: None,
+					is_upgraded_to_operations: Some(false),
+					vault_bitcoin_amount: None,
+					mining_seat_count: None,
+				},
+				false,
+			),
+			Error::<Test>::AlreadyOperational
+		);
 	});
 }
 


### PR DESCRIPTION
## Summary

Allow force_set_progress to explicitly mark an operational account as upgraded.

This gives test and admin repair flows a direct way to move an account forward when it should already count as upgraded, without using the normal sponsored upgrade flow.
