### PR TITLE
fix(ethereum): read bootstrap bonds from vault state

### DIFF
--- a/chains/ethereum/deploy/index.ts
+++ b/chains/ethereum/deploy/index.ts
@@ -58,10 +58,10 @@ async function main() {
     const initialCouncilMembers = (
       await Promise.all(
         registeredCouncilMembers.map(async member => {
-          const acceptedBondLots = await argonClient.query.treasury.bondLotsByVault(member.vaultId);
-          const activeBonds = acceptedBondLots.reduce(
+          const bondState = await argonClient.query.treasury.bondLotsByVault(member.vaultId);
+          const activeBonds = bondState.bondLots.reduce(
             (sum, bondLot) => sum + bondLot.bonds.toNumber(),
-            0,
+            bondState.backfillBonds.toNumber(),
           );
           return activeBonds > MIN_BOOTSTRAP_COUNCIL_BONDS ? member : undefined;
         }),


### PR DESCRIPTION
The Node.js workspace build now succeeds with the vault backfill runtime's treasury storage shape. Bootstrap council eligibility reads bond lots from `VaultBondState` and includes active backfill bonds in the total, preserving the existing 5,000-bond threshold.

Validated with `yarn workspace @argonprotocol/ethereum-deploy run tsup`.
