### PR TITLE
fix(oracle): recover stalled transaction watches

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -9,7 +9,7 @@ use jsonrpsee::{
 pub(crate) use polkadot_sdk::*;
 use sp_core::{crypto::AccountId32, H256};
 use sp_runtime::{MultiAddress, MultiSignature};
-use std::{fmt::Debug, io::Write, sync::Arc};
+use std::{fmt::Debug, io::Write, sync::Arc, time::Duration};
 use subxt::{
 	backend::{legacy::LegacyRpcMethods, rpc::RpcClient, BackendExt, BlockRef},
 	blocks::ExtrinsicEvents,
@@ -29,6 +29,7 @@ use subxt::{
 use tokio::{
 	sync::{mpsc, Mutex, RwLock},
 	task::JoinHandle,
+	time::timeout,
 };
 use tracing::{info, log::debug, warn};
 
@@ -69,6 +70,13 @@ impl Config for ArgonConfig {
 pub type ArgonExtrinsicParams<T> = DefaultExtrinsicParams<T>;
 
 pub type ArgonTxProgress = TxProgress<ArgonConfig, ArgonOnlineClient>;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Timed out waiting for transaction {extrinsic_hash:?} after {wait_timeout:?}")]
+pub struct TransactionWatchTimeout {
+	pub extrinsic_hash: H256,
+	pub wait_timeout: Duration,
+}
 
 /// A builder which leads to [`ArgonExtrinsicParams`] being constructed.
 /// This is what you provide to methods like `sign_and_submit()`.
@@ -377,6 +385,19 @@ impl MainchainClient {
 		Ok(Self::wait_for_ext_in_block(result, wait_for_finalized).await?)
 	}
 
+	pub async fn wait_for_ext_in_block_with_timeout(
+		tx_progress: ArgonTxProgress,
+		wait_for_finalized: bool,
+		wait_timeout: Duration,
+	) -> anyhow::Result<TxInBlockWithEvents> {
+		let extrinsic_hash = tx_progress.extrinsic_hash();
+		let result =
+			timeout(wait_timeout, Self::wait_for_ext_in_block(tx_progress, wait_for_finalized))
+				.await
+				.map_err(|_| TransactionWatchTimeout { extrinsic_hash, wait_timeout })??;
+		Ok(result)
+	}
+
 	pub async fn wait_for_ext_in_block(
 		mut tx_progress: ArgonTxProgress,
 		wait_for_finalized: bool,
@@ -621,8 +642,33 @@ impl ReconnectingClient {
 #[cfg(test)]
 mod test {
 	use argon_testing::start_argon_test_node;
+	use std::time::Duration;
+	use subxt::backend::{StreamOfResults, TransactionStatus};
 
 	use super::*;
+
+	#[tokio::test]
+	async fn transaction_watch_times_out_when_progress_stops() {
+		let ctx = start_argon_test_node().await;
+		let client =
+			MainchainClient::try_until_connected(&ctx.client.url, 100, 1_000).await.unwrap();
+		let statuses = StreamOfResults::new(Box::pin(futures::stream::pending::<
+			Result<TransactionStatus<H256>, subxt::error::Error>,
+		>()));
+		let progress = ArgonTxProgress::new(statuses, client.live.clone(), H256::repeat_byte(1));
+
+		let error = MainchainClient::wait_for_ext_in_block_with_timeout(
+			progress,
+			false,
+			Duration::from_millis(10),
+		)
+		.await
+		.unwrap_err();
+		let timeout = error.downcast_ref::<TransactionWatchTimeout>().unwrap();
+
+		assert_eq!(timeout.extrinsic_hash, H256::repeat_byte(1));
+		assert_eq!(timeout.wait_timeout, Duration::from_millis(10));
+	}
 
 	#[tokio::test]
 	async fn test_getting_ticker() {

--- a/oracle/src/bitcoin_tip.rs
+++ b/oracle/src/bitcoin_tip.rs
@@ -3,12 +3,15 @@ use argon_bitcoin::client::Client;
 use argon_client::{
 	api::{runtime_types::argon_primitives::bitcoin as bitcoin_primitives_subxt, storage, tx},
 	signer::Signer,
-	subxt_error, ArgonConfig, FetchAt, ReconnectingClient,
+	subxt_error, ArgonConfig, FetchAt, MainchainClient, ReconnectingClient,
+	TransactionWatchTimeout,
 };
 use argon_primitives::bitcoin::{BitcoinNetwork, H256Le};
 use bitcoincore_rpc::{Auth, RpcApi};
 use std::time::Duration;
 use tokio::time::sleep;
+
+use crate::utils::MIN_TRANSACTION_WATCH_TIMEOUT;
 
 const CONFIRMATIONS: u64 = 6;
 
@@ -28,9 +31,12 @@ pub async fn bitcoin_loop(
 	bitcoin_client.timeout = Duration::from_secs(60);
 	tracing::info!("Oracle Started. Connected to bitcoin at {}", bitcoin_rpc_url);
 
-	let required_bitcoin_network: BitcoinNetwork = mainchain_client
-		.get()
-		.await?
+	let client = mainchain_client.get().await?;
+	let ticker = client.lookup_ticker().await?;
+	let transaction_watch_timeout = Duration::from_millis(ticker.tick_duration_millis)
+		.saturating_mul(2)
+		.max(MIN_TRANSACTION_WATCH_TIMEOUT);
+	let required_bitcoin_network: BitcoinNetwork = client
 		.fetch_storage(&storage().bitcoin_utxos().bitcoin_network(), FetchAt::Finalized)
 		.await?
 		.expect("Expected network")
@@ -64,11 +70,31 @@ pub async fn bitcoin_loop(
 
 		let client = mainchain_client.get().await?;
 		let params = client.params_with_best_nonce(&account_id).await?.build();
-		match client.submit_tx(&latest_block, &signer, Some(params), false).await {
+		let submission = async {
+			let progress = client
+				.live
+				.tx()
+				.sign_and_submit_then_watch(&latest_block, &signer, params)
+				.await?;
+			MainchainClient::wait_for_ext_in_block_with_timeout(
+				progress,
+				false,
+				transaction_watch_timeout,
+			)
+			.await
+		}
+		.await;
+		match submission {
 			Ok(_) => {
 				tracing::info!(bitcoin_confirmed_height, ?bitcoin_tip, "Submitted bitcoin tip",);
 			},
 			Err(e) => {
+				if e.downcast_ref::<TransactionWatchTimeout>().is_some() {
+					return Err(e.context(
+						"Bitcoin tip transaction watch timed out. Throwing to kick off a restart",
+					));
+				}
+
 				// Try to detect the common "Invalid Transaction (1010)" failure mode.
 				// Depending on the RPC stack, this may surface either as a typed `TransactionError`
 				// somewhere in the error chain *or* only as an RPC string message.

--- a/oracle/src/price_index.rs
+++ b/oracle/src/price_index.rs
@@ -15,6 +15,7 @@ use crate::{
 	coin_usd_prices::PriceProviderKind,
 	uniswap_oracle::{PriceAndLiquidity, UniswapOracleError},
 	us_cpi::UsCpiRetriever,
+	utils::MIN_TRANSACTION_WATCH_TIMEOUT,
 };
 use argon_client::{
 	api::{constants, price_index::calls::types::submit::Index, storage, tx},
@@ -101,6 +102,9 @@ pub async fn price_index_loop(
 	if cfg!(test) {
 		min_sleep_duration = Duration::from_millis(50);
 	}
+	let transaction_watch_timeout = Duration::from_millis(ticker.tick_duration_millis)
+		.saturating_mul(2)
+		.max(MIN_TRANSACTION_WATCH_TIMEOUT);
 
 	let mut us_cpi = UsCpiRetriever::new(&ticker).await?;
 	let mut usd_price_lookups =
@@ -224,7 +228,13 @@ pub async fn price_index_loop(
 			last_target_price = target_price;
 
 			info!("Submitted price index with progress: {:?}", progress);
-			MainchainClient::wait_for_ext_in_block(progress, false).await.map_err(|e| {
+			MainchainClient::wait_for_ext_in_block_with_timeout(
+				progress,
+				false,
+				transaction_watch_timeout,
+			)
+			.await
+			.map_err(|e| {
 				tracing::warn!("Error processing price index!! {:?}", e);
 				e
 			})?;
@@ -264,6 +274,9 @@ pub async fn price_index_loop_from_file(
 	if cfg!(test) {
 		min_sleep_duration = Duration::from_millis(50);
 	}
+	let transaction_watch_timeout = Duration::from_millis(ticker.tick_duration_millis)
+		.saturating_mul(2)
+		.max(MIN_TRANSACTION_WATCH_TIMEOUT);
 
 	info!("Oracle Started.");
 	let account_id = signer.account_id();
@@ -301,7 +314,13 @@ pub async fn price_index_loop_from_file(
 		last_submitted_tick = tick;
 
 		info!("Submitted price index with progress: {:?}", progress);
-		MainchainClient::wait_for_ext_in_block(progress, false).await.map_err(|e| {
+		MainchainClient::wait_for_ext_in_block_with_timeout(
+			progress,
+			false,
+			transaction_watch_timeout,
+		)
+		.await
+		.map_err(|e| {
 			tracing::warn!("Error processing price index!! {:?}", e);
 			e
 		})?;

--- a/oracle/src/utils.rs
+++ b/oracle/src/utils.rs
@@ -3,6 +3,9 @@ use chrono::{DateTime, NaiveDate, Utc};
 use polkadot_sdk::*;
 use serde::{Deserialize, Deserializer};
 use sp_runtime::{FixedI128, FixedU128};
+use std::time::Duration;
+
+pub const MIN_TRANSACTION_WATCH_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 #[allow(dead_code)]
 pub fn to_fixed_u128(value: FixedI128) -> FixedU128 {


### PR DESCRIPTION
## Summary

Price-index and Bitcoin-tip workers no longer wait indefinitely when an RPC transaction-status subscription silently stops producing updates. Transaction watches now use a shared client timeout of two ticks with a five-minute minimum, allowing the oracle supervisor to restart a stalled worker while preserving the existing handling for other submission failures.

## Validation

The full client and oracle test suites pass, along with production-target clippy checks for both crates.
