### PR TITLE
fix(bitcoin-locks): correct ratchet liquidity accounting

### DIFF
--- a/pallets/bitcoin_locks/src/lib.rs
+++ b/pallets/bitcoin_locks/src/lib.rs
@@ -83,7 +83,7 @@ pub mod pallet {
 	};
 	use codec::HasCompact;
 	use core::iter::Sum;
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(9);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(10);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -1086,7 +1086,32 @@ pub mod pallet {
 
 			let mut duration_for_new_funds = FixedU128::zero();
 
-			let new_liquidity_promised = Self::calculate_redemption_amount(new_target_price, None)?;
+			// We need to determine up/down ratchet based on argon target rate
+			let is_up_ratchet = new_target_price > old_target_price;
+
+			// up-ratcheting
+			let (amount_to_mint, amount_to_burn, new_liquidity_promised) = if is_up_ratchet {
+				let start_height = lock.created_at_height;
+				let current_bitcoin_height = T::BitcoinBlockHeightChange::get().1;
+				let elapsed_blocks = current_bitcoin_height.saturating_sub(start_height);
+				let full_term = expiration_height.saturating_sub(start_height).max(1);
+				let remaining_blocks = full_term.saturating_sub(elapsed_blocks);
+				let diff_target_amount = new_target_price - old_target_price;
+				let amount_to_mint = Self::calculate_redemption_amount(diff_target_amount, None)?;
+				duration_for_new_funds =
+					FixedU128::from_rational(remaining_blocks as u128, full_term as u128);
+				let new_liquidity_promised = lock
+					.liquidity_promised
+					.checked_add(&amount_to_mint)
+					.ok_or(Error::<T>::OverflowError)?;
+				(amount_to_mint, T::Balance::zero(), new_liquidity_promised)
+
+			// down-ratcheting
+			} else {
+				let new_liquidity_promised =
+					Self::calculate_redemption_amount(new_target_price, None)?;
+				(new_liquidity_promised, new_liquidity_promised, new_liquidity_promised)
+			};
 
 			if lock.is_flexible {
 				let new_securitization =
@@ -1104,27 +1129,7 @@ pub mod pallet {
 				);
 			}
 
-			// We need to determine up/down ratchet based on argon target rate
-			let is_up_ratchet = new_target_price > old_target_price;
-
-			// up-ratcheting
-			let (amount_to_mint, amount_to_burn) = if is_up_ratchet {
-				let start_height = lock.created_at_height;
-				let current_bitcoin_height = T::BitcoinBlockHeightChange::get().1;
-				let elapsed_blocks = current_bitcoin_height.saturating_sub(start_height);
-				let full_term = expiration_height.saturating_sub(start_height).max(1);
-				let remaining_blocks = full_term.saturating_sub(elapsed_blocks);
-				let diff_target_amount = new_target_price - old_target_price;
-				let amount_to_mint = Self::calculate_redemption_amount(diff_target_amount, None)?;
-				duration_for_new_funds =
-					FixedU128::from_rational(remaining_blocks as u128, full_term as u128);
-				(amount_to_mint, T::Balance::zero())
-
-			// down-ratcheting
-			} else {
-				let amount_to_burn = new_liquidity_promised;
-				let amount_to_mint = new_liquidity_promised;
-
+			if !amount_to_burn.is_zero() {
 				// NOTE: we send amount_to_burn to be released
 				T::LockEvents::utxo_released(
 					utxo_id,
@@ -1149,9 +1154,7 @@ pub mod pallet {
 					lock.is_flexible,
 				)
 				.map_err(Error::<T>::from)?;
-
-				(amount_to_mint, amount_to_burn)
-			};
+			}
 
 			let mut lock_extension = lock.get_lock_extension();
 			let securitization = Securitization::new(amount_to_mint, lock.securitization_ratio);

--- a/pallets/bitcoin_locks/src/migrations/mod.rs
+++ b/pallets/bitcoin_locks/src/migrations/mod.rs
@@ -1,1 +1,310 @@
+use crate::{Config, LockedBitcoin, LocksByUtxoId, Pallet};
+use alloc::{collections::BTreeMap, vec::Vec};
+use argon_primitives::{bitcoin::UtxoId, vault::BitcoinVaultProvider, VaultId};
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+use pallet_prelude::*;
+use sp_arithmetic::FixedU128;
 
+#[cfg(feature = "try-runtime")]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use frame_support::ensure;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+
+pub struct CorrectLegacyRatchetedLiquidity<T>(core::marker::PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for CorrectLegacyRatchetedLiquidity<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		let locks = LocksByUtxoId::<T>::iter().collect::<Vec<_>>();
+		let lock_count_by_vault = Self::lock_count_by_vault(&locks);
+		if let Some((vault_id, lock_count)) =
+			Self::underbacked_multi_lock_vaults(&locks, &lock_count_by_vault).first()
+		{
+			log::error!(
+				"Cannot safely correct legacy ratcheted liquidity for underbacked vault {vault_id}: found {lock_count} active locks"
+			);
+			return Err(TryRuntimeError::Other(
+				"legacy ratcheted liquidity correction found an underbacked vault with multiple active locks",
+			));
+		}
+		let corrections = locks
+			.into_iter()
+			.filter_map(|(utxo_id, lock)| {
+				let corrected_liquidity = Self::corrected_liquidity(&lock, &lock_count_by_vault)?;
+				Some((utxo_id, corrected_liquidity))
+			})
+			.collect::<Vec<_>>();
+
+		Ok(corrections.encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		let locks = LocksByUtxoId::<T>::iter().collect::<Vec<_>>();
+		let lock_count_by_vault = Self::lock_count_by_vault(&locks);
+		for (vault_id, lock_count) in
+			Self::underbacked_multi_lock_vaults(&locks, &lock_count_by_vault)
+		{
+			log::warn!(
+				"Skipping legacy ratcheted liquidity correction for underbacked vault {vault_id}: found {lock_count} active locks"
+			);
+		}
+		let reads = (locks.len() as u64).saturating_mul(2);
+		let mut writes = 0u64;
+		let corrections = locks
+			.into_iter()
+			.filter_map(|(utxo_id, lock)| {
+				let corrected_liquidity = Self::corrected_liquidity(&lock, &lock_count_by_vault)?;
+				Some((utxo_id, lock, corrected_liquidity))
+			})
+			.collect::<Vec<_>>();
+
+		for (utxo_id, mut lock, new_liquidity_promised) in corrections {
+			lock.liquidity_promised = new_liquidity_promised;
+			LocksByUtxoId::<T>::insert(utxo_id, &lock);
+			writes.saturating_accrue(1);
+		}
+
+		T::DbWeight::get().reads_writes(reads, writes)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+		let corrections = <Vec<(UtxoId, T::Balance)>>::decode(&mut state.as_slice())
+			.map_err(|_| TryRuntimeError::Other("could not decode ratchet correction state"))?;
+		for (utxo_id, expected_liquidity) in corrections {
+			let lock = LocksByUtxoId::<T>::get(utxo_id)
+				.ok_or(TryRuntimeError::Other("corrected bitcoin lock was removed"))?;
+			ensure!(
+				lock.liquidity_promised == expected_liquidity,
+				TryRuntimeError::Other("bitcoin lock liquidity was not corrected"),
+			);
+		}
+
+		Ok(())
+	}
+}
+
+impl<T: Config> CorrectLegacyRatchetedLiquidity<T> {
+	fn lock_count_by_vault(locks: &[(UtxoId, LockedBitcoin<T>)]) -> BTreeMap<VaultId, u32> {
+		let mut lock_count_by_vault = BTreeMap::<VaultId, u32>::new();
+		for (_, lock) in locks {
+			lock_count_by_vault
+				.entry(lock.vault_id)
+				.and_modify(|count| count.saturating_accrue(1))
+				.or_insert(1);
+		}
+
+		lock_count_by_vault
+	}
+
+	fn corrected_liquidity(
+		lock: &LockedBitcoin<T>,
+		lock_count_by_vault: &BTreeMap<VaultId, u32>,
+	) -> Option<T::Balance> {
+		if !lock.is_funded || lock.securitization_ratio != FixedU128::one() {
+			return None;
+		}
+
+		if lock_count_by_vault.get(&lock.vault_id) != Some(&1) {
+			return None;
+		}
+
+		let corrected_liquidity = T::VaultProvider::get_locked_securitization(lock.vault_id)?;
+		(lock.liquidity_promised > corrected_liquidity).then_some(corrected_liquidity)
+	}
+
+	fn underbacked_multi_lock_vaults(
+		locks: &[(UtxoId, LockedBitcoin<T>)],
+		lock_count_by_vault: &BTreeMap<VaultId, u32>,
+	) -> Vec<(VaultId, u32)> {
+		lock_count_by_vault
+			.iter()
+			.filter(|(_, count)| **count > 1)
+			.filter_map(|(vault_id, lock_count)| {
+				let mut liquidity_promised = T::Balance::zero();
+				for (_, lock) in locks.iter().filter(|(_, lock)| lock.vault_id == *vault_id) {
+					if !lock.is_funded || lock.securitization_ratio != FixedU128::one() {
+						return None;
+					}
+					liquidity_promised.saturating_accrue(lock.liquidity_promised);
+				}
+
+				let securitization_locked = T::VaultProvider::get_locked_securitization(*vault_id)?;
+				(liquidity_promised > securitization_locked).then_some((*vault_id, *lock_count))
+			})
+			.collect()
+	}
+}
+
+pub type CorrectLegacyRatchetedLiquidityMigration<T> =
+	frame_support::migrations::VersionedMigration<
+		9,
+		10,
+		CorrectLegacyRatchetedLiquidity<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{mock::*, LockOptions, LocksByUtxoId, MicrogonPerBtcHistory, Pallet};
+	use argon_primitives::{
+		bitcoin::{CompressedBitcoinPubkey, SATOSHIS_PER_BITCOIN},
+		BitcoinUtxoEvents, MICROGONS_PER_ARGON,
+	};
+	use frame_support::traits::{OnRuntimeUpgrade, StorageVersion};
+
+	#[test]
+	fn derives_ratchet_correction_from_vault_backing() {
+		new_test_ext().execute_with(|| {
+			setup_overpromised_lock();
+
+			#[cfg(feature = "try-runtime")]
+			let state = CorrectLegacyRatchetedLiquidityMigration::<Test>::pre_upgrade()
+				.expect("pre-upgrade checks");
+			CorrectLegacyRatchetedLiquidityMigration::<Test>::on_runtime_upgrade();
+			#[cfg(feature = "try-runtime")]
+			CorrectLegacyRatchetedLiquidityMigration::<Test>::post_upgrade(state)
+				.expect("post-upgrade checks");
+
+			assert_eq!(LocksByUtxoId::<Test>::get(1).unwrap().liquidity_promised, 13_075_028_428);
+		});
+	}
+
+	#[test]
+	fn does_not_correct_an_unfunded_lock() {
+		new_test_ext().execute_with(|| {
+			let original_liquidity = setup_overpromised_lock();
+			LocksByUtxoId::<Test>::mutate(1, |lock| {
+				lock.as_mut().expect("initialized lock").is_funded = false;
+			});
+
+			CorrectLegacyRatchetedLiquidityMigration::<Test>::on_runtime_upgrade();
+
+			assert_eq!(
+				LocksByUtxoId::<Test>::get(1).unwrap().liquidity_promised,
+				original_liquidity
+			);
+		});
+	}
+
+	#[test]
+	fn does_not_correct_a_non_one_to_one_lock() {
+		new_test_ext().execute_with(|| {
+			let original_liquidity = setup_overpromised_lock();
+			LocksByUtxoId::<Test>::mutate(1, |lock| {
+				lock.as_mut().expect("initialized lock").securitization_ratio =
+					FixedU128::from_rational(2, 1);
+			});
+
+			CorrectLegacyRatchetedLiquidityMigration::<Test>::on_runtime_upgrade();
+
+			assert_eq!(
+				LocksByUtxoId::<Test>::get(1).unwrap().liquidity_promised,
+				original_liquidity
+			);
+		});
+	}
+
+	#[test]
+	fn does_not_correct_a_vault_with_multiple_active_locks() {
+		new_test_ext().execute_with(|| {
+			let original_liquidity = setup_overpromised_lock();
+			insert_second_lock();
+
+			CorrectLegacyRatchetedLiquidityMigration::<Test>::on_runtime_upgrade();
+
+			assert_eq!(
+				LocksByUtxoId::<Test>::get(1).unwrap().liquidity_promised,
+				original_liquidity
+			);
+			assert_eq!(
+				LocksByUtxoId::<Test>::get(2).unwrap().liquidity_promised,
+				original_liquidity
+			);
+		});
+	}
+
+	#[cfg(feature = "try-runtime")]
+	#[test]
+	fn try_runtime_rejects_an_underbacked_vault_with_multiple_active_locks() {
+		new_test_ext().execute_with(|| {
+			setup_overpromised_lock();
+			insert_second_lock();
+
+			assert!(CorrectLegacyRatchetedLiquidityMigration::<Test>::pre_upgrade().is_err());
+		});
+	}
+
+	#[cfg(feature = "try-runtime")]
+	#[test]
+	fn try_runtime_allows_a_fully_backed_vault_with_multiple_active_locks() {
+		new_test_ext().execute_with(|| {
+			let liquidity_promised = setup_overpromised_lock();
+			insert_second_lock();
+			DefaultVault::mutate(|vault| {
+				vault.securitization_locked = liquidity_promised.saturating_mul(2);
+			});
+
+			assert!(CorrectLegacyRatchetedLiquidityMigration::<Test>::pre_upgrade().is_ok());
+		});
+	}
+
+	#[test]
+	fn does_not_correct_liquidity_already_covered_by_vault_backing() {
+		new_test_ext().execute_with(|| {
+			setup_overpromised_lock();
+			let covered_liquidity = 13_000_000_000;
+			LocksByUtxoId::<Test>::mutate(1, |lock| {
+				lock.as_mut().expect("initialized lock").liquidity_promised = covered_liquidity;
+			});
+
+			CorrectLegacyRatchetedLiquidityMigration::<Test>::on_runtime_upgrade();
+
+			assert_eq!(
+				LocksByUtxoId::<Test>::get(1).unwrap().liquidity_promised,
+				covered_liquidity
+			);
+		});
+	}
+
+	fn setup_overpromised_lock() -> Balance {
+		System::set_block_number(1);
+		set_bitcoin_height(1);
+		let who = 1;
+		let target = 13_121_461_837;
+		let liquidity_promised = 13_200_000_000;
+		MicrogonPerBtcHistory::<Test>::mutate(|history| {
+			_ = history.try_push((1, target));
+		});
+		DefaultVault::mutate(|vault| {
+			vault.securitization = 50_000 * MICROGONS_PER_ARGON;
+			vault.securitization_target = vault.securitization;
+		});
+		assert_ok!(BitcoinLocks::initialize(
+			RuntimeOrigin::signed(who),
+			1,
+			SATOSHIS_PER_BITCOIN,
+			CompressedBitcoinPubkey([1; 33]),
+			Some(LockOptions::V1 { microgons_at_target_per_btc: Some(target) }),
+		));
+		assert_ok!(BitcoinLocks::funding_received(1, SATOSHIS_PER_BITCOIN));
+		LocksByUtxoId::<Test>::mutate(1, |lock| {
+			lock.as_mut().expect("initialized lock").liquidity_promised = liquidity_promised;
+		});
+		DefaultVault::mutate(|vault| {
+			vault.securitization_locked = 13_075_028_428;
+		});
+		StorageVersion::new(9).put::<Pallet<Test>>();
+
+		liquidity_promised
+	}
+
+	fn insert_second_lock() {
+		let second_lock = LocksByUtxoId::<Test>::get(1).expect("initialized lock");
+		LocksByUtxoId::<Test>::insert(2, second_lock);
+	}
+}

--- a/pallets/bitcoin_locks/src/mock.rs
+++ b/pallets/bitcoin_locks/src/mock.rs
@@ -229,6 +229,10 @@ impl BitcoinVaultProvider for StaticVaultProvider {
 		None
 	}
 
+	fn get_locked_securitization(vault_id: VaultId) -> Option<Self::Balance> {
+		(vault_id == 1).then(|| DefaultVault::get().securitization_locked)
+	}
+
 	fn get_registration_vault_data(
 		account_id: &Self::AccountId,
 	) -> Option<argon_primitives::vault::RegistrationVaultData<Self::Balance>> {

--- a/pallets/bitcoin_locks/src/tests.rs
+++ b/pallets/bitcoin_locks/src/tests.rs
@@ -1741,6 +1741,52 @@ fn it_should_allow_a_ratchet_up() {
 }
 
 #[test]
+fn up_ratchet_adds_newly_secured_liquidity_to_the_existing_lock() {
+	new_test_ext().execute_with(|| {
+		set_bitcoin_height(1);
+		System::set_block_number(1);
+
+		let who = 1;
+		let initial_target = 500_000 * MICROGONS_PER_ARGON;
+		let ratchet_target = 600_000 * MICROGONS_PER_ARGON;
+		MicrogonPerBtcHistory::<Test>::mutate(|history| {
+			_ = history.try_push((1, initial_target));
+			_ = history.try_push((2, ratchet_target));
+		});
+		ArgonPriceInUsd::set(Some(FixedU128::from_float(1.0)));
+		ArgonTargetPriceInUsd::set(Some(FixedU128::from_float(1.1)));
+		DefaultVault::mutate(|vault| {
+			vault.securitization = 700_000 * MICROGONS_PER_ARGON;
+			vault.securitization_target = vault.securitization;
+		});
+
+		assert_ok!(BitcoinLocks::initialize(
+			RuntimeOrigin::signed(who),
+			1,
+			SATOSHIS_PER_BITCOIN,
+			CompressedBitcoinPubkey([1; 33]),
+			Some(LockOptions::V1 { microgons_at_target_per_btc: Some(initial_target) }),
+		));
+		assert_ok!(BitcoinLocks::funding_received(1, SATOSHIS_PER_BITCOIN));
+		let initial_liquidity = 491_735_537_190;
+		assert_eq!(LocksByUtxoId::<Test>::get(1).unwrap().liquidity_promised, initial_liquidity);
+
+		ArgonTargetPriceInUsd::set(Some(FixedU128::from_float(1.0)));
+		assert_ok!(BitcoinLocks::ratchet(
+			RuntimeOrigin::signed(who),
+			1,
+			Some(LockOptions::V1 { microgons_at_target_per_btc: Some(ratchet_target) }),
+		));
+
+		let expected_liquidity = 591_735_537_190;
+		let lock = LocksByUtxoId::<Test>::get(1).unwrap();
+		assert_eq!(lock.liquidity_promised, expected_liquidity);
+		assert_eq!(DefaultVault::get().securitization_locked, expected_liquidity);
+		assert_eq!(LastLockEvent::get(), Some((1, who, 100_000 * MICROGONS_PER_ARGON)));
+	});
+}
+
+#[test]
 fn it_should_charge_ratchet_up_fee_for_remaining_lock_term() {
 	ChargeFee::set(true);
 	new_test_ext().execute_with(|| {
@@ -1929,6 +1975,47 @@ fn it_should_allow_a_ratchet_down() {
 			Balances::free_balance(who) > 10_000 * MICROGONS_PER_ARGON,
 			"user should pocket the 10k"
 		);
+	});
+}
+
+#[test]
+fn down_ratchet_reuses_reserved_flexible_securitization() {
+	new_test_ext().execute_with(|| {
+		set_bitcoin_height(1);
+		System::set_block_number(1);
+
+		let operator = 1;
+		let satoshis = SATOSHIS_PER_BITCOIN;
+		let initial_securitization = 62_000 * MICROGONS_PER_ARGON;
+		BitcoinPriceInUsd::set(Some(FixedU128::saturating_from_integer(62_000)));
+		DefaultVault::mutate(|vault| {
+			vault.securitization = initial_securitization;
+			vault.securitization_target = initial_securitization;
+		});
+		set_argons(operator, initial_securitization);
+
+		assert_ok!(BitcoinLocks::initialize(
+			RuntimeOrigin::signed(operator),
+			1,
+			satoshis,
+			CompressedBitcoinPubkey([1; 33]),
+			None,
+		));
+		assert_ok!(BitcoinLocks::funding_received(1, satoshis));
+		assert_ok!(BitcoinLocks::set_flexible(RuntimeOrigin::signed(operator), 1, true));
+		DefaultVault::mutate(|vault| {
+			vault
+				.set_reserved_securitization_space(initial_securitization)
+				.expect("reserve the flexible securitization");
+		});
+		assert_ok!(Balances::mint_into(&operator, initial_securitization));
+
+		BitcoinPriceInUsd::set(Some(FixedU128::saturating_from_integer(52_000)));
+
+		assert_ok!(BitcoinLocks::ratchet(RuntimeOrigin::signed(operator), 1, None));
+		let vault = DefaultVault::get();
+		assert_eq!(vault.flexible_securitization_locked, 52_000 * MICROGONS_PER_ARGON);
+		assert_eq!(vault.reserved_securitization_space, initial_securitization);
 	});
 }
 

--- a/pallets/vaults/src/lib.rs
+++ b/pallets/vaults/src/lib.rs
@@ -1343,6 +1343,10 @@ pub mod pallet {
 			VaultIdByOperator::<T>::get(account_id)
 		}
 
+		fn get_locked_securitization(vault_id: VaultId) -> Option<Self::Balance> {
+			VaultsById::<T>::get(vault_id).map(|vault| vault.securitization_locked)
+		}
+
 		fn get_registration_vault_data(
 			account_id: &Self::AccountId,
 		) -> Option<RegistrationVaultData<Self::Balance>> {

--- a/primitives/src/vault.rs
+++ b/primitives/src/vault.rs
@@ -249,6 +249,9 @@ pub trait BitcoinVaultProvider {
 	fn get_vault_operator(vault_id: VaultId) -> Option<Self::AccountId>;
 	fn get_vault_delegate(vault_id: VaultId) -> Option<Self::AccountId>;
 	fn get_vault_id(account_id: &Self::AccountId) -> Option<VaultId>;
+	fn get_locked_securitization(_vault_id: VaultId) -> Option<Self::Balance> {
+		None
+	}
 	fn get_registration_vault_data(
 		account_id: &Self::AccountId,
 	) -> Option<RegistrationVaultData<Self::Balance>>;
@@ -738,9 +741,14 @@ impl<
 		is_flexible: bool,
 		may_use_flexible_space: bool,
 	) -> Result<(), VaultError> {
+		// Flexible extensions replace capacity that can already back reservations.
+		let available_securitization = if is_flexible {
+			self.securitization_space().saturating_sub(self.flexible_securitization_locked)
+		} else {
+			self.available_securitization_space(may_use_flexible_space)
+		};
 		ensure!(
-			securitization.collateral_required <=
-				self.available_securitization_space(may_use_flexible_space),
+			securitization.collateral_required <= available_securitization,
 			VaultError::InsufficientVaultFunds
 		);
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -157,6 +157,8 @@ macro_rules! inject_runtime_vars {
 		/// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 		type Migrations = (
 			pallet_vaults::migrations::MoveVaultNameToOperationalAccountProfileMigration<Runtime>,
+			// Account reconciliation must read the corrected lock liquidity.
+			pallet_bitcoin_locks::migrations::CorrectLegacyRatchetedLiquidityMigration<Runtime>,
 			pallet_operational_accounts::migrations::ReconcileAccountBitcoinAmountsMigration<
 				Runtime,
 			>,


### PR DESCRIPTION
## Summary

Bitcoin lock ratchets now keep promised liquidity aligned with vault backing. Up-ratchets preserve the existing promise and add only the target increase. Flexible down-ratchets release the existing securitization before securing the smaller replacement, so reserved vault space no longer blocks them.

The runtime upgrade also repairs historical 1:1 lock overstatements when the correct amount can be derived unambiguously from vault backing. It runs before existing downstream reconciliation consumes that backing state. Ambiguous underbacked multi-lock vaults are left unchanged and surfaced through upgrade diagnostics.

## Validation

Bitcoin Locks tests pass in normal and `try-runtime` modes. Clippy passes with warnings denied, and both runtime `try-runtime` builds compile.
