### PR TITLE
fix(client): preserve Beacon API base paths

### DIFF
--- a/client/nodejs/src/EthereumBeaconApi.ts
+++ b/client/nodejs/src/EthereumBeaconApi.ts
@@ -10,7 +10,10 @@ export function buildExecutionHeaderProof(finalizedHeader: EthereumLightClientHe
 
 export async function getBeaconJson<T>(beaconApiUrl: string, path: string): Promise<T> {
   const response = await fetch(
-    new URL(path, beaconApiUrl.endsWith('/') ? beaconApiUrl : `${beaconApiUrl}/`),
+    new URL(
+      path.replace(/^\/+/, ''),
+      beaconApiUrl.endsWith('/') ? beaconApiUrl : `${beaconApiUrl}/`,
+    ),
   );
 
   if (!response.ok) {

--- a/client/nodejs/src/__test__/EthereumBeaconApi.test.ts
+++ b/client/nodejs/src/__test__/EthereumBeaconApi.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, it } from 'vitest';
+import { getBeaconJson } from '../EthereumBeaconApi';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+it('resolves Beacon routes against a root base URL', async () => {
+  globalThis.fetch = createUrlEchoFetch();
+
+  const response = await getBeaconJson<{ url: string }>(
+    'https://ethereum-beacon-api.publicnode.com',
+    '/eth/v1/config/spec',
+  );
+
+  expect(response.url).toBe('https://ethereum-beacon-api.publicnode.com/eth/v1/config/spec');
+});
+
+it('preserves the base pathname when resolving Beacon routes', async () => {
+  globalThis.fetch = createUrlEchoFetch();
+
+  const response = await getBeaconJson<{ url: string }>(
+    'https://eth-mainnetbeacon.g.alchemy.com/v2/example-key',
+    '/eth/v1/config/spec',
+  );
+
+  expect(response.url).toBe(
+    'https://eth-mainnetbeacon.g.alchemy.com/v2/example-key/eth/v1/config/spec',
+  );
+});
+
+function createUrlEchoFetch() {
+  return async (input: string | URL | Request) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    return {
+      ok: true,
+      json: async () => ({ url }),
+      status: 200,
+      statusText: 'OK',
+    } as Response;
+  };
+}


### PR DESCRIPTION
Path-authenticated Beacon providers such as Alchemy now retain their configured `/v2/<key>` prefix when the Node client requests standard Beacon routes. Root-host providers continue to resolve the same `/eth/v1/...` URLs as before.

Coverage exercises both URL shapes, and all 76 non-E2E Node client tests plus the Node client typecheck pass. The Ethereum E2E suite remains unavailable in this worktree because `target/debug/argon-node` is not built.
