### PR TITLE
fix(operational-accounts): requeue ready upstream access code awards

### DIFF
--- a/pallets/operational_accounts/src/benchmarking.rs
+++ b/pallets/operational_accounts/src/benchmarking.rs
@@ -78,11 +78,18 @@ mod benchmarks {
 		reset_benchmark_operational_accounts_provider_call_counters();
 		IsOperationalAccountInviteOnly::<T>::put(false);
 		let caller = benchmark_account_id::<T>(BENCH_OPERATIONAL_ACCOUNT);
+		let upstream = linked_accounts_with_seed::<T>(1);
 		let operational_account_proof = benchmark_account_proof(BENCH_OPERATIONAL_SIGNATURE);
 		let vault = benchmark_account_id::<T>(BENCH_VAULT_ACCOUNT);
 		let mining = benchmark_account_id::<T>(BENCH_MINING_ACCOUNT);
 		let vault_proof = benchmark_account_proof(BENCH_VAULT_SIGNATURE);
 		let mining_proof = benchmark_account_proof(BENCH_MINING_ACCOUNT_SIGNATURE);
+		let mut upstream_account = default_operational_account::<T>(&upstream);
+		upstream_account.available_access_codes = T::MaxAvailableAccessCodes::get();
+		upstream_account.vault_bitcoin_accrual = T::BitcoinLockSizeForAccessCode::get();
+		upstream_account.mining_seat_accrual = T::MiningSeatsPerAccessCode::get();
+		upstream_account.is_operationally_certified = true;
+		insert_operational_account::<T>(&upstream, upstream_account);
 		#[cfg(test)]
 		{
 			let linked = LinkedAccounts::<T> {
@@ -106,7 +113,10 @@ mod benchmarks {
 			mining_account: mining.clone(),
 			vault_account_proof: vault_proof,
 			mining_account_proof: mining_proof,
-			access_proof: None,
+			access_proof: Some(UpstreamAccessProof {
+				upstream_account: upstream.owner.clone(),
+				signature: sr25519::Signature::from_raw([0u8; 64]).into(),
+			}),
 		});
 		whitelist_account!(caller);
 		#[extrinsic_call]
@@ -126,6 +136,7 @@ mod benchmarks {
 		assert!(!account.is_operationally_certified);
 		assert!(OperationalAccountBySubAccount::<T>::contains_key(vault));
 		assert!(OperationalAccountBySubAccount::<T>::contains_key(mining));
+		assert!(AccessCodeReadyAccounts::<T>::contains_key(&upstream.owner));
 		assert_provider_calls(BenchmarkOperationalAccountsProviderCallCounters {
 			get_registration_vault_data: 1,
 			get_account_funded_bitcoin_amount: 1,

--- a/pallets/operational_accounts/src/lib.rs
+++ b/pallets/operational_accounts/src/lib.rs
@@ -628,6 +628,7 @@ pub mod pallet {
 							return Err(Error::<T>::UpstreamHasNoAvailableAccessCodes);
 						}
 						upstream_account_data.available_access_codes.saturating_reduce(1);
+						Self::queue_access_code_if_ready(&upstream_account, upstream_account_data);
 
 						Ok(upstream_account.clone())
 					},

--- a/pallets/operational_accounts/src/tests.rs
+++ b/pallets/operational_accounts/src/tests.rs
@@ -332,7 +332,7 @@ fn test_register_records_upstream_account() {
 }
 
 #[test]
-fn test_access_registration_does_not_materialize_accrual_access_code() {
+fn test_access_registration_queues_ready_accrual_access_code() {
 	new_test_ext().execute_with(|| {
 		let upstream_set = make_account_set(48, 49, 50);
 		let downstream_set = make_account_set(51, 52, 53);
@@ -368,9 +368,6 @@ fn test_access_registration_does_not_materialize_accrual_access_code() {
 		assert_eq!(upstream_account.available_access_codes, 1);
 		assert_eq!(upstream_account.vault_bitcoin_accrual, bitcoin_threshold);
 		assert_eq!(upstream_account.mining_seat_accrual, MiningSeatsPerAccessCode::get());
-		assert!(!AccessCodeReadyAccounts::<Test>::contains_key(&upstream_set.owner));
-
-		OperationalAccountsPallet::mining_seat_won(&upstream_set.mining);
 		assert!(AccessCodeReadyAccounts::<Test>::contains_key(&upstream_set.owner));
 
 		<OperationalAccountsPallet as OnNewSlot<TestAccountId>>::on_frame_start(1);

--- a/runtime/argon/src/weights/pallet_operational_accounts.rs
+++ b/runtime/argon/src/weights/pallet_operational_accounts.rs
@@ -32,20 +32,24 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_operational_accounts`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for WeightInfo<T> {
-	/// Storage: `OperationalAccounts::OperationalAccounts` (r:1 w:1)
+	/// Storage: `OperationalAccounts::OperationalAccounts` (r:2 w:2)
 	/// Proof: `OperationalAccounts::OperationalAccounts` (`max_values`: None, `max_size`: Some(340), added: 2815, mode: `MaxEncodedLen`)
 	/// Storage: `OperationalAccounts::OperationalAccountBySubAccount` (r:3 w:2)
 	/// Proof: `OperationalAccounts::OperationalAccountBySubAccount` (`max_values`: None, `max_size`: Some(80), added: 2555, mode: `MaxEncodedLen`)
 	/// Storage: `OperationalAccounts::IsOperationalAccountInviteOnly` (r:1 w:0)
 	/// Proof: `OperationalAccounts::IsOperationalAccountInviteOnly` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
+	/// Storage: `OperationalAccounts::AccessCodeReadyAccounts` (r:1 w:1)
+	/// Proof: `OperationalAccounts::AccessCodeReadyAccounts` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+	/// Storage: `OperationalAccounts::CounterForAccessCodeReadyAccounts` (r:1 w:1)
+	/// Proof: `OperationalAccounts::CounterForAccessCodeReadyAccounts` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn register() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `5`
+		//  Measured:  `299`
 		//  Estimated: `8655`
-		// Minimum execution time: 120_000_000 picoseconds.
-		Weight::from_parts(123_000_000, 8655)
-			.saturating_add(T::DbWeight::get().reads(5))
-			.saturating_add(T::DbWeight::get().writes(3))
+		// Minimum execution time: 137_000_000 picoseconds.
+		Weight::from_parts(139_000_000, 8655)
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(6))
 		}
 	/// Storage: `OperationalAccounts::OperationalAccounts` (r:2 w:1)
 	/// Proof: `OperationalAccounts::OperationalAccounts` (`max_values`: None, `max_size`: Some(340), added: 2815, mode: `MaxEncodedLen`)
@@ -55,8 +59,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 11_000_000 picoseconds.
-		Weight::from_parts(13_000_000, 6620)
+		// Minimum execution time: 12_000_000 picoseconds.
+		Weight::from_parts(16_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -68,8 +72,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `3805`
-		// Minimum execution time: 7_000_000 picoseconds.
-		Weight::from_parts(7_000_000, 3805)
+		// Minimum execution time: 8_000_000 picoseconds.
+		Weight::from_parts(9_000_000, 3805)
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -85,8 +89,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(14_000_000, 6620)
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(16_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
 		}
@@ -119,9 +123,9 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		//  Measured:  `178 + r * (328 +/- 0)`
 		//  Estimated: `3513 + r * (2815 +/- 0)`
 		// Minimum execution time: 12_000_000 picoseconds.
-		Weight::from_parts(12_000_000, 3513)
-			// Standard Error: 17_881
-			.saturating_add(Weight::from_parts(11_409_553, 0).saturating_mul(r.into()))
+		Weight::from_parts(13_000_000, 3513)
+			// Standard Error: 31_510
+			.saturating_add(Weight::from_parts(10_807_427, 0).saturating_mul(r.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((2_u64).saturating_mul(r.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -136,7 +140,7 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 9_000_000 picoseconds.
+		// Minimum execution time: 8_000_000 picoseconds.
 		Weight::from_parts(9_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -149,7 +153,7 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 8_000_000 picoseconds.
+		// Minimum execution time: 9_000_000 picoseconds.
 		Weight::from_parts(9_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -204,8 +208,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 12_000_000 picoseconds.
-		Weight::from_parts(14_000_000, 6620)
+		// Minimum execution time: 13_000_000 picoseconds.
+		Weight::from_parts(13_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -215,7 +219,7 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `274`
 		//  Estimated: `3805`
-		// Minimum execution time: 9_000_000 picoseconds.
+		// Minimum execution time: 10_000_000 picoseconds.
 		Weight::from_parts(10_000_000, 3805)
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))

--- a/runtime/canary/src/weights/pallet_operational_accounts.rs
+++ b/runtime/canary/src/weights/pallet_operational_accounts.rs
@@ -32,20 +32,24 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_operational_accounts`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for WeightInfo<T> {
-	/// Storage: `OperationalAccounts::OperationalAccounts` (r:1 w:1)
+	/// Storage: `OperationalAccounts::OperationalAccounts` (r:2 w:2)
 	/// Proof: `OperationalAccounts::OperationalAccounts` (`max_values`: None, `max_size`: Some(340), added: 2815, mode: `MaxEncodedLen`)
 	/// Storage: `OperationalAccounts::OperationalAccountBySubAccount` (r:3 w:2)
 	/// Proof: `OperationalAccounts::OperationalAccountBySubAccount` (`max_values`: None, `max_size`: Some(80), added: 2555, mode: `MaxEncodedLen`)
 	/// Storage: `OperationalAccounts::IsOperationalAccountInviteOnly` (r:1 w:0)
 	/// Proof: `OperationalAccounts::IsOperationalAccountInviteOnly` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
+	/// Storage: `OperationalAccounts::AccessCodeReadyAccounts` (r:1 w:1)
+	/// Proof: `OperationalAccounts::AccessCodeReadyAccounts` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+	/// Storage: `OperationalAccounts::CounterForAccessCodeReadyAccounts` (r:1 w:1)
+	/// Proof: `OperationalAccounts::CounterForAccessCodeReadyAccounts` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn register() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `5`
+		//  Measured:  `299`
 		//  Estimated: `8655`
-		// Minimum execution time: 118_000_000 picoseconds.
-		Weight::from_parts(123_000_000, 8655)
-			.saturating_add(T::DbWeight::get().reads(5))
-			.saturating_add(T::DbWeight::get().writes(3))
+		// Minimum execution time: 139_000_000 picoseconds.
+		Weight::from_parts(405_000_000, 8655)
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(6))
 		}
 	/// Storage: `OperationalAccounts::OperationalAccounts` (r:2 w:1)
 	/// Proof: `OperationalAccounts::OperationalAccounts` (`max_values`: None, `max_size`: Some(340), added: 2815, mode: `MaxEncodedLen`)
@@ -55,8 +59,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 11_000_000 picoseconds.
-		Weight::from_parts(13_000_000, 6620)
+		// Minimum execution time: 12_000_000 picoseconds.
+		Weight::from_parts(26_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -68,8 +72,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `3805`
-		// Minimum execution time: 7_000_000 picoseconds.
-		Weight::from_parts(8_000_000, 3805)
+		// Minimum execution time: 8_000_000 picoseconds.
+		Weight::from_parts(16_000_000, 3805)
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -85,8 +89,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(14_000_000, 6620)
+		// Minimum execution time: 16_000_000 picoseconds.
+		Weight::from_parts(30_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
 		}
@@ -102,8 +106,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(14_000_000, 6620)
+		// Minimum execution time: 30_000_000 picoseconds.
+		Weight::from_parts(31_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
 		}
@@ -120,8 +124,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		//  Estimated: `3513 + r * (2815 +/- 0)`
 		// Minimum execution time: 12_000_000 picoseconds.
 		Weight::from_parts(13_000_000, 3513)
-			// Standard Error: 16_208
-			.saturating_add(Weight::from_parts(11_416_204, 0).saturating_mul(r.into()))
+			// Standard Error: 25_657
+			.saturating_add(Weight::from_parts(10_996_301, 0).saturating_mul(r.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((2_u64).saturating_mul(r.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -136,8 +140,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 9_000_000 picoseconds.
-		Weight::from_parts(10_000_000, 6620)
+		// Minimum execution time: 10_000_000 picoseconds.
+		Weight::from_parts(11_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -150,7 +154,7 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		//  Measured:  `381`
 		//  Estimated: `6620`
 		// Minimum execution time: 10_000_000 picoseconds.
-		Weight::from_parts(10_000_000, 6620)
+		Weight::from_parts(11_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -162,8 +166,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 11_000_000 picoseconds.
-		Weight::from_parts(12_000_000, 6620)
+		// Minimum execution time: 12_000_000 picoseconds.
+		Weight::from_parts(13_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -181,8 +185,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `691`
 		//  Estimated: `9435`
-		// Minimum execution time: 22_000_000 picoseconds.
-		Weight::from_parts(23_000_000, 9435)
+		// Minimum execution time: 24_000_000 picoseconds.
+		Weight::from_parts(25_000_000, 9435)
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(4))
 		}
@@ -193,7 +197,7 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 4_000_000 picoseconds.
-		Weight::from_parts(4_000_000, 0)
+		Weight::from_parts(5_000_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
 	/// Storage: `OperationalAccounts::OperationalAccounts` (r:2 w:1)
@@ -204,8 +208,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `381`
 		//  Estimated: `6620`
-		// Minimum execution time: 12_000_000 picoseconds.
-		Weight::from_parts(13_000_000, 6620)
+		// Minimum execution time: 13_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 6620)
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}
@@ -215,8 +219,8 @@ impl<T: frame_system::Config> pallet_operational_accounts::WeightInfo for Weight
 		// Proof Size summary in bytes:
 		//  Measured:  `274`
 		//  Estimated: `3805`
-		// Minimum execution time: 9_000_000 picoseconds.
-		Weight::from_parts(10_000_000, 3805)
+		// Minimum execution time: 10_000_000 picoseconds.
+		Weight::from_parts(11_000_000, 3805)
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 		}


### PR DESCRIPTION
## Summary

Downstream registration can spend an upstream access code after the upstream account has already met both follow-on award thresholds. Before this patch, that spend freed capacity but did not requeue the upstream account, so the next frame had nothing to award unless a later mining or bitcoin event touched the account.

This requeues the upstream account at spend time and keeps the actual award on the next frame, rather than making it immediate. The regression test now covers the delayed frame-award path directly.

## Testing

- `cargo test -p pallet-operational-accounts access_registration_queues_ready_accrual_access_code`
- `cargo test -p pallet-operational-accounts frame_awards_are_bounded_and_remaining_accounts_stay_ready`
