### PR TITLE
Fix mining bid proxy fee sponsorship

### DIFF
--- a/pallets/fee_control/src/check_fee_wrapper.rs
+++ b/pallets/fee_control/src/check_fee_wrapper.rs
@@ -364,8 +364,7 @@ where
 			let mut delegated_origin = origin.clone();
 			let mut tx_sponsor = None;
 			// Runtime refund policies are evaluated on the effective call after proxy unwrapping.
-			// Proxy-specific sponsored refunds are carried separately by the sponsor itself.
-			let mut refund_fee_on_success =
+			let refund_fee_on_success =
 				T::CallFeeRefundProviders::refund_fee_on_success(inner_call);
 
 			if let Some(signer) = origin.as_signer() {
@@ -381,13 +380,12 @@ where
 
 				if let Some(sponsor) = sponsor {
 					log::debug!("fee sponsor detected: payer={:?}", sponsor.payer);
-					refund_fee_on_success |= sponsor.refund_fee_on_success;
 					delegated_origin.set_caller_from_signed(sponsor.payer.clone());
 					tx_sponsor = Some(sponsor);
 				}
 			}
 
-			let (mut validity, inner_val, origin_out) = self.0.validate(
+			let (mut validity, inner_val, _) = self.0.validate(
 				delegated_origin.clone(),
 				call,
 				info,
@@ -424,7 +422,7 @@ where
 					tx_sponsor,
 					refund_fee_on_success,
 				},
-				origin_out,
+				origin,
 			))
 		}
 	}

