### PR TITLE
fix(nodejs): run package validation on Windows

### DIFF
--- a/client/nodejs/src/scripts/validatePackage.ts
+++ b/client/nodejs/src/scripts/validatePackage.ts
@@ -1,16 +1,10 @@
-import { execFileSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import ts from 'typescript';
 
 const packageRoot = path.resolve(import.meta.dirname, '..', '..');
-const yarnPath = process.env.npm_execpath;
-
-if (!yarnPath) {
-  throw new Error('Yarn executable path is unavailable');
-}
-
-const packOutput = execFileSync(yarnPath, ['pack', '--dry-run', '--json'], {
+const packOutput = execSync('yarn pack --dry-run --json', {
   cwd: packageRoot,
   encoding: 'utf8',
 });


### PR DESCRIPTION
Node.js binding builds can validate the published package on Windows again. Yarn now resolves through the platform shell, so Windows can execute its `.cmd` shim instead of trying the extensionless temporary `npm_execpath` path. The existing packed-declaration validation remains unchanged on other platforms.

Related: [failing Windows CI job](https://github.com/argonprotocol/mainchain/actions/runs/30718635458/job/91419635537)
