### PR TITLE
fix: restore MinIO image pulls

### DIFF
--- a/.github/templates/minio/action.yml
+++ b/.github/templates/minio/action.yml
@@ -10,31 +10,8 @@ runs:
       shell: bash
       run: |
         set -eu
-        release_file="minio.RELEASE.2025-09-07T16-13-09Z"
-        platform="darwin"
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
-          platform="linux"
-        fi
-
-        arch=$(uname -m)
-        arch_part="amd64"
-        expected_sha="4759080aeef7385aaceaac1131c30aaeb99605921553967dc6d3ef4e16ac64f9"
-        if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
-          arch_part="arm64"
-          expected_sha="7c3b3039b76e55a1b80935848ed83998d5e8d317374f87851f46a019ff5c0aa4"
-        fi
-
-        if [[ "$platform" == "linux" && "$arch_part" == "amd64" ]]; then
-          expected_sha="7c5bd8512c6e966455b1d198209358b2d191c77a83ab377c4073281065fb855f"
-        elif [[ "$platform" == "linux" && "$arch_part" == "arm64" ]]; then
-          expected_sha="5c83cd2cf151717ba0243f73e1c7802ff36e272b67144bdd7f1f7d684fd6f03d"
-        fi
-
-        url="https://dl.min.io/server/minio/release/${platform}-${arch_part}/${release_file}"
-        curl --fail --location --silent --show-error "$url" -o minio
-        echo "${expected_sha}  minio" | shasum -a 256 -c -
-        chmod +x minio
-        sudo mv minio /usr/local/bin
+        CGO_ENABLED=0 GOBIN="$RUNNER_TEMP/minio-bin" go install github.com/minio/minio@RELEASE.2025-09-07T16-13-09Z
+        sudo mv "$RUNNER_TEMP/minio-bin/minio" /usr/local/bin
 
     - name: Start Minio on Linux and macOS
       shell: bash

--- a/.github/templates/minio/action.yml
+++ b/.github/templates/minio/action.yml
@@ -5,6 +5,12 @@ description: |
 runs:
   using: "composite"
   steps:
+    - name: Install Go
+      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      with:
+        go-version: '1.24.6'
+
     - name: Install Minio
       if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       shell: bash

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -287,7 +287,7 @@ jobs:
             -v /tmp/minio-data:/data \
             -p 9000:9000 \
             --name minio \
-            minio/minio server /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e server /data
 
       - name: Wait for MinIO to start
         run: |

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -34,7 +34,7 @@ x-bitcoin-config: &bitcoin
 
 services:
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin

--- a/scripts/docker_minio.sh
+++ b/scripts/docker_minio.sh
@@ -6,4 +6,4 @@ if [ "$(docker ps -q -f name=minio)" ]; then
     exit 0
 fi
 
-docker run --name minio --rm -p 9000:9000 -p 9001:9001 --mount type=tmpfs,destination=/data  minio/minio server /data --console-address ":9001" > /dev/null 2>&1 &
+docker run --name minio --rm -p 9000:9000 -p 9001:9001 --mount type=tmpfs,destination=/data  quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e server /data --console-address ":9001" > /dev/null 2>&1 &


### PR DESCRIPTION
Local Docker networks and downstream Apps CI can start MinIO again after Docker Hub archived `minio/minio`. The service now pulls the same release from Quay by immutable multi-platform digest while preserving its existing configuration and health check.