### PR TITLE
fix(nodejs): handle retracted transaction results

### DIFF
--- a/client/nodejs/src/TxResult.ts
+++ b/client/nodejs/src/TxResult.ts
@@ -175,7 +175,7 @@ export class TxResult {
       this.isBroadcast = true;
       if (result.internalError) this.submissionError = result.internalError;
     }
-    if (status.isInBlock) {
+    if (status.isInBlock && txIndex !== undefined) {
       try {
         const pendingInBlock = createPendingInBlock(
           Uint8Array.from(status.asInBlock),
@@ -191,6 +191,23 @@ export class TxResult {
         });
       } catch (error) {
         this.submissionError = error as Error;
+      }
+    }
+    if (status.isRetracted) {
+      const retractedHash = Uint8Array.from(status.asRetracted);
+      if (this.#pendingInBlock && u8aEq(this.#pendingInBlock.blockHash, retractedHash)) {
+        this.#pendingInBlock = undefined;
+      }
+      if (this.blockHash && u8aEq(this.blockHash, retractedHash)) {
+        this.events = [];
+        this.extrinsicError = undefined;
+        this.extrinsicIndex = undefined;
+        this.batchInterruptedIndex = undefined;
+        this.blockHash = undefined;
+        this.blockNumber = undefined;
+        this.finalFee = undefined;
+        this.finalFeeTip = undefined;
+        this.updateProgress();
       }
     }
     if (status.isUsurped) {

--- a/client/nodejs/src/__test__/TxResult.test.ts
+++ b/client/nodejs/src/__test__/TxResult.test.ts
@@ -57,6 +57,77 @@ describe('TxResult', () => {
     });
   });
 
+  it('keeps watching after an in-block result without a transaction index', async () => {
+    const reIncludedHash = Uint8Array.from([4, 5, 6]);
+    const getHeader = vi.fn().mockResolvedValue({
+      number: {
+        toNumber: () => 145,
+      },
+    });
+    const result = createTxResult({
+      rpc: {
+        chain: {
+          getHeader,
+        },
+      },
+    } as any);
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: true,
+        asInBlock: Uint8Array.from([1, 2, 3]),
+        isInvalid: false,
+        isRetracted: false,
+        isUsurped: false,
+      },
+      txIndex: undefined,
+    } as any);
+
+    expect(result.submissionError).toBeUndefined();
+    expect(getHeader).not.toHaveBeenCalled();
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: true,
+        asInBlock: reIncludedHash,
+        isInvalid: false,
+        isRetracted: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await expect(result.waitForInFirstBlock).resolves.toEqual(reIncludedHash);
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: true,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isFinalized: true,
+        asFinalized: reIncludedHash,
+        isInBlock: false,
+        isInvalid: false,
+        isRetracted: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await expect(result.waitForFinalizedBlock).resolves.toEqual(reIncludedHash);
+    expect(result.submissionError).toBeUndefined();
+    expect(result.isFinalized).toBe(true);
+  });
+
   it('waits to publish in-block until it can resolve a real finalized block', async () => {
     const getHeader = vi
       .fn()
@@ -205,6 +276,123 @@ describe('TxResult', () => {
 
     expect(result.blockHash).toEqual(finalizedHash);
     expect(result.blockNumber).toBe(145);
+  });
+
+  it('ignores an in-block lookup after the transaction is retracted', async () => {
+    const inBlockHash = Uint8Array.from([1, 2, 3]);
+    let resolveInBlockHeader!: (value: unknown) => void;
+    const getHeader = vi.fn().mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveInBlockHeader = resolve;
+        }),
+    );
+    const result = createTxResult({
+      rpc: {
+        chain: {
+          getHeader,
+        },
+      },
+    } as any);
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: true,
+        asInBlock: inBlockHash,
+        isInvalid: false,
+        isRetracted: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await Promise.resolve();
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: false,
+        isInvalid: false,
+        isRetracted: true,
+        asRetracted: inBlockHash,
+        isUsurped: false,
+      },
+      txIndex: undefined,
+    } as any);
+
+    resolveInBlockHeader({
+      number: {
+        toNumber: () => 144,
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(result.blockHash).toBeUndefined();
+    expect(result.blockNumber).toBeUndefined();
+  });
+
+  it('clears a published block inclusion when the transaction is retracted', async () => {
+    const inBlockHash = Uint8Array.from([1, 2, 3]);
+    const result = createTxResult({
+      rpc: {
+        chain: {
+          getHeader: vi.fn().mockResolvedValue({
+            number: {
+              toNumber: () => 144,
+            },
+          }),
+        },
+      },
+    } as any);
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: true,
+        asInBlock: inBlockHash,
+        isInvalid: false,
+        isRetracted: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await expect(result.waitForInFirstBlock).resolves.toEqual(inBlockHash);
+    expect(result.blockNumber).toBe(144);
+    expect(result.extrinsicIndex).toBe(4);
+    expect(result.txProgress).toBe(99);
+
+    result.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: false,
+        isInvalid: false,
+        isRetracted: true,
+        asRetracted: inBlockHash,
+        isUsurped: false,
+      },
+      txIndex: undefined,
+    } as any);
+
+    expect(result.blockHash).toBeUndefined();
+    expect(result.blockNumber).toBeUndefined();
+    expect(result.extrinsicIndex).toBeUndefined();
+    expect(result.txProgress).toBe(10);
   });
 });
 


### PR DESCRIPTION
Transactions that temporarily enter an orphaned block can now keep tracking through re-inclusion instead of becoming terminal when PolkadotJS cannot resolve an extrinsic index. Explicit retractions clear pending or published block state so the next inclusion is authoritative. Coverage exercises missing-index recovery, retraction during header lookup, and retraction after inclusion publication. Validated with the Node client unit suite, typecheck, ESLint, and Prettier.
