### PR TITLE
feat(node): expose sync status via rpc

### DIFF
--- a/docker/argon-rpc/rpcs.yml
+++ b/docker/argon-rpc/rpcs.yml
@@ -315,6 +315,10 @@ methods:
       size: 1
       ttl_seconds: 5
 
+  - method: system_syncStatus
+    cache:
+      size: 0
+
   - method: system_accountNextIndex
     cache:
       size: 0

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -9,9 +9,10 @@ use std::sync::Arc;
 
 use crate::runtime_api::opaque::{Block, Hash};
 use argon_primitives::{AccountId, Balance, BlockNumber, BlockSealAuthorityId, MiningApis, Nonce};
-use jsonrpsee::RpcModule;
+use jsonrpsee::{types::ErrorObjectOwned, RpcModule};
 use sc_client_api::{AuxStore, BlockBackend, ProofProvider};
 use sc_consensus_grandpa::FinalityProofProvider;
+use sc_network_sync::{SyncState, SyncStatus, SyncingService, WarpSyncPhase};
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
@@ -23,6 +24,10 @@ pub struct FullDeps<C, P, B> {
 	pub client: Arc<C>,
 	/// Transaction pool instance.
 	pub pool: Arc<P>,
+	/// Current network synchronization service.
+	pub sync_service: Arc<SyncingService<Block>>,
+	/// Best block when the node's synchronization service started.
+	pub starting_block: BlockNumber,
 	/// GRANDPA specific dependencies.
 	pub grandpa: GrandpaDeps<B>,
 }
@@ -66,7 +71,7 @@ where
 	use substrate_frame_rpc_system::{System, SystemApiServer};
 
 	let mut module = RpcModule::new(());
-	let FullDeps { client, pool, grandpa } = deps;
+	let FullDeps { client, pool, sync_service, starting_block, grandpa } = deps;
 	let GrandpaDeps {
 		shared_voter_state,
 		shared_authority_set,
@@ -89,5 +94,129 @@ where
 		.into_rpc(),
 	)?;
 
+	let sync_service = sync_service.clone();
+	let client_for_sync_status = client.clone();
+	module.register_async_method("system_syncStatus", move |_, _, _| {
+		let sync_service = sync_service.clone();
+		let client = client_for_sync_status.clone();
+
+		async move {
+			let sync_status = sync_service.status().await.map_err(|_| {
+				ErrorObjectOwned::owned(-32603, "Syncing service has terminated", None::<()>)
+			})?;
+			let current_block = client.info().best_number;
+
+			Ok::<_, ErrorObjectOwned>(to_sync_status_response(
+				starting_block,
+				current_block,
+				sync_status,
+			))
+		}
+	})?;
+
 	Ok(module)
