### PR TITLE
fix(operations): reconcile funded bitcoin accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "pallet-mint",
  "pallet-notaries",
  "pallet-notebook",
+ "pallet-operational-accounts",
  "pallet-prelude",
  "pallet-price-index",
  "pallet-ticks",

--- a/pallets/operational_accounts/src/lib.rs
+++ b/pallets/operational_accounts/src/lib.rs
@@ -1003,8 +1003,10 @@ pub mod pallet {
 				operational_account,
 				T::MinimumUniswapTransfer::get(),
 			);
-			let has_account_bitcoin =
-				operational_account.account_bitcoin_amount >= T::MinimumBitcoin::get();
+			let has_account_bitcoin = Self::meets_amount_with_rounding_tolerance(
+				operational_account.account_bitcoin_amount,
+				T::MinimumBitcoin::get(),
+			);
 			let has_account_vault_bonds =
 				operational_account.account_vault_bond_amount >= T::MinimumBonds::get();
 
@@ -1017,8 +1019,10 @@ pub mod pallet {
 					operational_account,
 					T::OperationalMinimumUniswapTransfer::get(),
 				);
-			let has_vault_securitization = Self::vault_amount(operational_account) >=
-				T::OperationalMinimumVaultSecuritization::get();
+			let has_vault_securitization = Self::meets_amount_with_rounding_tolerance(
+				Self::vault_amount(operational_account),
+				T::OperationalMinimumVaultSecuritization::get(),
+			);
 			let has_mining_seats =
 				Self::mining_seat_count(operational_account) >= T::MiningSeatsForOperational::get();
 
@@ -1037,6 +1041,12 @@ pub mod pallet {
 				Self::deposit_event(Event::AccountMeetsMinimums { account: owner.clone() });
 			}
 			meets_minimums
