### PR TITLE
fix(ci): use protected RPC for try-runtime

### DIFF
--- a/.github/workflows/try_runtime.yml
+++ b/.github/workflows/try_runtime.yml
@@ -58,8 +58,8 @@ jobs:
     strategy:
       matrix:
         runtime:
-          - { artifact: "argon_canary_runtime", uri_secret: "TRY_RUNTIME_TESTNET_URI" }
-          - { artifact: "argon_runtime", uri_secret: "TRY_RUNTIME_MAINNET_URI" }
+          - { artifact: "argon_canary_runtime", network: "testnet" }
+          - { artifact: "argon_runtime", network: "mainnet" }
     steps:
       - name: Download try-runtime-cli
         run: |
@@ -78,16 +78,33 @@ jobs:
       - name: List runtimes
         run: ls -R runtimes
 
-      - name: Try runtime upgrade
+      - name: Configure testnet RPC
+        if: matrix.runtime.network == 'testnet'
         env:
-          TRY_RUNTIME_URI: ${{ secrets[matrix.runtime.uri_secret] }}
+          TRY_RUNTIME_URI: ${{ secrets.TRY_RUNTIME_TESTNET_URI }}
         run: |
           set -eu
           if [[ -z "$TRY_RUNTIME_URI" ]]; then
-            echo "::error::Missing repository secret ${{ matrix.runtime.uri_secret }}"
+            echo "::error::Missing repository secret TRY_RUNTIME_TESTNET_URI"
             exit 1
           fi
+          printf 'TRY_RUNTIME_URI=%s\n' "$TRY_RUNTIME_URI" >> "$GITHUB_ENV"
 
+      - name: Configure mainnet RPC
+        if: matrix.runtime.network == 'mainnet'
+        env:
+          TRY_RUNTIME_URI: ${{ secrets.TRY_RUNTIME_MAINNET_URI }}
+        run: |
+          set -eu
+          if [[ -z "$TRY_RUNTIME_URI" ]]; then
+            echo "::error::Missing repository secret TRY_RUNTIME_MAINNET_URI"
+            exit 1
+          fi
+          printf 'TRY_RUNTIME_URI=%s\n' "$TRY_RUNTIME_URI" >> "$GITHUB_ENV"
+
+      - name: Try runtime upgrade
+        run: |
+          set -eu
           ./try-runtime \
             --runtime ./runtimes/${{ matrix.runtime.artifact }}.compact.compressed.wasm \
             on-runtime-upgrade \

--- a/.github/workflows/try_runtime.yml
+++ b/.github/workflows/try_runtime.yml
@@ -58,8 +58,8 @@ jobs:
     strategy:
       matrix:
         runtime:
-          - { artifact: "argon_canary_runtime", uri: "wss://rpc.testnet.argonprotocol.org" }
-          - { artifact: "argon_runtime", uri: "wss://rpc.argon.network" }
+          - { artifact: "argon_canary_runtime", uri_secret: "TRY_RUNTIME_TESTNET_URI" }
+          - { artifact: "argon_runtime", uri_secret: "TRY_RUNTIME_MAINNET_URI" }
     steps:
       - name: Download try-runtime-cli
         run: |
@@ -78,12 +78,20 @@ jobs:
       - name: List runtimes
         run: ls -R runtimes
 
-      - name: Try testnet runtime upgrades
+      - name: Try runtime upgrade
+        env:
+          TRY_RUNTIME_URI: ${{ secrets[matrix.runtime.uri_secret] }}
         run: |
+          set -eu
+          if [[ -z "$TRY_RUNTIME_URI" ]]; then
+            echo "::error::Missing repository secret ${{ matrix.runtime.uri_secret }}"
+            exit 1
+          fi
+
           ./try-runtime \
             --runtime ./runtimes/${{ matrix.runtime.artifact }}.compact.compressed.wasm \
             on-runtime-upgrade \
               --print-storage-diff \
               --blocktime 60000 \
               --disable-mbm-checks \
-            live --uri ${{ matrix.runtime.uri }}
+            live --uri "$TRY_RUNTIME_URI"


### PR DESCRIPTION
## Summary

Try-runtime CI can now use protected direct RPC endpoints instead of downloading full chain state through the rate-limited public Subway gateways. Each runtime selects its authenticated endpoint from a repository secret, and the job fails clearly when the required secret has not been configured.

This is the CI half of the change; the matching protected Nginx routes are being prepared separately in `argon-ansible`.

## Validation

Validated the workflow with `actionlint` and YAML parsing.
