### PR TITLE
increase-minimum-canary-argons

### DIFF
--- a/runtime/canary/src/lib.rs
+++ b/runtime/canary/src/lib.rs
@@ -412,7 +412,7 @@ impl Get<Tick> for TicksSinceGenesis {
 }
 
 parameter_types! {
-	pub const MinimumArgonsPerContributor: Balance = ARGON; // 1 argons minimum
+	pub const MinimumArgonsPerContributor: Balance = 10 * ARGON; // 10 argons minimum
 	pub const MaxPendingUnlocksPerFrame: u32 = 1000;
 	pub const TreasuryExitDelayFrames: FrameId = 10;
 }


### PR DESCRIPTION
Increase the MinimumArgonsPerContributor on canary from 1 to 10. Using a value of 1 was making it difficult to know whether the Min/Max was actually working in the dev-docker UI.