+		}
+
+		fn meets_amount_with_rounding_tolerance(amount: T::Balance, minimum: T::Balance) -> bool {
+			let tolerance = T::Balance::from(MICROGONS_PER_ARGON);
+
+			amount >= minimum.saturating_sub(tolerance)
 		}
 
 		fn award_accrued_access_code(account: &mut OperationalAccount<T>) {

--- a/pallets/operational_accounts/src/migrations/mod.rs
+++ b/pallets/operational_accounts/src/migrations/mod.rs
@@ -1,1 +1,141 @@
+use crate::{Config, OperationalAccounts, Pallet};
+use argon_primitives::{BitcoinLocksProvider, BitcoinLocksProviderWeightInfo};
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+use pallet_prelude::*;
 
+#[cfg(feature = "try-runtime")]
+use alloc::vec::Vec;
+#[cfg(feature = "try-runtime")]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use frame_support::ensure;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+
+pub struct ReconcileAccountBitcoinAmounts<T>(core::marker::PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for ReconcileAccountBitcoinAmounts<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		let expected_amounts = OperationalAccounts::<T>::iter()
+			.map(|(owner, account)| {
+				let amount = T::BitcoinLocksProvider::get_account_funded_bitcoin_amount(
+					&account.vault_account,
+				);
+				(owner, amount)
+			})
+			.collect::<Vec<_>>();
+
+		Ok(expected_amounts.encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		let mut weight = Weight::zero();
+		let mut account_reads = 0u64;
+		let mut account_writes = 0u64;
+
+		for (owner, mut account) in OperationalAccounts::<T>::iter() {
+			account_reads.saturating_accrue(1);
+			let funded_amount =
+				T::BitcoinLocksProvider::get_account_funded_bitcoin_amount(&account.vault_account);
+			weight.saturating_accrue(<T::BitcoinLocksProvider as BitcoinLocksProvider<
+				T::AccountId,
+				T::Balance,
+			>>::Weights::get_account_funded_bitcoin_amount());
+
+			if account.account_bitcoin_amount == funded_amount {
+				continue;
+			}
+
+			account.account_bitcoin_amount = funded_amount;
+			OperationalAccounts::<T>::insert(owner, account);
+			account_writes.saturating_accrue(1);
+		}
+
+		weight.saturating_add(T::DbWeight::get().reads_writes(account_reads, account_writes))
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+		let expected_amounts = <Vec<(T::AccountId, T::Balance)>>::decode(&mut state.as_slice())
+			.map_err(|_| TryRuntimeError::Other("could not decode bitcoin reconciliation state"))?;
+		for (owner, expected_amount) in expected_amounts {
+			let account = OperationalAccounts::<T>::get(owner).ok_or(TryRuntimeError::Other(
+				"operational account was removed during bitcoin reconciliation",
+			))?;
+			ensure!(
+				account.account_bitcoin_amount == expected_amount,
+				TryRuntimeError::Other("operational account bitcoin amount was not reconciled"),
+			);
+		}
+
+		Ok(())
+	}
+}
+
+pub type ReconcileAccountBitcoinAmountsMigration<T> = frame_support::migrations::VersionedMigration<
+	3,
+	4,
+	ReconcileAccountBitcoinAmounts<T>,
+	Pallet<T>,
+	<T as frame_system::Config>::DbWeight,
+>;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{mock::*, OpaqueEncryptionPubkey, OperationalAccount};
+	use frame_support::traits::{OnRuntimeUpgrade, StorageVersion};
+
+	#[test]
+	fn reconciles_each_account_to_its_linked_vault_funded_total() {
+		new_test_ext().execute_with(|| {
+			let owner = TestAccountId::new([1; 32]);
+			let vault_account = TestAccountId::new([2; 32]);
+			let funded_total = 1_999_999_932;
+			record_funded_bitcoin_amount(&vault_account, funded_total);
+			crate::OperationalAccounts::<Test>::insert(
+				&owner,
+				OperationalAccount::<Test> {
+					vault_account,
+					mining_account: TestAccountId::new([3; 32]),
+					encryption_pubkey: OpaqueEncryptionPubkey([0; 32]),
+					upstream_account: None,
+					name: None,
+					last_name_change_tick: None,
+					uniswap_argon_transfers_in_amount: 0,
+					account_bitcoin_amount: 0,
+					account_vault_bond_amount: 0,
+					vault_created: false,
+					vault_bitcoin_accrual: 0,
+					vault_bitcoin_applied_total: 0,
+					mining_seat_accrual: 0,
+					mining_seat_applied_total: 0,
+					operational_certifications_count: 0,
+					available_access_codes: 0,
+					rewards_earned_count: 0,
+					rewards_earned_amount: 0,
+					rewards_collected_amount: 0,
+					is_operationally_certified: false,
+				},
+			);
+			StorageVersion::new(3).put::<Pallet<Test>>();
+
+			#[cfg(feature = "try-runtime")]
+			let state = ReconcileAccountBitcoinAmountsMigration::<Test>::pre_upgrade()
+				.expect("pre-upgrade checks");
+			ReconcileAccountBitcoinAmountsMigration::<Test>::on_runtime_upgrade();
+			#[cfg(feature = "try-runtime")]
+			ReconcileAccountBitcoinAmountsMigration::<Test>::post_upgrade(state)
+				.expect("post-upgrade checks");
+
+			assert_eq!(
+				crate::OperationalAccounts::<Test>::get(&owner)
+					.expect("operational account")
+					.account_bitcoin_amount,
+				funded_total
+			);
+			assert_eq!(StorageVersion::get::<Pallet<Test>>(), 4);
+		});
+	}
+}