+}
+
+fn to_sync_status_response(
+	starting_block: BlockNumber,
+	current_block: BlockNumber,
+	sync_status: SyncStatus<Block>,
+) -> serde_json::Value {
+	let (state, target_block) = match sync_status.state {
+		SyncState::Idle => ("idle", None),
+		SyncState::Downloading { target } => ("downloading", Some(target)),
+		SyncState::Importing { target } => ("importing", Some(target)),
+	};
+
+	serde_json::json!({
+		"startingBlock": starting_block,
+		"currentBlock": current_block,
+		"state": state,
+		"targetBlock": target_block,
+		"bestSeenBlock": sync_status.best_seen_block,
+		"numPeers": sync_status.num_peers,
+		"queuedBlocks": sync_status.queued_blocks,
+		"stateSync": sync_status.state_sync.map(|progress| serde_json::json!({
+			"percentage": progress.percentage,
+			"size": progress.size,
+			"phase": match progress.phase {
+				sc_network_sync::strategy::state_sync::StateSyncPhase::DownloadingState => "downloadingState",
+				sc_network_sync::strategy::state_sync::StateSyncPhase::ImportingState => "importingState",
+			},
+		})),
+		"warpSync": sync_status.warp_sync.map(|progress| {
+			let (phase, block) = match progress.phase {
+				WarpSyncPhase::AwaitingPeers { .. } => ("awaitingPeers", None),
+				WarpSyncPhase::DownloadingWarpProofs => ("downloadingWarpProofs", None),
+				WarpSyncPhase::DownloadingTargetBlock => ("downloadingTargetBlock", None),
+				WarpSyncPhase::DownloadingState => ("downloadingState", None),
+				WarpSyncPhase::ImportingState => ("importingState", None),
+				WarpSyncPhase::DownloadingBlocks(block) => ("downloadingBlocks", Some(block)),
+				WarpSyncPhase::Complete => ("complete", None),
+			};
+
+			serde_json::json!({
+				"phase": phase,
+				"block": block,
+				"totalBytes": progress.total_bytes,
+				"status": progress.status,
+			})
+		}),
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sc_network_sync::{
+		strategy::state_sync::{StateSyncPhase, StateSyncProgress},
+		SyncState, SyncStatus, WarpSyncPhase, WarpSyncProgress,
+	};
+	use serde_json::json;
+
+	#[test]
+	fn converts_sync_status() {
+		let status = SyncStatus::<Block> {
+			state: SyncState::Downloading { target: 42 },
+			best_seen_block: Some(42),
+			num_peers: 3,
+			queued_blocks: 7,
+			state_sync: Some(StateSyncProgress {
+				percentage: 65,
+				size: 1234,
+				phase: StateSyncPhase::DownloadingState,
+			}),
+			warp_sync: Some(WarpSyncProgress {
+				phase: WarpSyncPhase::DownloadingBlocks(40),
+				total_bytes: 5678,
+				status: Some("downloading history".to_string()),
+			}),
+		};
+
+		let response = to_sync_status_response(10, 20, status);
+
+		assert_eq!(
+			serde_json::to_value(response).unwrap(),
+			json!({
+				"startingBlock": 10,
+				"currentBlock": 20,
+				"state": "downloading",
+				"targetBlock": 42,
+				"bestSeenBlock": 42,
+				"numPeers": 3,
+				"queuedBlocks": 7,
+				"stateSync": {
+					"percentage": 65,
+					"size": 1234,
+					"phase": "downloadingState"
+				},
+				"warpSync": {
+					"phase": "downloadingBlocks",
+					"block": 40,
+					"totalBytes": 5678,
+					"status": "downloading history"
+				}
+			})
+		);
+	}
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -298,6 +298,7 @@ where
 			block_relay: None,
 			metrics,
 		})?;
+	let starting_block = client.info().best_number;
 
 	let role = config.role;
 	let name = config.network.node_name.clone();
@@ -320,6 +321,7 @@ where
 		let backend = backend.clone();
 		let justification_stream = grandpa_link.justification_stream();
 		let shared_authority_set = grandpa_link.shared_authority_set().clone();
+		let sync_service = sync_service.clone();
 		let finality_proof_provider = GrandpaFinalityProofProvider::new_for_service(
 			backend.clone(),
 			Some(shared_authority_set.clone()),
@@ -329,6 +331,8 @@ where
 			let deps = rpc::FullDeps {
 				client: client.clone(),
 				pool: transaction_pool.clone(),
+				sync_service: sync_service.clone(),
+				starting_block,
 				grandpa: GrandpaDeps {
 					shared_voter_state: shared_voter_state.clone(),
 					shared_authority_set: shared_authority_set.clone(),


### PR DESCRIPTION
## Summary

Nodes can now expose their live synchronization state through `system_syncStatus`, including state-download percentage and progress details. The response also includes the block at sync-service startup, the current local block, peer target, queued blocks, and warp-sync progress when applicable.

The RPC gateway allowlist exposes the method without caching so callers receive current sync information.

## Validation

- `cargo test -p argon-node` (13 passed)
- `cargo check -p argon-node`
- `cargo make lint-check`