--- a/pallets/fee_control/src/mock.rs
+++ b/pallets/fee_control/src/mock.rs
@@ -97,12 +97,27 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::DummyWrapper => matches!(
-				c,
+			ProxyType::DummyWrapper => match c {
 				RuntimeCall::DummyPallet(
-					pallet_dummy::Call::sponsored { .. } | pallet_dummy::Call::pooled { .. }
-				)
-			),
+					pallet_dummy::Call::sponsored { .. } |
+					pallet_dummy::Call::pooled { .. } |
+					pallet_dummy::Call::pooled_fail { .. },
+				) => true,
+				RuntimeCall::Utility(
+					pallet_utility::Call::batch { calls } |
+					pallet_utility::Call::batch_all { calls } |
+					pallet_utility::Call::force_batch { calls },
+				) => calls.iter().all(|call| {
+					matches!(
+						call,
+						RuntimeCall::DummyPallet(
+							pallet_dummy::Call::pooled { .. } |
+								pallet_dummy::Call::pooled_fail { .. }
+						)
+					)
+				}),
+				_ => false,
+			},
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {
@@ -296,6 +311,9 @@ pub mod pallet_dummy {
 	#[pallet::storage]
 	pub type ConsumedPoolKeys<T> = StorageMap<_, Blake2_128Concat, u32, (), OptionQuery>;
 
+	#[pallet::storage]
+	pub type DispatchedPoolKeys<T> = StorageMap<_, Blake2_128Concat, u32, (), OptionQuery>;
+
 	#[pallet::config]
 	pub trait Config: polkadot_sdk::frame_system::Config {}
 
@@ -328,7 +346,13 @@ pub mod pallet_dummy {
 
 		pub fn pooled(_origin: OriginFor<T>, _key: u32) -> DispatchResult {
 			let _who = ensure_signed(_origin)?;
+			DispatchedPoolKeys::<T>::insert(_key, ());
 			Ok(())
+		}
+
+		pub fn pooled_fail(_origin: OriginFor<T>, _key: u32) -> DispatchResult {
+			let _who = ensure_signed(_origin)?;
+			Err(DispatchError::Other("pooled failed"))
 		}
 
 		pub fn sponsored_pooled(_origin: OriginFor<T>, _key: u32) -> DispatchResult {
@@ -359,6 +383,8 @@ pub mod pallet_dummy {
 			match call {
 				RuntimeCall::DummyPallet(pallet_dummy::Call::pooled { key }) =>
 					Some((b"general", key).encode()),
+				RuntimeCall::DummyPallet(pallet_dummy::Call::pooled_fail { key }) =>
+					Some((b"general", key).encode()),
 				RuntimeCall::DummyPallet(pallet_dummy::Call::stacked { key }) =>
 					Some((b"general", key).encode()),
 				RuntimeCall::DummyPallet(pallet_dummy::Call::stacked_operational { key }) =>
@@ -377,6 +403,7 @@ pub mod pallet_dummy {
 			match call {
 				RuntimeCall::DummyPallet(
 					pallet_dummy::Call::pooled { key } |
+					pallet_dummy::Call::pooled_fail { key } |
 					pallet_dummy::Call::sponsored_pooled { key } |
 					pallet_dummy::Call::stacked { key },
 				) if ConsumedPoolKeys::<T>::contains_key(key) =>
@@ -385,24 +412,60 @@ pub mod pallet_dummy {
 			}
 		}
 	}
-	impl<T: Config> TransactionSponsorProvider<u64, RuntimeCall, Balance> for Pallet<T> {
+	impl<T> TransactionSponsorProvider<u64, RuntimeCall, Balance> for Pallet<T>
+	where
+		T: Config
+			+ pallet_proxy::Config<
+				AccountId = u64,
+				RuntimeCall = RuntimeCall,
+				ProxyType = crate::mock::ProxyType,
+			>,
+	{
 		fn get_transaction_sponsor(
-			_signer: &u64,
+			signer: &u64,
 			call: &RuntimeCall,
 		) -> Option<TxSponsor<u64, Balance>> {
-			if let RuntimeCall::Proxy(pallet_proxy::Call::proxy {
-				real,
-				force_proxy_type: Some(crate::mock::ProxyType::DummyWrapper),
-				call,
-			}) = call && let RuntimeCall::DummyPallet(pallet_dummy::Call::pooled { key }) =
-				call.as_ref()
+			if let RuntimeCall::Proxy(pallet_proxy::Call::proxy { real, force_proxy_type, call }) =
+				call
 			{
-				return Some(TxSponsor {
-					payer: *real,
-					max_fee_with_tip: Some(5_000),
-					unique_tx_key: Some((b"proxy", key).encode()),
-					refund_fee_on_success: true,
-				});
+				let Ok(def) =
+					pallet_proxy::Pallet::<T>::find_proxy(real, signer, *force_proxy_type)
+				else {
+					return None;
+				};
+				if def.proxy_type != crate::mock::ProxyType::DummyWrapper {
+					return None;
+				}
+
+				let unique_tx_key = match call.as_ref() {
+					RuntimeCall::DummyPallet(
+						pallet_dummy::Call::pooled { key } |
+						pallet_dummy::Call::pooled_fail { key },
+					) => Some((b"proxy", key).encode()),
+					RuntimeCall::Utility(
+						pallet_utility::Call::batch { calls } |
+						pallet_utility::Call::batch_all { calls } |
+						pallet_utility::Call::force_batch { calls },
+					) if calls.iter().all(|inner| {
+						matches!(
+							inner,
+							RuntimeCall::DummyPallet(
+								pallet_dummy::Call::pooled { .. } |
+									pallet_dummy::Call::pooled_fail { .. }
+							)
+						)
+					}) =>
+						Some((b"proxy-batch", calls).encode()),
+					_ => None,
+				};
+
+				if let Some(unique_tx_key) = unique_tx_key {
+					return Some(TxSponsor {
+						payer: *real,
+						max_fee_with_tip: Some(1_000_000_000_000),
+						unique_tx_key: Some(unique_tx_key),
+					});
+				}
 			}
 
 			if let RuntimeCall::DummyPallet(
@@ -414,7 +477,6 @@ pub mod pallet_dummy {
 					payer: sponsor,
 					max_fee_with_tip: Some(max_fee_with_tip),
 					unique_tx_key: Some(key.encode()),
-					refund_fee_on_success: false,
 				});
 			}
 			None

--- a/pallets/fee_control/src/test.rs
+++ b/pallets/fee_control/src/test.rs
@@ -16,10 +16,10 @@
 use super::*;
 use crate::mock::{
 	new_test_ext,
-	pallet_dummy::{Call, ConsumedPoolKeys, OneUseCodes},
-	Balances, FeeAmount, FeeControl, LastPayer, LastPostDispatchPaysFee,
+	pallet_dummy::{Call, ConsumedPoolKeys, DispatchedPoolKeys, OneUseCodes},
+	Balances, FeeAmount, FeeControl, FeeUnbalancedAmount, LastPayer, LastPostDispatchPaysFee,
 	MockChargePaymentExtension, PrepareCount, Proxy, ProxyType, RuntimeCall, Test, TipAmount,
-	ValidateCount,
+	TipUnbalancedAmount, ValidateCount,
 };
 use codec::Encode;
 use frame_support::dispatch::{DispatchInfo, GetDispatchInfo, Pays};
@@ -778,17 +778,54 @@ fn delegation_changes_fee_payer_seen_by_payment_ext_with_proxy() {
 }
 
 #[test]
-fn delegation_refunds_fees_for_proxy_specific_sponsors() {
+fn proxy_specific_sponsors_require_registered_delegate() {
 	new_test_ext().execute_with(|| {
-		LastPayer::set(None);
-		LastPostDispatchPaysFee::set(None);
+		let real = 7u64;
+		let delegate = 1u64;
+		let attacker = 2u64;
+		let key = 35u32;
+
+		set_argons(real, 1_000_000u128);
+		assert_ok!(Proxy::add_proxy(Some(real).into(), delegate, ProxyType::DummyWrapper, 0,));
+
+		let call = RuntimeCall::Proxy(pallet_proxy::Call::<Test>::proxy {
+			real,
+			force_proxy_type: Some(ProxyType::DummyWrapper),
+			call: Box::new(RuntimeCall::DummyPallet(Call::<Test>::pooled { key })),
+		});
+
+		let result =
+			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension)
+				.validate_only(
+					Some(attacker).into(),
+					&call,
+					&DispatchInfo::default(),
+					0,
+					TransactionSource::External,
+					0,
+				);
+
+		assert!(matches!(
+			result,
+			Err(TransactionValidityError::Invalid(InvalidTransaction::Payment))
+		));
+	});
+}
+
+#[test]
+fn proxy_specific_sponsors_charge_real_account_directly() {
+	new_test_ext().execute_with(|| {
+		FeeUnbalancedAmount::set(0);
+		TipUnbalancedAmount::set(0);
 
 		let real = 7u64;
 		let delegate = 1u64;
 		let key = 33u32;
-		let sponsor_balance: Balance = 2_000_000u128;
+		let delegate_balance: Balance = 1_000_000_000_000u128;
+		let sponsor_balance: Balance = 1_000_000_000_000u128;
+		let tip: Balance = 500u128;
 
-		assert_eq!(Balances::free_balance(delegate), 0u128);
+		set_argons(delegate, delegate_balance);
 		set_argons(real, sponsor_balance);
 		assert_ok!(Proxy::add_proxy(Some(real).into(), delegate, ProxyType::DummyWrapper, 0,));
 
@@ -800,18 +837,22 @@ fn delegation_refunds_fees_for_proxy_specific_sponsors() {
 		let info = call.get_dispatch_info();
 		let len = call.encoded_size();
 		let origin = crate::mock::RuntimeOrigin::signed(delegate);
-		let wrapper =
-			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension);
+		let delegate_before = Balances::free_balance(delegate);
+		let sponsor_before = Balances::free_balance(real);
+		let wrapper = CheckFeeWrapper::<Test, ChargeTransactionPayment<Test>>::from(
+			ChargeTransactionPayment::<Test>::from(tip),
+		);
 		let (_, val, _) = wrapper
 			.validate_only(origin.clone(), &call, &info, len, TransactionSource::External, 0)
 			.unwrap();
-		let pre =
-			CheckFeeWrapper::<Test, MockChargePaymentExtension>::from(MockChargePaymentExtension)
-				.prepare(val, &origin, &call, &info, len)
-				.unwrap();
+		let pre = CheckFeeWrapper::<Test, ChargeTransactionPayment<Test>>::from(
+			ChargeTransactionPayment::<Test>::from(tip),
+		)
+		.prepare(val, &origin, &call, &info, len)
+		.unwrap();
 
 		let dispatch_result = call.dispatch(origin);
-		let dispatch_outcome = match &dispatch_result {
+		let outer_dispatch_outcome = match &dispatch_result {
 			Ok(_) => Ok(()),
 			Err(err) => Err(err.error.clone()),
 		};
@@ -819,19 +860,94 @@ fn delegation_refunds_fees_for_proxy_specific_sponsors() {
 			Ok(post_info) => post_info,
 			Err(err) => &err.post_info,
 		};
+		let actual_fee = pallet_transaction_payment::Pallet::<Test>::compute_actual_fee(
+			len as u32, &info, post_info, tip,
+		);
 
-		CheckFeeWrapper::<Test, MockChargePaymentExtension>::post_dispatch_details(
+		CheckFeeWrapper::<Test, ChargeTransactionPayment<Test>>::post_dispatch_details(
 			pre,
 			&info,
 			post_info,
 			len,
-			&dispatch_outcome,
+			&outer_dispatch_outcome,
 		)
 		.unwrap();
 
-		assert!(dispatch_outcome.is_ok());
-		assert_eq!(LastPayer::get(), Some(real));
-		assert_eq!(LastPostDispatchPaysFee::get(), Some(Pays::No));
+		assert!(outer_dispatch_outcome.is_ok());
+		assert!(DispatchedPoolKeys::<Test>::contains_key(key));
+		assert_eq!(Balances::free_balance(delegate), delegate_before);
+		assert_eq!(Balances::free_balance(real), sponsor_before - actual_fee);
+		assert_eq!(FeeUnbalancedAmount::get() + TipUnbalancedAmount::get(), actual_fee);
+	});
+}
+
+#[test]
+fn proxy_specific_sponsors_charge_real_account_for_failed_calls() {
+	new_test_ext().execute_with(|| {
+		FeeUnbalancedAmount::set(0);
+		TipUnbalancedAmount::set(0);
+
+		let real = 7u64;
+		let delegate = 1u64;
+		let key = 34u32;
+		let delegate_balance: Balance = 1_000_000_000_000u128;
+		let sponsor_balance: Balance = 1_000_000_000_000u128;
+		let tip: Balance = 500u128;
+
+		set_argons(delegate, delegate_balance);
+		set_argons(real, sponsor_balance);
+		assert_ok!(Proxy::add_proxy(Some(real).into(), delegate, ProxyType::DummyWrapper, 0,));
+
+		let call = RuntimeCall::Proxy(pallet_proxy::Call::<Test>::proxy {
+			real,
+			force_proxy_type: Some(ProxyType::DummyWrapper),
+			call: Box::new(RuntimeCall::DummyPallet(Call::<Test>::pooled_fail { key })),
+		});
+		let info = call.get_dispatch_info();
+		let len = call.encoded_size();
+		let origin = crate::mock::RuntimeOrigin::signed(delegate);
+		let delegate_before = Balances::free_balance(delegate);
+		let sponsor_before = Balances::free_balance(real);
+		let wrapper = CheckFeeWrapper::<Test, ChargeTransactionPayment<Test>>::from(
+			ChargeTransactionPayment::<Test>::from(tip),
+		);
+		let (_, val, _) = wrapper
+			.validate_only(origin.clone(), &call, &info, len, TransactionSource::External, 0)
+			.unwrap();
+		let pre = CheckFeeWrapper::<Test, ChargeTransactionPayment<Test>>::from(
+			ChargeTransactionPayment::<Test>::from(tip),
+		)
+		.prepare(val, &origin, &call, &info, len)
+		.unwrap();
+
+		let dispatch_result = call.dispatch(origin);
+		let outer_dispatch_outcome = match &dispatch_result {
+			Ok(_) => Ok(()),
+			Err(err) => Err(err.error.clone()),
+		};
+		let post_info = match &dispatch_result {
+			Ok(post_info) => post_info,
+			Err(err) => &err.post_info,
+		};
+		let actual_fee = pallet_transaction_payment::Pallet::<Test>::compute_actual_fee(
+			len as u32, &info, post_info, tip,
+		);
+
+		CheckFeeWrapper::<Test, ChargeTransactionPayment<Test>>::post_dispatch_details(
+			pre,
+			&info,
+			post_info,
+			len,
+			&outer_dispatch_outcome,
+		)
+		.unwrap();
+
+		// `proxy(...)` returns `Ok(())` even when the proxied call fails.
+		assert!(outer_dispatch_outcome.is_ok());
+		assert!(!DispatchedPoolKeys::<Test>::contains_key(key));
+		assert_eq!(Balances::free_balance(delegate), delegate_before);
+		assert_eq!(Balances::free_balance(real), sponsor_before - actual_fee);
+		assert_eq!(FeeUnbalancedAmount::get() + TipUnbalancedAmount::get(), actual_fee);
 	});
 }
 

--- a/primitives/src/providers.rs
+++ b/primitives/src/providers.rs
@@ -1300,22 +1300,20 @@ impl<RuntimeCall, AccountId> CallTxValidityProvider<RuntimeCall, AccountId> for 
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TxSponsor<AccountId, Balance> {
-	/// The account that will pay for the transaction fee
+	/// The account that will pay for the transaction fee.
 	pub payer: AccountId,
 	/// The maximum fee (including tip) that the sponsor is willing to pay
 	pub max_fee_with_tip: Option<Balance>,
 	/// A unique key to identify this sponsored transaction in the tx pool to prevent dos
 	/// attacks
 	pub unique_tx_key: Option<Vec<u8>>,
-	/// Whether the charged fee should be refunded when the transaction succeeds.
-	pub refund_fee_on_success: bool,
 }
 
-/// A configurable hook that can recognize calls where one account should reimburse another
-/// for the transaction fee after dispatch.
+/// A configurable hook that can recognize calls whose transaction fee should be charged to a
+/// different account during fee validation and payment.
 ///
-/// Return a `Some(account_id)` if another account has explicitly authorized to pay the fee for
-/// the `signer` for the given `call`. Otherwise return `None`.
+/// Return a `Some(TxSponsor)` if another account has explicitly authorized paying the fee for the
+/// `signer` for the given `call`. Otherwise return `None`.
 pub trait TransactionSponsorProvider<AccountId, RuntimeCall, Balance> {
 	fn get_transaction_sponsor(
 		signer: &AccountId,
@@ -1342,7 +1340,8 @@ impl<AccountId, RuntimeCall, Balance> TransactionSponsorProvider<AccountId, Runt
 	}
 }
 
-/// Provides runtime-defined call combinations that should be refunded after successful dispatch.
+/// Provides runtime-defined call combinations whose fees should be refunded after successful
+/// dispatch.
 ///
 /// This is evaluated against the effective call after proxy unwrapping, allowing the runtime to
 /// keep fee-refund policy close to its own call-shape and proxy rules instead of hard-coding

--- a/runtime/argon/src/lib.rs
+++ b/runtime/argon/src/lib.rs
@@ -787,6 +787,6 @@ impl pallet_fee_control::Config for Runtime {
 	type FeelessCallTxPoolKeyProviders = ();
 	type CallTxPoolKeyProviders = (BitcoinLocks, EthereumVerifier, CrosschainTransfer);
 	type CallTxValidityProviders = (EthereumVerifier, CrosschainTransfer);
-	type TransactionSponsorProviders = ProxyFeeDelegate<Runtime>;
+	type TransactionSponsorProviders = MiningBidProxyFeeSponsor<Runtime>;
 	type CallFeeRefundProviders = VaultAdminFeeRefundPolicy;
 }

--- a/runtime/canary/src/lib.rs
+++ b/runtime/canary/src/lib.rs
@@ -789,6 +789,6 @@ impl pallet_fee_control::Config for Runtime {
 	type FeelessCallTxPoolKeyProviders = ();
 	type CallTxPoolKeyProviders = (BitcoinLocks, EthereumVerifier, CrosschainTransfer);
 	type CallTxValidityProviders = (EthereumVerifier, CrosschainTransfer);
-	type TransactionSponsorProviders = ProxyFeeDelegate<Runtime>;
+	type TransactionSponsorProviders = MiningBidProxyFeeSponsor<Runtime>;
 	type CallFeeRefundProviders = VaultAdminFeeRefundPolicy;
 }

--- a/runtime/common/src/deal_with_fees.rs
+++ b/runtime/common/src/deal_with_fees.rs
@@ -25,13 +25,13 @@ macro_rules! deal_with_fees {
 			}
 		}
 
-		pub struct ProxyFeeDelegate<R>(PhantomData<R>);
+		pub struct MiningBidProxyFeeSponsor<R>(PhantomData<R>);
 		impl<R>
 			TransactionSponsorProvider<
 				R::AccountId,
 				<R as frame_system::Config>::RuntimeCall,
 				Balance,
-			> for ProxyFeeDelegate<R>
+			> for MiningBidProxyFeeSponsor<R>
 		where
 			R: frame_system::Config<RuntimeCall = RuntimeCall, AccountId = AccountId32>
 				+ pallet_balances::Config<ArgonToken, Balance = Balance>
@@ -84,23 +84,15 @@ macro_rules! deal_with_fees {
 						false
 					}
 
-					// Determine the effective proxy type.
-					let effective_proxy_type = if let Some(t) = force_proxy_type {
-						Some(*t)
-					} else {
-						// Look up the stored proxy relationship to determine proxy type.
-						let (defs, _deposit) =
-							pallet_proxy::Pallet::<R>::proxies(real_account.clone());
-						defs.into_iter().find_map(|def| {
-							if def.delegate == *signer {
-								Some(def.proxy_type)
-							} else {
-								None
-							}
-						})
+					let Ok(def) = pallet_proxy::Pallet::<R>::find_proxy(
+						real_account,
+						signer,
+						*force_proxy_type,
+					) else {
+						return None;
 					};
 
-					if !matches!(effective_proxy_type, Some(ProxyType::MiningBidRealPaysFee)) {
+					if def.proxy_type != ProxyType::MiningBidRealPaysFee {
 						return None;
 					}
 
@@ -119,7 +111,6 @@ macro_rules! deal_with_fees {
 								.using_encoded(sp_crypto_hashing::blake2_256)
 								.to_vec(),
 						),
-						refund_fee_on_success: true,
 					});
 				}
 				None


### PR DESCRIPTION
## Summary

This updates the mining bid proxy fee sponsorship path to match the intended model:

- the real/funding account pays the transaction fee directly
- the proxy/hot wallet does not need to hold funds just to submit bids
- only an actually registered `MiningBidRealPaysFee` proxy delegate can trigger sponsorship

## What changed

- removed the old sponsor-driven success refund behavior from the mining proxy path
- preserved the fee-control fix that keeps proxied dispatch using the outer proxy origin
- tightened sponsorship authorization to reuse the proxy pallet's real `find_proxy(...)` check instead of trusting `force_proxy_type`
- renamed the runtime sponsor implementation to `MiningBidProxyFeeSponsor`
- added regression coverage so an unregistered delegate cannot get a real account to sponsor fees

## Why

The previous behavior had two problems:

1. it had drifted away from the intended mining model, which is "real account pays, proxy stays minimally funded"
2. the runtime sponsor lookup was looser than proxy authorization, so a forged `force_proxy_type` could cause the real account to pay fees for a proxy call that would later be rejected as `NotProxy`

This brings the fee path back in line with the intended mining proxy behavior and closes that authorization gap.