--- a/pallets/operational_accounts/src/mock.rs
+++ b/pallets/operational_accounts/src/mock.rs
@@ -3,7 +3,7 @@ use argon_primitives::{
 	tick::Ticker,
 	vault::{BitcoinVaultProvider, RegistrationVaultData},
 	BitcoinLocksProvider, MiningSlotProvider, OperationalRewardsPayer, TickProvider,
-	TreasuryPoolProvider, UniswapTransferProvider, VotingSchedule,
+	TreasuryPoolProvider, UniswapTransferProvider, VotingSchedule, MICROGONS_PER_ARGON,
 };
 use frame_support::traits::{
 	fungible::{Inspect, Mutate},
@@ -92,10 +92,10 @@ parameter_types! {
 	pub const MaxAvailableAccessCodes: u32 = 2;
 	pub const MaxAccessCodeAwardsPerFrame: u32 = 2;
 	pub const MinimumUniswapTransfer: Balance = 250;
-	pub const MinimumBitcoin: Balance = 500;
+	pub const MinimumBitcoin: Balance = 2_000 * MICROGONS_PER_ARGON;
 	pub const MinimumBonds: Balance = 200;
 	pub const OperationalMinimumUniswapTransfer: Balance = 3_000;
-	pub const OperationalMinimumVaultSecuritization: Balance = 2_000;
+	pub const OperationalMinimumVaultSecuritization: Balance = 2_000 * MICROGONS_PER_ARGON;
 	pub const BitcoinLockSizeForAccessCode: Balance = 5_000;
 	pub const MiningSeatsForOperational: u32 = 2;
 	pub const MiningSeatsPerAccessCode: u32 = 5;

--- a/pallets/operational_accounts/src/tests.rs
+++ b/pallets/operational_accounts/src/tests.rs
@@ -154,6 +154,42 @@ fn test_register_requires_minimums() {
 }
 
 #[test]
+fn test_register_allows_one_argon_bitcoin_shortfall_but_not_more() {
+	new_test_ext().execute_with(|| {
+		let within_tolerance = make_account_set(201, 202, 203);
+		record_microgons_in(&within_tolerance.owner, MinimumUniswapTransfer::get());
+		record_account_bitcoin(
+			&within_tolerance.vault,
+			MinimumBitcoin::get().saturating_sub(Balance::from(MICROGONS_PER_ARGON)),
+		);
+		record_account_vault_bond_amount(&within_tolerance.vault, MinimumBonds::get());
+
+		assert_ok!(OperationalAccountsPallet::register(
+			RuntimeOrigin::signed(within_tolerance.owner.clone()),
+			within_tolerance.registration(None),
+		));
+
+		let beyond_tolerance = make_account_set(205, 206, 207);
+		record_microgons_in(&beyond_tolerance.owner, MinimumUniswapTransfer::get());
+		record_account_bitcoin(
+			&beyond_tolerance.vault,
+			MinimumBitcoin::get()
+				.saturating_sub(Balance::from(MICROGONS_PER_ARGON))
+				.saturating_sub(1),
+		);
+		record_account_vault_bond_amount(&beyond_tolerance.vault, MinimumBonds::get());
+
+		assert_noop!(
+			OperationalAccountsPallet::register(
+				RuntimeOrigin::signed(beyond_tolerance.owner.clone()),
+				beyond_tolerance.registration(None),
+			),
+			Error::<Test>::MinimumsNotMet
+		);
+	});
+}
+
+#[test]
 fn test_referred_operational_account_replenishes_upstream_access_code() {
 	new_test_ext().execute_with(|| {
 		let upstream_set = make_account_set(9, 10, 11);
@@ -791,6 +827,61 @@ fn test_activate_requires_current_minimums() {
 		assert_noop!(
 			OperationalAccountsPallet::activate(RuntimeOrigin::signed(account_set.mining.clone())),
 			Error::<Test>::MinimumsNotMet
+		);
+	});
+}
+
+#[test]
+fn test_activate_allows_one_argon_vault_shortfall_but_not_more() {
+	new_test_ext().execute_with(|| {
+		let within_tolerance = make_account_set(209, 210, 211);
+		register_account(&within_tolerance, None);
+		set_registration_lookup(
+			within_tolerance.vault.clone(),
+			within_tolerance.mining.clone(),
+			MinimumBitcoin::get(),
+			OperationalMinimumVaultSecuritization::get()
+				.saturating_sub(Balance::from(MICROGONS_PER_ARGON)),
+			MinimumBonds::get(),
+			0,
+		);
+		OperationalAccountsPallet::vault_created(&within_tolerance.vault);
+		set_linked_account_uniswap_argon_transfers_in_amount(
+			&within_tolerance.vault,
+			OperationalMinimumUniswapTransfer::get().saturating_sub(MinimumUniswapTransfer::get()),
+		);
+		OperationalAccountsPallet::mining_seat_won(&within_tolerance.mining);
+		OperationalAccountsPallet::mining_seat_won(&within_tolerance.mining);
+
+		assert_ok!(OperationalAccountsPallet::activate(RuntimeOrigin::signed(
+			within_tolerance.owner.clone(),
+		)));
+
+		let beyond_tolerance = make_account_set(213, 214, 215);
+		register_account(&beyond_tolerance, None);
+		set_registration_lookup(
+			beyond_tolerance.vault.clone(),
+			beyond_tolerance.mining.clone(),
+			MinimumBitcoin::get(),
+			OperationalMinimumVaultSecuritization::get()
+				.saturating_sub(Balance::from(MICROGONS_PER_ARGON))
+				.saturating_sub(1),
+			MinimumBonds::get(),
+			0,
+		);
+		OperationalAccountsPallet::vault_created(&beyond_tolerance.vault);
+		set_linked_account_uniswap_argon_transfers_in_amount(
+			&beyond_tolerance.vault,
+			OperationalMinimumUniswapTransfer::get().saturating_sub(MinimumUniswapTransfer::get()),
+		);
+		OperationalAccountsPallet::mining_seat_won(&beyond_tolerance.mining);
+		OperationalAccountsPallet::mining_seat_won(&beyond_tolerance.mining);
+
+		assert_noop!(
+			OperationalAccountsPallet::activate(RuntimeOrigin::signed(
+				beyond_tolerance.owner.clone(),
+			)),
+			Error::<Test>::NotEligibleForActivation
 		);
 	});
 }

--- a/pallets/vaults/src/migrations/mod.rs
+++ b/pallets/vaults/src/migrations/mod.rs
@@ -119,10 +119,6 @@ where
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
 		ensure!(
-			StorageVersion::get::<Pallet<T>>() == 16,
-			TryRuntimeError::Other("vault storage version must be 16 before profile migration"),
-		);
-		ensure!(
 			StorageVersion::get::<pallet_operational_accounts::Pallet<T>>() == 3,
 			TryRuntimeError::Other(
 				"operational account storage version must be 3 before profile migration",
@@ -236,26 +232,14 @@ where
 			})
 		});
 
-		frame_support::traits::StorageVersion::new(17).put::<Pallet<T>>();
 		T::DbWeight::get().reads_writes(
 			operational_account_count.saturating_add(vault_count.saturating_mul(3)),
-			operational_account_count
-				.saturating_add(vault_count.saturating_mul(2))
-				.saturating_add(1),
+			operational_account_count.saturating_add(vault_count.saturating_mul(2)),
 		)
 	}
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
-		ensure!(
-			StorageVersion::get::<Pallet<T>>() == 17,
-			TryRuntimeError::Other("vault storage version was not updated"),
-		);
-		ensure!(
-			StorageVersion::get::<pallet_operational_accounts::Pallet<T>>() == 4,
-			TryRuntimeError::Other("operational account storage version was not updated"),
-		);
-
 		let (expected_operational_account_count, expected_vault_count, expected_named_count) =
 			<(u64, u64, u64)>::decode(&mut state.as_slice())
 				.map_err(|_| TryRuntimeError::Other("could not decode profile migration state"))?;
