### PR TITLE
fix(oracle): extend price transaction mortality

### DIFF
--- a/oracle/src/price_index.rs
+++ b/oracle/src/price_index.rs
@@ -338,7 +338,7 @@ async fn submit_price_index(
 	let client = reconnecting_client.get().await?;
 	let account_id = signer.account_id();
 	let nonce = client.get_account_nonce(&account_id).await?;
-	let params = MainchainClient::ext_params_builder().nonce(nonce.into()).mortal(5).build();
+	let params = MainchainClient::ext_params_builder().nonce(nonce.into()).mortal(32).build();
 	let metadata = client.live.metadata();
 	let submit_call = metadata
 		.pallet_by_name("PriceIndex")


### PR DESCRIPTION
Price-index submissions now remain valid for 32 blocks, reducing expiration risk during transaction-pool or inclusion delays. The online Subxt builder remains in place, so mortality is still anchored to the latest finalized block; this PR does not add retries or switch to best-block anchoring.

Verified with `env RUSTC_WRAPPER= cargo check -p argon-oracle`, `cargo make fmt`, and `git diff --check`. Existing tests do not decode the signed era, so no focused regression test was added.
