### PR TITLE
fix(node): reject incomplete fast-sync databases on startup

### DIFF
--- a/end-to-end/src/sync.rs
+++ b/end-to-end/src/sync.rs
@@ -5,7 +5,9 @@ use crate::utils::{
 use argon_client::{api::storage, conversion::SubxtRuntime, FetchAt};
 use argon_notary_audit::VerifyError;
 use argon_primitives::{ArgonDigests, BlockSealDigest};
-use argon_testing::{test_miner_count, ArgonNodeStartArgs, ArgonTestNode, ArgonTestNotary};
+use argon_testing::{
+	test_miner_count, ArgonNodeStartArgs, ArgonTestNode, ArgonTestNotary, LogWatcher,
+};
 use polkadot_sdk::sp_core::{DeriveJunction, Pair, H256};
 use serial_test::serial;
 use std::{
@@ -13,7 +15,7 @@ use std::{
 	fs::{copy, create_dir_all, read_dir, read_to_string, remove_dir_all, write},
 	io,
 	path::{Path, PathBuf},
-	process::Command,
+	process::{Child, Command},
 	sync::{
 		atomic::{AtomicBool, Ordering},
 		Arc,
@@ -90,6 +92,41 @@ async fn test_warp_sync_recovers_after_state_sync_restart() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[ignore = "runs two live node processes"]
+async fn test_interrupted_fast_sync_is_rejected_on_restart() {
+	let mut source_args = ArgonNodeStartArgs::new("alice", 1, "").unwrap();
+	source_args.bitcoin_rpc = "http://127.0.0.1:1".to_string();
+	let source = ArgonTestNode::start(source_args).await.unwrap();
+
+	let mut sync_args = source.get_fork_args("bob", 0);
+	sync_args.bootnodes.clear();
+	sync_args.is_validator = false;
+	sync_args.is_archive_node = false;
+	sync_args.rust_log = "warn,sync=debug".to_string();
+	sync_args.extra_flags.extend([
+		"--sync=fast".to_string(),
+		"--reserved-only".to_string(),
+		format!("--reserved-nodes={}", source.boot_url),
+	]);
+
+	let mut initial_sync = SyncNodeProcess::start(&sync_args, "fast-sync").unwrap();
+	initial_sync
+		.log_watcher
+		.wait_for_log_for_secs("Starting state sync for #", 1, 5 * 60)
+		.await
+		.unwrap();
+	initial_sync.stop().unwrap();
+
+	let restarted_sync = SyncNodeProcess::start(&sync_args, "fast-sync-restart").unwrap();
+	restarted_sync
+		.log_watcher
+		.wait_for_log_for_secs("ARGON_RECOVERY_REQUIRED: missing-state-anchor", 1, 30)
+		.await
+		.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
 #[ignore = "slow live sync soak"]
 async fn test_soak_late_node_catches_up() {
 	let settings = SyncSoakSettings::from_env();
@@ -155,6 +192,40 @@ struct SyncHarness {
 	archive_bucket: String,
 	archive_host: String,
 	reused_state: bool,
+}
+
+struct SyncNodeProcess {
+	child: Child,
+	log_watcher: LogWatcher,
+	cleanup_data_path: Option<PathBuf>,
+}
+
+impl SyncNodeProcess {
+	fn start(args: &ArgonNodeStartArgs, name: &str) -> anyhow::Result<Self> {
+		let mut child = args.command().spawn()?;
+		let stderr = child.stderr.take().expect("node stderr should be piped");
+		let log_watcher = LogWatcher::new(stderr, name);
+		let cleanup_data_path = args.cleanup_base_data_path.then(|| args.base_data_path.clone());
+		Ok(Self { child, log_watcher, cleanup_data_path })
+	}
+
+	fn stop(&mut self) -> anyhow::Result<()> {
+		if self.child.try_wait()?.is_none() {
+			self.child.kill()?;
+		}
+		let _ = self.child.wait();
+		self.log_watcher.close();
+		Ok(())
+	}
+}
+
+impl Drop for SyncNodeProcess {
+	fn drop(&mut self) {
+		let _ = self.stop();
+		if let Some(data_path) = &self.cleanup_data_path {
+			let _ = remove_dir_all(data_path);
+		}
+	}
 }
 
 #[derive(Debug)]

--- a/end-to-end/src/sync.rs
+++ b/end-to-end/src/sync.rs
@@ -92,8 +92,8 @@ async fn test_warp_sync_recovers_after_state_sync_restart() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-#[ignore = "runs two live node processes"]
-async fn test_interrupted_fast_sync_is_rejected_on_restart() {
+#[ignore = "sync recovery scenario runs in the sync action"]
+async fn test_normal_interrupted_fast_sync_is_rejected_on_restart() {
 	let mut source_args = ArgonNodeStartArgs::new("alice", 1, "").unwrap();
 	source_args.bitcoin_rpc = "http://127.0.0.1:1".to_string();
 	let source = ArgonTestNode::start(source_args).await.unwrap();

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -82,12 +82,13 @@ macro_rules! construct_async_run {
 		let mining_config = MiningConfig::new(&$cli);
 		if runner.config().chain_spec.is_canary() {
 			runner.async_run(|$config| {
-				let $components = new_partial::<CanaryRuntimeApi>(&$config, &mining_config)?;
+				let $components =
+					new_partial::<CanaryRuntimeApi>(&$config, &mining_config, false)?;
 				Ok::<_, sc_cli::Error>(( { $( $code )* }, $components.task_manager))
 			})
 		} else {
 			runner.async_run(|$config| {
-				let $components = new_partial::<ArgonRuntimeApi>(&$config, &mining_config)?;
+				let $components = new_partial::<ArgonRuntimeApi>(&$config, &mining_config, false)?;
 				Ok::<_, sc_cli::Error>(( { $( $code )* }, $components.task_manager))
 			})
 		}

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -20,7 +20,7 @@ use argon_primitives::{
 	AccountId, TickApis,
 };
 use polkadot_sdk::*;
-use sc_client_api::{BlockBackend, HeaderBackend};
+use sc_client_api::{backend::Backend as BackendT, BlockBackend, HeaderBackend};
 use sc_consensus::BasicQueue;
 use sc_consensus_grandpa::{
 	BeforeBestBlockBy, FinalityProofProvider as GrandpaFinalityProofProvider,
@@ -74,6 +74,7 @@ pub type Service<Runtime> = sc_service::PartialComponents<
 pub fn new_partial<Runtime>(
 	config: &Configuration,
 	mining_config: &MiningConfig,
+	validate_persisted_chain_state: bool,
 ) -> Result<Service<Runtime>, ServiceError>
 where
 	Runtime: ConstructRuntimeApi<Block, FullClient<Runtime>> + Send + Sync + 'static,
@@ -92,12 +93,33 @@ where
 
 	let executor = sc_service::new_wasm_executor::<sp_io::SubstrateHostFunctions>(&config.executor);
 
+	// Mirror sc_service::new_full_parts so node startup can inspect the opened backend before
+	// client initialization writes genesis state or warms the best block's trie.
+	let backend = sc_service::new_db_backend(config.db_config())?;
+	if validate_persisted_chain_state {
+		let info = backend.blockchain().info();
+		if info.best_number > 0 && !backend.have_state_at(info.best_hash, info.best_number) {
+			return Err(ServiceError::Other(format!(
+				"ARGON_RECOVERY_REQUIRED: missing-state-anchor; database best block #{} ({}) has no state",
+				info.best_number, info.best_hash
+			)));
+		}
+	}
+
+	let genesis_block_builder = sc_service::GenesisBlockBuilder::new(
+		config.chain_spec.as_storage_builder(),
+		!config.no_genesis(),
+		backend.clone(),
+		executor.clone(),
+	)?;
 	let (client, backend, keystore_container, task_manager) =
-		sc_service::new_full_parts::<Block, Runtime, _>(
+		sc_service::new_full_parts_with_genesis_builder::<Block, Runtime, _, _>(
 			config,
 			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
 			executor,
-			Vec::new(),
+			backend,
+			genesis_block_builder,
+			false,
 		)?;
 	// let runtime_overrides =
 	// 	GrandpaStateOverrider::for_chain(Chain::from_str(config.chain_spec.name())?);
@@ -230,7 +252,7 @@ where
 		config.network.min_peers_to_start_warp_sync = Some(1);
 	}
 
-	let params = new_partial::<Runtime>(&config, &mining_config)?;
+	let params = new_partial::<Runtime>(&config, &mining_config, true)?;
 	let Service {
 		select_chain,
 		client,

--- a/testing/src/argon_node.rs
+++ b/testing/src/argon_node.rs
@@ -77,6 +77,47 @@ impl ArgonNodeStartArgs {
 		keyring.to_account_id()
 	}
 
+	pub fn command(&self) -> Command {
+		let mut more_args = self.extra_flags.clone();
+		if !self.bootnodes.is_empty() {
+			more_args.push(format!("--bootnodes={}", &self.bootnodes));
+		}
+		if !self.notebook_archive_urls.is_empty() {
+			more_args
+				.push(format!("--notebook-archive-hosts={}", self.notebook_archive_urls.join(",")));
+		}
+		if self.is_validator {
+			more_args.push("--validator".to_string());
+		}
+		if self.is_archive_node {
+			more_args.push("--state-pruning=archive".to_string());
+			more_args.push("--blocks-pruning=archive".to_string());
+		}
+
+		let mut command = Command::new("./argon-node");
+		command
+			.current_dir(self.target_dir.clone())
+			.env("RUST_LOG", &self.rust_log)
+			.stderr(process::Stdio::piped())
+			.stdout(process::Stdio::null())
+			.arg("--no-mdns")
+			.arg(format!("--base-path={}", self.base_data_path.display()))
+			.arg("--detailed-log-output")
+			.arg("--unsafe-force-node-key-generation")
+			.arg("--allow-private-ipv4")
+			.arg("--no-telemetry")
+			.arg("--no-prometheus")
+			.arg("--chain=dev")
+			.arg(format!("--{}", self.authority.to_lowercase()))
+			.arg(format!("--name={}", self.authority.to_lowercase()))
+			.arg("--port=0")
+			.arg(format!("--rpc-port={}", self.rpc_port))
+			.arg(format!("--compute-miners={}", self.compute_miners))
+			.arg(format!("--bitcoin-rpc-url={}", &self.bitcoin_rpc))
+			.args(more_args);
+		command
+	}
+
 	pub fn new(authority: &str, compute_miners: u16, bootnodes: &str) -> anyhow::Result<Self> {
 		let target_dir = get_target_dir();
 
@@ -199,47 +240,9 @@ impl ArgonTestNode {
 	async fn start_process(
 		args: &mut ArgonNodeStartArgs,
 	) -> anyhow::Result<(process::Child, LogWatcher)> {
-		let mut more_args = args.extra_flags.clone();
-		if !args.bootnodes.is_empty() {
-			more_args.push(format!("--bootnodes={}", &args.bootnodes))
-		};
-		if !args.notebook_archive_urls.is_empty() {
-			more_args
-				.push(format!("--notebook-archive-hosts={}", args.notebook_archive_urls.join(",")))
-		};
+		println!("Starting argon-node with args: {args:?}");
 
-		if args.is_validator {
-			more_args.push("--validator".to_string());
-		}
-
-		if args.is_archive_node {
-			more_args.push("--state-pruning=archive".to_string());
-			more_args.push("--blocks-pruning=archive".to_string());
-		}
-
-		println!("Starting argon-node with args: {args:?}. {more_args:?}");
-
-		let mut proc = Command::new("./argon-node")
-			.current_dir(args.target_dir.clone())
-			.env("RUST_LOG", &args.rust_log)
-			.stderr(process::Stdio::piped())
-			.stdout(process::Stdio::null()) // Redirect stdout to /dev/null
-			.arg("--no-mdns")
-			.arg(format!("--base-path={}", args.base_data_path.display()))
-			.arg("--detailed-log-output")
-			.arg("--unsafe-force-node-key-generation")
-			.arg("--allow-private-ipv4")
-			.arg("--no-telemetry")
-			.arg("--no-prometheus")
-			.arg("--chain=dev")
-			.arg(format!("--{}", &args.authority.to_lowercase()))
-			.arg(format!("--name={}", &args.authority.to_lowercase()))
-			.arg("--port=0")
-			.arg(format!("--rpc-port={}", args.rpc_port))
-			.arg(format!("--compute-miners={}", args.compute_miners))
-			.arg(format!("--bitcoin-rpc-url={}", &args.bitcoin_rpc))
-			.args(more_args.into_iter())
-			.spawn()?;
+		let mut proc = args.command().spawn()?;
 
 		// Wait for RPC port to be logged (it's logged to stderr).
 		let stderr = proc.stderr.take().unwrap();

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -18,6 +18,7 @@ pub use argon_node::ArgonTestNode;
 pub use argon_notary::ArgonTestNotary;
 pub use argon_oracle::ArgonTestOracle;
 pub use bitcoind::*;
+pub use log_watcher::LogWatcher;
 
 pub async fn start_argon_test_node() -> ArgonTestNode {
 	let start_args = ArgonNodeStartArgs::new("alice", test_miner_count(), "").unwrap();


### PR DESCRIPTION
## Summary

Nodes now reject a database whose persisted best block has no state before client initialization can mask the incomplete sync state. Full startup returns `ARGON_RECOVERY_REQUIRED: missing-state-anchor`, while offline subcommands remain able to open the database without this startup-only validation.

## Validation

- Interrupted a live fast sync at state-sync startup and restarted the same database.
- The recovery E2E passed three consecutive fresh runs.
- Disabling the new validation made the E2E fail and reproduced the later `State already discarded` startup error.
- All 13 `argon-node` binary tests passed, and `argon-testing` compiled successfully.