@@ -289,17 +273,16 @@ where
 			!has_uncleared_access_code_progress,
 			TryRuntimeError::Other("access code progress was not reset"),
 		);
-
 		Ok(())
 	}
 }
 
 pub type MoveVaultNameToOperationalAccountProfileMigration<T> =
 	frame_support::migrations::VersionedMigration<
-		3,
-		4,
+		16,
+		17,
 		MoveVaultNameToOperationalAccountProfile<T>,
-		pallet_operational_accounts::Pallet<T>,
+		Pallet<T>,
 		<T as frame_system::Config>::DbWeight,
 	>;
 
@@ -307,7 +290,7 @@ pub type MoveVaultNameToOperationalAccountProfileMigration<T> =
 mod test {
 	use super::*;
 	use crate::mock::{new_test_ext, Test};
-	use frame_support::{assert_ok, traits::OnRuntimeUpgrade};
+	use frame_support::traits::OnRuntimeUpgrade;
 
 	mod operational_v3 {
 		use super::*;
@@ -403,12 +386,8 @@ mod test {
 			StorageVersion::new(16).put::<Pallet<Test>>();
 			StorageVersion::new(3).put::<pallet_operational_accounts::Pallet<Test>>();
 
-			let state = MoveVaultNameToOperationalAccountProfileMigration::<Test>::pre_upgrade()
-				.expect("pre-upgrade checks");
-			let _ = MoveVaultNameToOperationalAccountProfileMigration::<Test>::on_runtime_upgrade();
-			assert_ok!(MoveVaultNameToOperationalAccountProfileMigration::<Test>::post_upgrade(
-				state
-			));
+			MoveVaultNameToOperationalAccountProfileMigration::<Test>::try_on_runtime_upgrade(true)
+				.expect("runtime upgrade checks");
 
 			let account = pallet_operational_accounts::OperationalAccounts::<Test>::get(owner)
 				.expect("migrated operational account");
@@ -437,7 +416,7 @@ mod test {
 			assert_eq!(pending_terms.treasury_profit_sharing, Permill::from_percent(20));
 			assert_eq!(vault.operational_minimum_release_tick, Some(111));
 			assert_eq!(StorageVersion::get::<Pallet<Test>>(), 17);
-			assert_eq!(StorageVersion::get::<pallet_operational_accounts::Pallet<Test>>(), 4);
+			assert_eq!(StorageVersion::get::<pallet_operational_accounts::Pallet<Test>>(), 3);
 		});
 	}
 }

