### PR TITLE
fix(treasury): allow bonds against vault securitization

### DIFF
--- a/pallets/pallet_prelude/src/benchmarking.rs
+++ b/pallets/pallet_prelude/src/benchmarking.rs
@@ -1533,11 +1533,11 @@ where
 	type Balance = Balance;
 	type AccountId = AccountId;
 
-	fn get_securitized_satoshis(vault_id: VaultId) -> Satoshis {
+	fn get_securitization_and_securitized_satoshis(vault_id: VaultId) -> (Self::Balance, Satoshis) {
 		benchmark_bitcoin_vault_provider_state::<AccountId, Balance>()
 			.vaults
 			.get(&vault_id)
-			.map(|vault| vault.securitized_satoshis)
+			.map(|vault| (vault.securitization, vault.securitized_satoshis))
 			.unwrap_or_default()
 	}
 

--- a/pallets/treasury/src/lib.rs
+++ b/pallets/treasury/src/lib.rs
@@ -55,8 +55,9 @@ pub use pallet::*;
 /// locked the same day as a slot are eligible for instant-liquidity.
 ///
 /// ## Treasury Pool Allocation
-/// Each frame's treasury pool can sell whole bonds up to the full argon value of a vault's
-/// securitized satoshis (`sats * securitization ratio`).
+/// A vault can accept whole bonds up to the greater of its securitization or the full argon value
+/// of its effective securitized satoshis. Frame participation and earnings remain capped by this
+/// effective Bitcoin-backed value.
 ///
 /// ## Profits from Bid Pool
 /// Once each bid pool is closed, 20% of the pool is reserved for treasury reserves. (Operational
@@ -441,9 +442,13 @@ pub mod pallet {
 			);
 			ensure!(bonds >= Self::minimum_purchase_bonds(), Error::<T>::BondPurchaseBelowMinimum);
 
-			let activated_vault_bonds =
-				Self::balance_to_bonds(Self::get_vault_securitized_funds_cap(vault_id));
-			ensure!(!activated_vault_bonds.is_zero(), Error::<T>::VaultNotAcceptingBondPurchases);
+			let (securitization, securitized_satoshis) =
+				T::TreasuryVaultProvider::get_securitization_and_securitized_satoshis(vault_id);
+			let securitized_funds_cap =
+				T::PriceProvider::get_btc_price_in_market_microgons(securitized_satoshis)
+					.unwrap_or_default();
+			let vault_bond_cap = Self::balance_to_bonds(securitization.max(securitized_funds_cap));
+			ensure!(!vault_bond_cap.is_zero(), Error::<T>::VaultNotAcceptingBondPurchases);
 
 			let current_frame_id = T::MiningFrameTransitionProvider::get_current_frame_id();
 			let sharing_percent =
@@ -469,7 +474,7 @@ pub mod pallet {
 				vault_bonds.backfill_bonds_reserved.saturating_sub(backfill_bonds_to_unreserve);
 
 			let bonds_total = Self::sum_bonds(&vault_bonds.bond_lots);
-			let available_bond_space_now = activated_vault_bonds
+			let available_bond_space_now = vault_bond_cap
 				.saturating_sub(bonds_total)
 				.saturating_sub(vault_bonds.backfill_bonds_reserved);
 
@@ -1367,7 +1372,8 @@ pub mod pallet {
 		}
 
 		pub(crate) fn get_vault_securitized_funds_cap(vault_id: VaultId) -> T::Balance {
-			let securitized_satoshis = T::TreasuryVaultProvider::get_securitized_satoshis(vault_id);
+			let (_, securitized_satoshis) =
+				T::TreasuryVaultProvider::get_securitization_and_securitized_satoshis(vault_id);
 			T::PriceProvider::get_btc_price_in_market_microgons(securitized_satoshis)
 				.unwrap_or_default()
 		}

--- a/pallets/treasury/src/mock.rs
+++ b/pallets/treasury/src/mock.rs
@@ -179,6 +179,7 @@ parameter_types! {
 
 #[derive(Clone)]
 pub struct TestVault {
+	pub securitization: Balance,
 	pub securitized_satoshis: Satoshis,
 	pub sharing_percent: Permill,
 	pub bonus_percent: Permill,
@@ -228,10 +229,10 @@ impl TreasuryVaultProvider for StaticTreasuryVaultProvider {
 	type Balance = Balance;
 	type AccountId = TestAccountId;
 
-	fn get_securitized_satoshis(vault_id: VaultId) -> Satoshis {
+	fn get_securitization_and_securitized_satoshis(vault_id: VaultId) -> (Self::Balance, Satoshis) {
 		VaultsById::get()
 			.get(&vault_id)
-			.map(|a| a.securitized_satoshis)
+			.map(|vault| (vault.securitization, vault.securitized_satoshis))
 			.unwrap_or_default()
 	}
 

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -45,6 +45,7 @@ fn argonot_bond_lots() -> Vec<BondLotSummary> {
 fn test_vault(account_id: u64, securitized_satoshis: u64, sharing_percent: Permill) -> TestVault {
 	TestVault {
 		account_id: account(account_id),
+		securitization: 0,
 		securitized_satoshis,
 		sharing_percent,
 		bonus_percent: Permill::zero(),
@@ -76,6 +77,44 @@ fn bonus_approval(
 		backfill_bonds_to_unreserve,
 		signature,
 	}
+}
+
+#[test]
+fn buy_bonds_uses_greater_of_vault_securitization_and_securitized_bitcoin_value() {
+	new_test_ext().execute_with(|| {
+		MinimumArgonsPerContributor::set(1);
+
+		let mut securitization_funded_vault =
+			test_vault(10, (4 * MICROGONS_PER_ARGON) as u64, Permill::zero());
+		securitization_funded_vault.securitization = 6 * MICROGONS_PER_ARGON;
+		insert_vault(1, securitization_funded_vault);
+
+		let mut bitcoin_funded_vault =
+			test_vault(11, (6 * MICROGONS_PER_ARGON) as u64, Permill::zero());
+		bitcoin_funded_vault.securitization = 4 * MICROGONS_PER_ARGON;
+		insert_vault(2, bitcoin_funded_vault);
+
+		set_argons(2, 7 * MICROGONS_PER_ARGON);
+		set_argons(3, 7 * MICROGONS_PER_ARGON);
+
+		assert_ok!(Treasury::buy_bonds(origin(2), 1, 6, None));
+		assert_noop!(
+			Treasury::buy_bonds(origin(2), 1, 1, None),
+			Error::<Test>::BondPurchaseAboveSecurity
+		);
+
+		assert_ok!(Treasury::buy_bonds(origin(3), 2, 6, None));
+		assert_noop!(
+			Treasury::buy_bonds(origin(3), 2, 1, None),
+			Error::<Test>::BondPurchaseAboveSecurity
+		);
+
+		Treasury::lock_in_vault_capital(1);
+
+		let frame = CurrentFrameVaultCapital::<Test>::get().expect("frame capital");
+		assert_eq!(frame.vaults.get(&1).map(|vault| vault.eligible_bonds), Some(4));
+		assert_eq!(frame.vaults.get(&2).map(|vault| vault.eligible_bonds), Some(6));
+	});
 }
 
 #[test]

--- a/pallets/vaults/src/lib.rs
+++ b/pallets/vaults/src/lib.rs
@@ -18,8 +18,10 @@ pub mod weights;
 
 /// The Vaults pallet allows a user to fund BitcoinLocks for bitcoin holders. This allows them to
 /// participate in treasury pools. Vaults can define the number of Argons available for bitcoin
-/// locks and the terms of both bitcoin locks and treasury pools. However, bonded argons for
-/// Treasury may only be issued up to the amount of locked bitcoin.
+/// locks and the terms of both bitcoin locks and treasury pools. A Treasury pool can accept bonded
+/// argons up to the greater of the vault's securitization or its effective Bitcoin-backed value.
+/// Bonds above the effective Bitcoin-backed value do not participate in frame earnings until that
+/// capacity grows.
 ///
 /// ** Activated Securitization **
 /// A vault can create treasury pools up to 2x the locked securitization used for Bitcoin. This
@@ -1413,9 +1415,11 @@ pub mod pallet {
 		type Balance = T::Balance;
 		type AccountId = T::AccountId;
 
-		fn get_securitized_satoshis(vault_id: VaultId) -> Satoshis {
+		fn get_securitization_and_securitized_satoshis(
+			vault_id: VaultId,
+		) -> (Self::Balance, Satoshis) {
 			VaultsById::<T>::get(vault_id)
-				.map(|a| a.effective_securitized_satoshis())
+				.map(|vault| (vault.securitization, vault.effective_securitized_satoshis()))
 				.unwrap_or_default()
 		}
 

--- a/primitives/src/vault.rs
+++ b/primitives/src/vault.rs
@@ -154,8 +154,9 @@ pub trait TreasuryVaultProvider {
 	type Balance: Codec;
 	type AccountId: Codec;
 
-	/// Get the number of securitized satoshis tracked by the vault.
-	fn get_securitized_satoshis(vault_id: VaultId) -> Satoshis;
+	/// Get the vault securitization and effective securitized satoshis eligible as
+	/// Bitcoin-backed Treasury capacity.
+	fn get_securitization_and_securitized_satoshis(vault_id: VaultId) -> (Self::Balance, Satoshis);
 
 	fn get_vault_operator(vault_id: VaultId) -> Option<Self::AccountId>;
 	fn get_vault_delegate(vault_id: VaultId) -> Option<Self::AccountId>;


### PR DESCRIPTION
## Summary

Bonders can enter a vault pool as soon as the vault has securitization instead of waiting for matching Bitcoin locks. Purchase capacity uses the greater of vault securitization or effective securitized Bitcoin value, while frame earnings remain capped by effective Bitcoin backing. This improves immediate bond availability but can temporarily dilute earnings per bond when admitted bond supply exceeds Bitcoin-backed capacity.

The runtime version is intentionally unchanged; the next release will carry the normal version bump.

## Validation

- Covered both capacity branches and confirmed that six admitted bonds remain only four-bond frame eligible when Bitcoin backing is four.
- The 33-test treasury suite and the vault and runtime-benchmark provider compile checks pass.
