### PR TITLE
fix(mining-slot): prevent scheduled seat compounding

### DIFF
--- a/pallets/mining_slot/src/lib.rs
+++ b/pallets/mining_slot/src/lib.rs
@@ -1119,12 +1119,8 @@ impl<T: Config> Pallet<T> {
 			return;
 		}
 
-		let last_planned_cohort_size: u32 = ScheduledCohortSizeChangeByFrame::<T>::get()
-			.into_iter()
-			.next_back()
-			.map(|(_, size)| size)
-			.unwrap_or(NextCohortSize::<T>::get());
-		let mut next_cohort_size = adjustment_percent.saturating_mul_int(last_planned_cohort_size);
+		let mut next_cohort_size =
+			adjustment_percent.saturating_mul_int(NextCohortSize::<T>::get());
 		if next_cohort_size < min_cohort_size {
 			next_cohort_size = min_cohort_size;
 		} else if next_cohort_size > max_cohort_size {

--- a/pallets/mining_slot/src/tests.rs
+++ b/pallets/mining_slot/src/tests.rs
@@ -1906,7 +1906,7 @@ fn it_adjusts_mining_seats() {
 		assert_eq!(ScheduledCohortSizeChangeByFrame::<Test>::get().len(), 11);
 		assert_eq!(
 			ScheduledCohortSizeChangeByFrame::<Test>::get().into_iter().next_back(),
-			Some((23u32.into(), 11 + 13))
+			Some((23u32.into(), 12))
 		);
 		assert_eq!(AveragePricePerSeat::<Test>::get().len(), 10);
 	});


### PR DESCRIPTION
Mining-seat forecasts could recursively amplify the same trailing price signal across ten unpublished schedule entries, driving future cohorts upward before any increase affected bidding.

New schedule entries now adjust from the cohort size currently published to bidders. Existing locked entries, the trailing price window, target price, and 20% cap remain unchanged. The pallet test suite verifies repeated high-price observations no longer compound unpublished cohort sizes.