--- a/runtime/argon/src/lib.rs
+++ b/runtime/argon/src/lib.rs
@@ -334,8 +334,10 @@ impl pallet_bitcoin_locks::Config for Runtime {
 	type Currency = Balances;
 	type Balance = Balance;
 	type RuntimeHoldReason = RuntimeHoldReason;
-	type LockEvents =
-		use_unless_benchmark!((Mint,), benchmarking::BenchmarkUtxoLockEvents<AccountId, Balance>);
+	type LockEvents = use_unless_benchmark!(
+		(Mint, OperationalAccounts),
+		benchmarking::BenchmarkUtxoLockEvents<AccountId, Balance>
+	);
 	type BitcoinUtxoTracker =
 		use_unless_benchmark!(BitcoinUtxos, benchmarking::BenchmarkBitcoinUtxoTracker);
 	type PriceProvider =

--- a/runtime/canary/src/lib.rs
+++ b/runtime/canary/src/lib.rs
@@ -336,8 +336,10 @@ impl pallet_bitcoin_locks::Config for Runtime {
 	type Currency = Balances;
 	type Balance = Balance;
 	type RuntimeHoldReason = RuntimeHoldReason;
-	type LockEvents =
-		use_unless_benchmark!((Mint,), benchmarking::BenchmarkUtxoLockEvents<AccountId, Balance>);
+	type LockEvents = use_unless_benchmark!(
+		(Mint, OperationalAccounts),
+		benchmarking::BenchmarkUtxoLockEvents<AccountId, Balance>
+	);
 	type BitcoinUtxoTracker =
 		use_unless_benchmark!(BitcoinUtxos, benchmarking::BenchmarkBitcoinUtxoTracker);
 	type PriceProvider =

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -70,6 +70,7 @@ pallet-fee-control = { workspace = true }
 pallet-treasury = { workspace = true }
 pallet-mining-slot = { workspace = true }
 pallet-price-index = { workspace = true }
+pallet-operational-accounts = { workspace = true }
 pallet-ticks = { workspace = true }
 pallet-mint = { workspace = true }
 pallet-vaults = { workspace = true }
@@ -102,6 +103,7 @@ std = [
 	"pallet-mint/std",
 	"pallet-notaries/std",
 	"pallet-notebook/std",
+	"pallet-operational-accounts/std",
 	"pallet-prelude/std",
 	"pallet-price-index/std",
 	"pallet-ticks/std",
@@ -128,6 +130,7 @@ runtime-benchmarks = [
 	"pallet-mint/runtime-benchmarks",
 	"pallet-notaries/runtime-benchmarks",
 	"pallet-notebook/runtime-benchmarks",
+	"pallet-operational-accounts/runtime-benchmarks",
 	"pallet-prelude/runtime-benchmarks",
 	"pallet-price-index/runtime-benchmarks",
 	"pallet-ticks/runtime-benchmarks",
@@ -151,6 +154,7 @@ try-runtime = [
 	"pallet-mint/try-runtime",
 	"pallet-notaries/try-runtime",
 	"pallet-notebook/try-runtime",
+	"pallet-operational-accounts/try-runtime",
 	"pallet-price-index/try-runtime",
 	"pallet-ticks/try-runtime",
 	"pallet-treasury/try-runtime",

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -157,6 +157,9 @@ macro_rules! inject_runtime_vars {
 		/// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 		type Migrations = (
 			pallet_vaults::migrations::MoveVaultNameToOperationalAccountProfileMigration<Runtime>,
+			pallet_operational_accounts::migrations::ReconcileAccountBitcoinAmountsMigration<
+				Runtime,
+			>,
 		);
 
 		/// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
## Summary

Operational certification now tracks funded Bitcoin after registration as locks are funded, ratcheted, or released. Existing operational accounts are reconciled from their linked vault's funded locks during the pending runtime 158 upgrade.

Bitcoin funding and live vault securitization checks also accept an inclusive one-ARGN rounding shortfall. Other certification thresholds remain unchanged.

The existing Vaults migration now owns only its v16 to v17 transition. A following Operational Accounts v3 to v4 migration owns the exact Bitcoin reconciliation.

## Validation

- `cargo make fmt`
- `cargo test -p pallet-operational-accounts --features try-runtime -- --nocapture`
- `cargo test -p pallet-vaults --features try-runtime moves_vault_name_into_operational_account_profile -- --nocapture`
- `cargo check -p argon-runtime -p argon-canary-runtime --features try-runtime,runtime-benchmarks`
