### PR TITLE
fix(nodejs): bundle EVM contract declarations

### DIFF
--- a/client/nodejs/package.json
+++ b/client/nodejs/package.json
@@ -14,11 +14,14 @@
   "homepage": "https://github.com/argonprotocol/mainchain#readme",
   "scripts": {
     "build": "yarn generate:defs && yarn generate:meta && node clean-build.js && yarn tsc",
+    "generate:contract-declarations": "tsc -p tsconfig.contracts.json",
     "generate:defs": "polkadot-types-from-defs --endpoint metadata.json --input ./src/interfaces --package @argonprotocol/mainchain/interfaces",
     "generate:meta": "polkadot-types-from-chain --endpoint metadata.json --output ./src/interfaces --package @argonprotocol/mainchain/interfaces --strict",
     "test": "vitest --run --config vitest.config.ts",
-    "tsc": "yarn workspace @argonprotocol/ethereum-contracts build && tsup",
-    "watch": "tsup --watch",
+    "tsc": "yarn workspace @argonprotocol/ethereum-contracts build && yarn generate:contract-declarations && tsup && yarn validate:package",
+    "tsup": "yarn tsc",
+    "validate:package": "tsx src/scripts/validatePackage.ts",
+    "watch": "yarn generate:contract-declarations && tsup --watch",
     "typecheck": "tsc --noEmit -p tsconfig.test.json"
   },
   "files": [

--- a/client/nodejs/src/BitcoinLock.ts
+++ b/client/nodejs/src/BitcoinLock.ts
@@ -2,6 +2,8 @@ import {
   ArgonClient,
   ArgonPrimitivesBitcoinBitcoinNetwork,
   ArgonPrimitivesBitcoinUtxoRef,
+  FIXED_U128_DECIMALS,
+  fromFixedNumber,
   getBigIntFallback,
 } from './index';
 import { GenericEvent } from '@polkadot/types';
@@ -63,6 +65,7 @@ export class BitcoinLock implements IBitcoinLock {
   public lockedTargetPrice: bigint;
   public liquidityPromised: bigint;
   public ownerAccount: string;
+  public securitizationRatio: number;
   public satoshis: bigint;
   public utxoSatoshis?: bigint;
   public vaultPubkey: string;
@@ -90,6 +93,7 @@ export class BitcoinLock implements IBitcoinLock {
     this.lockedTargetPrice = data.lockedTargetPrice;
     this.liquidityPromised = data.liquidityPromised;
     this.ownerAccount = data.ownerAccount;
+    this.securitizationRatio = data.securitizationRatio;
     this.satoshis = data.satoshis;
     this.utxoSatoshis = data.utxoSatoshis;
     this.vaultPubkey = data.vaultPubkey;
@@ -645,6 +649,10 @@ export class BitcoinLock implements IBitcoinLock {
     ]);
     const liquidityPromised = utxo.liquidityPromised.toBigInt();
     const ownerAccount = utxo.ownerAccount.toHuman();
+    const securitizationRatio = fromFixedNumber(
+      utxo.securitizationRatio.toBigInt(),
+      FIXED_U128_DECIMALS,
+    ).toNumber();
     const satoshis = utxo.satoshis.toBigInt();
     const utxoSatoshis = utxo.utxoSatoshis?.isSome ? utxo.utxoSatoshis.value.toBigInt() : undefined;
     const vaultPubkey = utxo.vaultPubkey.toHex();
@@ -676,6 +684,7 @@ export class BitcoinLock implements IBitcoinLock {
       lockedTargetPrice,
       liquidityPromised,
       ownerAccount,
+      securitizationRatio,
       satoshis,
       utxoSatoshis,
       vaultPubkey,
@@ -915,6 +924,7 @@ export interface IBitcoinLock {
   lockedTargetPrice: bigint;
   liquidityPromised: bigint;
   ownerAccount: string;
+  securitizationRatio: number;
   satoshis: bigint;
   utxoSatoshis?: bigint;
   vaultPubkey: string;

--- a/client/nodejs/src/EvmContracts.ts
+++ b/client/nodejs/src/EvmContracts.ts
@@ -1,21 +1,32 @@
 import type { Abi, Hex } from 'viem';
 import {
+  MINTING_GATEWAY_RUNTIME_DECIMALS,
+  MINTING_GATEWAY_RUNTIME_TO_ERC20_SCALE,
+  MINTING_GATEWAY_TOKEN_DECIMALS,
+  argonTokenArtifact as rawArgonTokenArtifact,
+  argonotTokenArtifact as rawArgonotTokenArtifact,
+  mintingGatewayArtifact as rawMintingGatewayArtifact,
+  proxyAdminArtifact as rawProxyAdminArtifact,
+  transparentUpgradeableProxyArtifact as rawTransparentUpgradeableProxyArtifact,
+} from '@argonprotocol/ethereum-contracts';
+import {
   ArgonTokenEvents,
   ArgonotTokenEvents,
   CanonicalMintableBurnableERC20Events,
   ICanonicalTokenEvents,
-  MINTING_GATEWAY_RUNTIME_DECIMALS,
-  MINTING_GATEWAY_RUNTIME_TO_ERC20_SCALE,
-  MINTING_GATEWAY_TOKEN_DECIMALS,
-  MINTING_GATEWAY_UPDATE_KINDS,
   MintingGatewayEvents,
   ProxyAdminEvents,
   TransparentUpgradeableProxyEvents,
   argonTokenAbi,
-  argonTokenArtifact as rawArgonTokenArtifact,
   argonotTokenAbi,
-  argonotTokenArtifact as rawArgonotTokenArtifact,
   canonicalMintableBurnableErc20Abi,
+  iCanonicalTokenAbi,
+  mintingGatewayAbi,
+  proxyAdminAbi,
+  transparentUpgradeableProxyAbi,
+} from '@argonprotocol/ethereum-contracts/generated';
+import {
+  MINTING_GATEWAY_UPDATE_KINDS,
   encodeMintingGatewayCouncilSnapshot,
   encodeMintingGatewayGlobalIssuanceCouncilRotateTarget,
   encodeMintingGatewayMintingAuthorityActivationTarget,
@@ -29,16 +40,10 @@ import {
   hashMintingGatewayRotateGlobalIssuanceCouncil,
   hashMintingGatewayRotateGlobalIssuanceCouncilApproval,
   hashMintingGatewayTransferOutOfArgonRequest as rawHashMintingGatewayTransferOutOfArgonRequest,
-  iCanonicalTokenAbi,
-  mintingGatewayAbi,
-  mintingGatewayArtifact as rawMintingGatewayArtifact,
-  proxyAdminAbi,
-  proxyAdminArtifact as rawProxyAdminArtifact,
-  transparentUpgradeableProxyAbi,
-  transparentUpgradeableProxyArtifact as rawTransparentUpgradeableProxyArtifact,
-} from '@argonprotocol/ethereum-contracts';
+} from '@argonprotocol/ethereum-contracts/hashing';
 
-export type * from '@argonprotocol/ethereum-contracts';
+export type * from '@argonprotocol/ethereum-contracts/generated';
+export type * from '@argonprotocol/ethereum-contracts/hashing';
 
 export type EvmContractArtifact = {
   abi: Abi;

--- a/client/nodejs/src/TxSubmitter.ts
+++ b/client/nodejs/src/TxSubmitter.ts
@@ -1,7 +1,7 @@
 import { waitForLoad } from './index';
 import type { ArgonClient } from './index';
+import type { SignerOptions } from '@polkadot/api-base/types';
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
-import type { SignerOptions } from '@polkadot/api/types';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import { ITxProgressCallback, TxResult } from './TxResult';
 

--- a/client/nodejs/src/__test__/TxSubmitter.test.ts
+++ b/client/nodejs/src/__test__/TxSubmitter.test.ts
@@ -1,5 +1,11 @@
-import { TxSubmitter } from '../TxSubmitter';
+import { TxSubmitter, type ISubmittableOptions } from '../TxSubmitter';
 import { expect, it, vi } from 'vitest';
+
+it('accepts numeric mortal eras', () => {
+  const options: ISubmittableOptions = { era: 64 };
+
+  expect(options.era).toBe(64);
+});
 
 it('supports external signers via address+signer', async () => {
   const address = '5G9v3eN9y1xS7G8fFqL3J4d4G2fG1m3wZ7kH9n1Y2x3p4q5r';

--- a/client/nodejs/src/scripts/validatePackage.ts
+++ b/client/nodejs/src/scripts/validatePackage.ts
@@ -1,0 +1,60 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const packageRoot = path.resolve(import.meta.dirname, '..', '..');
+const yarnPath = process.env.npm_execpath;
+
+if (!yarnPath) {
+  throw new Error('Yarn executable path is unavailable');
+}
+
+const packOutput = execFileSync(yarnPath, ['pack', '--dry-run', '--json'], {
+  cwd: packageRoot,
+  encoding: 'utf8',
+});
+const packedFiles = new Set(
+  packOutput
+    .trim()
+    .split('\n')
+    .map(line => (JSON.parse(line) as { location?: string }).location)
+    .filter(location => location !== undefined)
+    .map(location => location.replaceAll(path.win32.sep, path.posix.sep)),
+);
+const declarationFiles = [...packedFiles].filter(file => /\.d\.(?:c|m)?ts$/.test(file));
+const missingImports = new Set<string>();
+
+for (const declarationFile of declarationFiles) {
+  const declaration = readFileSync(path.join(packageRoot, declarationFile), 'utf8');
+  const imports = ts.preProcessFile(declaration, true, true).importedFiles;
+
+  for (const { fileName } of imports) {
+    if (!fileName.startsWith('.')) continue;
+
+    const resolvedImport = path.posix.normalize(
+      path.posix.join(path.posix.dirname(declarationFile), fileName),
+    );
+    const candidates = [resolvedImport];
+
+    if (resolvedImport.endsWith('.js')) {
+      candidates.push(resolvedImport.replace(/\.js$/, '.d.ts'));
+    } else if (resolvedImport.endsWith('.cjs')) {
+      candidates.push(resolvedImport.replace(/\.cjs$/, '.d.cts'));
+    } else if (resolvedImport.endsWith('.mjs')) {
+      candidates.push(resolvedImport.replace(/\.mjs$/, '.d.mts'));
+    } else if (!path.posix.extname(resolvedImport)) {
+      candidates.push(`${resolvedImport}.d.ts`, `${resolvedImport}/index.d.ts`);
+    }
+
+    if (!candidates.some(candidate => packedFiles.has(candidate))) {
+      missingImports.add(`${declarationFile}: ${fileName}`);
+    }
+  }
+}
+
+if (missingImports.size) {
+  throw new Error(
+    `Packed declarations contain unresolved relative imports:\n${[...missingImports].join('\n')}`,
+  );
+}

--- a/client/nodejs/tsconfig.contracts.json
+++ b/client/nodejs/tsconfig.contracts.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../chains/ethereum/contracts/tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": ".contract-declarations",
+    "rootDir": "../../chains/ethereum/contracts",
+    "types": []
+  },
+  "include": [
+    "../../chains/ethereum/contracts/generated.ts",
+    "../../chains/ethereum/contracts/hashing.ts"
+  ]
+}

--- a/client/nodejs/tsup.config.ts
+++ b/client/nodejs/tsup.config.ts
@@ -10,6 +10,12 @@ const contractArtifacts = [
   'artifacts/contracts/ProxyArtifacts.sol/TransparentUpgradeableProxy.json',
 ] as const;
 
+// Bundle contract types from TypeScript's declaration output; tsup cannot parse generated.ts directly.
+const contractDeclarationPaths = {
+  '@argonprotocol/ethereum-contracts/generated': ['.contract-declarations/generated.d.ts'],
+  '@argonprotocol/ethereum-contracts/hashing': ['.contract-declarations/hashing.d.ts'],
+};
+
 async function copyContractArtifacts(outDir: 'lib' | 'browser') {
   const contractsRoot = resolve('..', '..', 'chains', 'ethereum', 'contracts');
 
@@ -25,6 +31,7 @@ export default defineConfig([
     entry: ['src/index.ts'],
     dts: {
       compilerOptions: {
+        paths: contractDeclarationPaths,
         rootDir: '.',
       },
       resolve: ['@argonprotocol/ethereum-contracts'],
@@ -52,6 +59,7 @@ export default defineConfig([
     external: ['@polkadot/types/lookup'],
     dts: {
       compilerOptions: {
+        paths: contractDeclarationPaths,
         rootDir: '.',
       },
       resolve: ['@argonprotocol/ethereum-contracts'],


### PR DESCRIPTION
## Summary

Published Node client consumers now receive complete types for the existing `EvmContracts` namespace, so generated ABIs and hashing helpers no longer degrade to TypeScript's error type.

Contract declarations are emitted and bundled into the ESM, CommonJS, and browser declaration entries. The package build also validates the dry-run tarball so relative declaration imports cannot point to files missing from the published artifact.

## Validation

- Built and packed `@argonprotocol/mainchain`
- Compiled and type-aware linted a fresh consumer against the packed tarball
- Ran the focused EVM contracts tests and Node client typecheck
