### PR TITLE
fix(nodejs): restore clean-checkout typechecking

### DIFF
--- a/bitcoin/nodejs/ts/__test__/CosignScript.test.ts
+++ b/bitcoin/nodejs/ts/__test__/CosignScript.test.ts
@@ -31,7 +31,7 @@ import {
   getXpubFromXpriv,
   HDKey,
   p2wshScriptHexToAddress,
-} from '../../lib/index.js';
+} from '@argonprotocol/bitcoin';
 import { wordlist as english } from '@scure/bip39/wordlists/english';
 
 const { generateMnemonic, mnemonicToSeedSync } = bip39;
@@ -146,7 +146,7 @@ describe.skipIf(SKIP_E2E)('Bitcoin Bindings test', { retry: 0, timeout: 60e3 }, 
       mnemonicToSeedSync(bitcoinMnemonic),
       "m/84'/0'/0'/0/0'",
     );
-    const ownerBitcoinPubkey = getCompressedPubkey(ownerBitcoinXpriv.publicKey);
+    const ownerBitcoinPubkey = getCompressedPubkey(ownerBitcoinXpriv.publicKey!);
     console.log('Owner Bitcoin Pubkey:', u8aToHex(ownerBitcoinPubkey), ownerBitcoinPubkey.length);
     const priceIndex = new PriceIndex();
     await priceIndex.load(vaulterClient);

--- a/bitcoin/nodejs/tsconfig.json
+++ b/bitcoin/nodejs/tsconfig.json
@@ -15,6 +15,9 @@
     "skipDefaultLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
+    "paths": {
+      "@argonprotocol/bitcoin": ["ts/index.ts"]
+    },
     "rootDir": "./ts",
     "outDir": "./lib",
     "types": ["vitest/globals", "node"]

--- a/chains/ethereum/deploy/index.ts
+++ b/chains/ethereum/deploy/index.ts
@@ -59,9 +59,9 @@ async function main() {
       await Promise.all(
         registeredCouncilMembers.map(async member => {
           const bondState = await argonClient.query.treasury.bondLotsByVault(member.vaultId);
-          const activeBonds = bondState.bondLots.reduce(
+          const activeBonds = bondState.regularBondLots.reduce(
             (sum, bondLot) => sum + bondLot.bonds.toNumber(),
-            bondState.backfillBonds.toNumber(),
+            bondState.flexibleBonds.toNumber(),
           );
           return activeBonds > MIN_BOOTSTRAP_COUNCIL_BONDS ? member : undefined;
         }),

--- a/testing/nodejs/package.json
+++ b/testing/nodejs/package.json
@@ -13,8 +13,8 @@
   },
   "homepage": "https://github.com/argonprotocol/mainchain#readme",
   "scripts": {
-    "build": "yarn workspace @argonprotocol/ethereum-contracts run build && tsup",
-    "tsc": "yarn workspace @argonprotocol/ethereum-contracts run build && tsup",
+    "build": "yarn workspace @argonprotocol/mainchain run tsc && tsup",
+    "tsc": "yarn workspace @argonprotocol/mainchain run tsc && tsup",
     "watch": "tsup --watch",
     "typecheck": "tsc --noEmit -p tsconfig.test.json"
   },


### PR DESCRIPTION
`yarn typecheck` now succeeds from a fresh checkout instead of depending on declarations left by earlier package builds.

The Node package build graph now prepares mainchain declarations through the testing package, Bitcoin typechecks its package surface against source, and Ethereum bootstrap bond counting matches the current regular and flexible bond state.
